### PR TITLE
Fix state filter on non-nested facts

### DIFF
--- a/src/SmartComponents/modules/reducers.js
+++ b/src/SmartComponents/modules/reducers.js
@@ -52,7 +52,7 @@ function filterCompareData(data, stateFilter, factFilter, newExpandedRows) {
                     filteredFacts.push(data[i]);
                 }
                 else if (stateFilter === data[i].state) {
-                    filteredComparisons.push(data[i]);
+                    filteredFacts.push(data[i]);
                 }
             }
         }


### PR DESCRIPTION
Previously, the state filter only worked on nested facts. Now it works on nested and non-nested facts