### PR TITLE
Updating items per page returns to page 1

### DIFF
--- a/src/SmartComponents/DriftPage/Pagination/Pagination.js
+++ b/src/SmartComponents/DriftPage/Pagination/Pagination.js
@@ -22,7 +22,7 @@ class TablePagination extends Component {
     }
 
     onPerPageSelect(perPage) {
-        const { page } = this.props;
+        const page = 1;
         const pagination = { page, perPage };
         this.props.updatePagination(pagination);
     }


### PR DESCRIPTION
Before, when you changed the number of items shown per page, the table would render and you would remain on the same page you were previously on, even if that page did not exist.
Now, you are automatically returned to page 1 when you updated the number of items per page.