### PR TITLE
On closing 500 error, table populated with no data

### DIFF
--- a/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
+++ b/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
@@ -309,7 +309,7 @@ class DriftTable extends Component {
                     showModal={ this.props.addSystemModalOpened }
                     confirmModal={ this.fetchCompare }
                 />
-                { systems.length > 0 || loading || this.systemIds.length !== 0 ?
+                { systems.length > 0 || loading || this.props.fullCompareData.length !== 0 ?
                     this.renderTable(filteredCompareData, systems, loading) : this.renderEmptyState()
                 }
             </React.Fragment>


### PR DESCRIPTION
We changed the table to render a table if there were ids stored in systemIds: https://github.com/RedHatInsights/drift-frontend/pull/112 If you had an empty state, then tried to add a system but got a 500 error, it would revert to an empty table, but because there was an id in systemIds array, it would populated an empty table. The id is only cleared out after the rendering.

I've changed it to check for fullCompareData because in the same instance above, the fullCompareData will be empty. Otherwise, if you had previous fullCompareData before the 500, you would convert back to that without getting the empty table to flash before the compare.