### PR TITLE
Fix System ID = 0

### DIFF
--- a/src/SmartComponents/modules/reducers.js
+++ b/src/SmartComponents/modules/reducers.js
@@ -80,7 +80,7 @@ function sortData(filteredFacts, sort) {
 function selectedSystems(selectedIds, selectedSystem) {
     let id = selectedSystem.id;
 
-    if (selectedSystem.selected && !selectedIds.includes(id)) {
+    if (selectedSystem.selected && !selectedIds.includes(id) && id !== 0 && id !== null) {
         selectedIds.push(id);
     } else if (!selectedSystem.selected) {
         selectedIds = selectedIds.filter(item => item !== id);


### PR DESCRIPTION
In Add System, if you click the checkbox next to "Name" and run a compare or click the "X" to close the modal, The table gets trapped in a loading state because the system id submitted to the api is 0, which it can't find.

With this fix, we check that the id added to the array of system ids to run the compare against is not 0 and not null before we add it to the list of ids.