### PR TITLE
Fixes issue with filtering by all

### DIFF
--- a/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
+++ b/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
@@ -43,7 +43,7 @@ class DriftTable extends Component {
 
         for (let i = 0; i < data.facts.length; i += 1) {
             if (data.facts[i].name.includes(this.props.factFilter)) {
-                if (this.props.stateFilter === 'all' || this.props.stateFilter === undefined) {
+                if (this.props.stateFilter.toLowerCase() === 'all' || this.props.stateFilter === undefined) {
                     rowData = this.renderRowData(data.facts[i], data.systems);
                     rows.push(<tr>{ rowData }</tr>);
                 }


### PR DESCRIPTION
If you switched from filtering by View: All to another filter, when you try to go back to View: All, the table would not populate any information.

This is because this line is changing the state to be equal to "All" instead of the default "all": https://github.com/RedHatInsights/drift-frontend/blob/master/src/SmartComponents/DriftPage/FilterDropDown/FilterDropDown.js#L47