### PR TITLE
Fix two-column sorting on table

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -14,6 +14,14 @@
     color: #39A5DC;
   }
 
+  .not-active {
+    color: #D2D2D2;
+  }
+
+  .not-active:hover {
+    color: #151515;
+  }
+
   .pf-c-card__body {
     padding-left: 0;
     padding-right: 0;

--- a/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
+++ b/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
@@ -4,7 +4,7 @@ import { withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { EmptyState, EmptyStateBody, EmptyStateIcon, Title, Tooltip } from '@patternfly/react-core';
 import queryString from 'query-string';
-import { AddCircleOIcon, AngleDownIcon, AngleRightIcon, ArrowUpIcon, ArrowDownIcon, ArrowsAltVIcon,
+import { AddCircleOIcon, AngleDownIcon, AngleRightIcon, LongArrowAltUpIcon, LongArrowAltDownIcon, ArrowsAltVIcon,
     CloseIcon, ServerIcon, WarningTriangleIcon } from '@patternfly/react-icons';
 import { Skeleton, SkeletonSize } from '@red-hat-insights/insights-frontend-components';
 
@@ -220,13 +220,13 @@ class DriftTable extends Component {
         let sortIcon;
 
         if (sort === ASC) {
-            sortIcon = <ArrowUpIcon className="pointer active-blue" onClick={ () => this.toggleSort(sortType, sort) }/>;
+            sortIcon = <LongArrowAltUpIcon className="pointer active-blue" onClick={ () => this.toggleSort(sortType, sort) }/>;
         }
         else if (sort === DESC) {
-            sortIcon = <ArrowDownIcon className="pointer active-blue" onClick={ () => this.toggleSort(sortType, sort) }/>;
+            sortIcon = <LongArrowAltDownIcon className="pointer active-blue" onClick={ () => this.toggleSort(sortType, sort) }/>;
         }
         else {
-            sortIcon = <ArrowsAltVIcon className="pointer" onClick={ () => this.toggleSort(sortType, sort) }/>;
+            sortIcon = <ArrowsAltVIcon className="pointer not-active" onClick={ () => this.toggleSort(sortType, sort) }/>;
         }
 
         return sortIcon;
@@ -243,19 +243,18 @@ class DriftTable extends Component {
     }
 
     renderHeaderRow(systems, loading) {
-        const { activeSort, stateSort } = this.props;
+        const { stateSort } = this.props;
 
         return (
             <tr className="sticky-column-header">
-                <th className={ activeSort === 'fact' || stateSort === '' ?
-                    'active-sort fact-header sticky-column fixed-column-1' :
-                    'fact-header sticky-column fixed-column-1' }>
-                    <div>Fact { this.renderSortButton('fact', this.props.factSort) }</div>
+                <th className="fact-header sticky-column fixed-column-1">
+                    <div className="active-blue">Fact { this.renderSortButton('fact', this.props.factSort) }</div>
                 </th>
-                <th className={ activeSort === 'state' && stateSort !== '' ?
-                    'active-sort state-header sticky-column fixed-column-2' :
-                    'state-header sticky-column fixed-column-2' }>
-                    <div>State { this.renderSortButton('state', this.props.stateSort) }</div>
+                <th className="state-header sticky-column fixed-column-2">
+                    { stateSort !== '' ?
+                        <div className="active-blue">State { this.renderSortButton('state', this.props.stateSort) }</div> :
+                        <div>State { this.renderSortButton('state', this.props.stateSort) }</div>
+                    }
                 </th>
                 { this.renderSystems(systems) }
                 <th>
@@ -354,8 +353,7 @@ function mapStateToProps(state) {
         systems: state.compareReducer.systems,
         factSort: state.compareReducer.factSort,
         stateSort: state.compareReducer.stateSort,
-        expandedRows: state.compareReducer.expandedRows,
-        activeSort: state.activeSortReducer.activeSort
+        expandedRows: state.compareReducer.expandedRows
     };
 }
 
@@ -364,7 +362,6 @@ function mapDispatchToProps(dispatch) {
         fetchCompare: ((systemIds) => dispatch(compareActions.fetchCompare(systemIds))),
         toggleFactSort: ((sortType) => dispatch(compareActions.toggleFactSort(sortType))),
         toggleStateSort: ((sortType) => dispatch(compareActions.toggleStateSort(sortType))),
-        toggleActiveSort: ((activeSort) => dispatch(compareActions.toggleActiveSort(activeSort))),
         expandRow: ((factName) => dispatch(compareActions.expandRow(factName))),
         clearState: (() => dispatch(compareActions.clearState()))
     };
@@ -389,8 +386,7 @@ DriftTable.propTypes = {
     toggleActiveSort: PropTypes.func,
     expandRow: PropTypes.func,
     expandRows: PropTypes.func,
-    expandedRows: PropTypes.array,
-    activeSort: PropTypes.string
+    expandedRows: PropTypes.array
 };
 
 export default withRouter (connect(mapStateToProps, mapDispatchToProps)(DriftTable));

--- a/src/SmartComponents/modules/__tests__/reducer-test.js
+++ b/src/SmartComponents/modules/__tests__/reducer-test.js
@@ -19,7 +19,6 @@ describe('compare reducer', () => {
                     { filter: 'DIFFERENT', display: 'Different', selected: true },
                     { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: true }
                 ],
-                activeSort: 'fact',
                 factSort: ASC,
                 stateSort: '',
                 filteredCompareData: [],
@@ -409,7 +408,6 @@ describe('add system modal reducer', () => {
                     { filter: 'DIFFERENT', display: 'Different', selected: true },
                     { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: true }
                 ],
-                activeSort: 'fact',
                 factSort: ASC,
                 stateSort: '',
                 filteredCompareData: [],
@@ -462,7 +460,6 @@ describe('filter dropdown reducer', () => {
                     { filter: 'DIFFERENT', display: 'Different', selected: true },
                     { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: true }
                 ],
-                activeSort: 'fact',
                 factSort: ASC,
                 stateSort: '',
                 filteredCompareData: [],
@@ -515,7 +512,6 @@ describe('export reducer', () => {
                     { filter: 'DIFFERENT', display: 'Different', selected: true },
                     { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: true }
                 ],
-                activeSort: 'fact',
                 factSort: ASC,
                 stateSort: '',
                 filteredCompareData: [],

--- a/src/SmartComponents/modules/actions.js
+++ b/src/SmartComponents/modules/actions.js
@@ -113,13 +113,6 @@ function toggleKebab() {
     };
 }
 
-function toggleActiveSort(activeSort) {
-    return {
-        type: types.TOGGLE_ACTIVE_SORT,
-        payload: activeSort
-    };
-}
-
 export default {
     fetchCompare,
     revertCompareData,
@@ -135,6 +128,5 @@ export default {
     updatePagination,
     exportToCSV,
     expandRow,
-    toggleKebab,
-    toggleActiveSort
+    toggleKebab
 };

--- a/src/SmartComponents/modules/reducers.js
+++ b/src/SmartComponents/modules/reducers.js
@@ -24,8 +24,7 @@ const initialState = {
     expandedRows: [],
     kebabOpened: false,
     error: {},
-    errorAlertOpened: false,
-    activeSort: 'fact'
+    errorAlertOpened: false
 };
 
 function paginateData(data, selectedPage, factsPerPage) {
@@ -522,25 +521,10 @@ function exportReducer(state = initialState, action) {
     }
 }
 
-function activeSortReducer(state = initialState, action) {
-    switch (action.type) {
-        case `${types.TOGGLE_ACTIVE_SORT}`:
-            return {
-                ...state,
-                activeSort: action.payload
-            };
-        default:
-            return {
-                ...state
-            };
-    }
-}
-
 export default {
     compareReducer,
     addSystemModalReducer,
     errorAlertReducer,
     filterDropdownReducer,
-    exportReducer,
-    activeSortReducer
+    exportReducer
 };

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -20,8 +20,7 @@ export function init (...middleware) {
         addSystemModalReducer: reducers.addSystemModalReducer,
         errorAlertReducer: reducers.errorAlertReducer,
         filterDropdownReducer: reducers.filterDropdownReducer,
-        exportReducer: reducers.exportReducer,
-        activeSortReducer: reducers.activeSortReducer
+        exportReducer: reducers.exportReducer
     });
 
     return registry;


### PR DESCRIPTION
Fact column should always be sorted by either ascending or descending. It will remain blue.

State column should start turned off. The sorting icon should be gray when turned off and will turn black when hovered over with the mouse. The state column will turn blue in conjunction with the fact column when set to ascending or descending. When the state sort is turned off, it will no longer be blue.

The state sort will take priority in the sorting pattern when turned on.