### PR TITLE
Add blue bar to nested facts when expanded

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -11,7 +11,7 @@
     cursor: pointer;
   }
   .active-blue {
-    color:#39A5DC;
+    color: #39A5DC;
   }
 
   .pf-c-card__body {
@@ -111,6 +111,9 @@
     width: 60px;
     min-width: 60px;
     max-width: 60px;
+  }
+  .nested-fact {
+    border-left: 3px solid #39A5DC;
   }
   .child-row {
     margin-left: 2em;

--- a/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
+++ b/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
@@ -100,7 +100,10 @@ class DriftTable extends Component {
 
         if (fact.comparisons) {
             row.push(
-                <td className="sticky-column fixed-column-1">
+                <td className={
+                    this.props.expandedRows.includes(fact.name) ?
+                        'nested-fact stick-column fixed-column-1' :
+                        'sticky-column fixed-column-1' }>
                     { this.renderExpandableRowButton(this.props.expandedRows, fact.name) } { fact.name }
                 </td>
             );
@@ -141,7 +144,7 @@ class DriftTable extends Component {
     renderRowChild(fact, systems) {
         let row = [];
 
-        row.push(<td className="sticky-column fixed-column-1">
+        row.push(<td className="nested-fact sticky-column fixed-column-1">
             <p className="child-row">{ fact.name }</p>
         </td>);
         row.push(<td className="fact-state sticky-column fixed-column-2"><StateIcon factState={ fact.state }/></td>);
@@ -204,7 +207,7 @@ class DriftTable extends Component {
         let expandIcon;
 
         if (expandedRows.includes(factName)) {
-            expandIcon = <AngleDownIcon className="pointer" onClick={ () => this.props.expandRow(factName) } />;
+            expandIcon = <AngleDownIcon className="pointer active-blue" onClick={ () => this.props.expandRow(factName) } />;
         } else {
             expandIcon = <AngleRightIcon className="pointer" onClick={ () => this.props.expandRow(factName) } />;
         }


### PR DESCRIPTION
Left border and dropdown carat turn blue when a category is expanded. Reverts back when collapsed.