### PR TITLE
On running fetch, the submitted ids comes from the selectedSystemIds

### DIFF
--- a/src/SmartComponents/AddSystemModal/AddSystemModal.js
+++ b/src/SmartComponents/AddSystemModal/AddSystemModal.js
@@ -18,15 +18,7 @@ class AddSystemModal extends Component {
     }
 
     confirmModal() {
-        let selected = this.props.entities.rows.filter(function (item) {
-            return item.selected;
-        });
-
-        selected = selected.map(function (item) {
-            return item.id;
-        });
-
-        this.props.confirmModal(selected);
+        this.props.confirmModal(this.props.entities.selectedSystemIds);
         this.props.toggleModal();
     }
 


### PR DESCRIPTION
The bug is, when you select a system from the modal on page 1, then go to page 2 and select another system and click compare, you only submit the selected system of the page you are currently on. By changing to selectedSystemIds, we are submitting all systems that have been selected in the modal. Systems are added and taken away from the selectedSystemIds array each time the modal is opened.