### PR TITLE
Add test for Add System Button

### DIFF
--- a/src/SmartComponents/DriftPage/DriftTable/__tests__/AddSystem.test.js
+++ b/src/SmartComponents/DriftPage/DriftTable/__tests__/AddSystem.test.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import { AddSystem } from '../AddSystem';
+import { toggleAddSystemModal } from '../../../modules/actions';
+
+describe('add system button', () => {
+    it('should render correctly', async () => {
+        const button = render(
+            <AddSystem
+                getAddSystemModal={ toggleAddSystemModal }
+            />);
+        expect(toJson(button)).toMatchSnapshot();
+    });
+});

--- a/src/SmartComponents/DriftPage/DriftTable/__tests__/__snapshots__/AddSystem.test.js.snap
+++ b/src/SmartComponents/DriftPage/DriftTable/__tests__/__snapshots__/AddSystem.test.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`add system button should render correctly 1`] = `
+<button
+  class="pf-c-button pf-m-primary"
+  type="button"
+>
+  Add System
+</button>
+`;


### PR DESCRIPTION
Let me know if you think this test should be more robust. To be honest, I think we're only testing for proper rendering at this point. Otherwise we could maybe test that clicking the button would call the function, but that seems better tested here: https://github.com/RedHatInsights/drift-frontend/blob/master/src/SmartComponents/DriftPage/DriftTable/DriftTable.js#L101