### PR TITLE
Catch 400 error when too many system Ids are in url

### DIFF
--- a/src/SmartComponents/modules/reducers.js
+++ b/src/SmartComponents/modules/reducers.js
@@ -267,7 +267,9 @@ function compareReducer(state = initialState, action) {
             };
         case `${types.FETCH_COMPARE}_REJECTED`:
             response = action.payload.response;
-            if (response.data.message) {
+            if (response.data === '') {
+                errorObject = { detail: response.statusText, status: response.status };
+            } else if (response.data.message) {
                 errorObject = { detail: response.data.message, status: response.status };
             } else {
                 errorObject = { detail: response.data.detail, status: response.status };


### PR DESCRIPTION
This works to show the error, but is still broken if you try to close the alert. That will be fixed in another pr.