### PR TITLE
Expanding Rows doesn't kick you to page 1

### DIFF
--- a/src/SmartComponents/modules/reducers.js
+++ b/src/SmartComponents/modules/reducers.js
@@ -361,7 +361,7 @@ function compareReducer(state = initialState, action) {
             newExpandedRows = toggleExpandedRow(state.expandedRows, action.payload);
             filteredFacts = filterCompareData(state.fullCompareData, state.stateFilter, state.factFilter, newExpandedRows);
             sortedFacts = sortData(filteredFacts, state.sort);
-            paginatedFacts = paginateData(sortedFacts, 1, state.perPage);
+            paginatedFacts = paginateData(sortedFacts, state.page, state.perPage);
             return {
                 ...state,
                 expandedRows: newExpandedRows,


### PR DESCRIPTION
Before, when expanding a row, you would be kicked to page 1, but the page number would remain the same as the previous page you were on.

Now, when expanding a row, you remain on the page you are currently on.