### PR TITLE
Updated time-date stamps to match UX requirements

### DIFF
--- a/src/SmartComponents/BaselinesTable/redux/__tests__/baselinesTableReducer.fixtures.js
+++ b/src/SmartComponents/BaselinesTable/redux/__tests__/baselinesTableReducer.fixtures.js
@@ -1,3 +1,5 @@
+import moment from 'moment';
+
 /*eslint-disable camelcase*/
 const baselinesListPayload = ([
     {
@@ -35,8 +37,8 @@ const baselinesListPayloadResults = ([
 /*eslint-enable camelcase*/
 
 const baselineTableDataRows = ([
-    [ 'beavs baseline', '18 May 2019, 15:00 UTC' ],
-    [ 'micjohns baseline', '19 May 2019, 15:00 UTC' ]
+    [ 'beavs baseline', moment('18 May 2019, 15:00 UTC').fromNow() ],
+    [ 'micjohns baseline', moment('19 May 2019, 15:00 UTC').fromNow() ]
 ]);
 
 export default {

--- a/src/SmartComponents/BaselinesTable/redux/helpers.js
+++ b/src/SmartComponents/BaselinesTable/redux/helpers.js
@@ -52,7 +52,7 @@ function findBaselineId(baseline, fullBaselineData) {
 }
 
 function getDateTimeStamp(dateTime) {
-    return moment.utc(dateTime).format('DD MMM YYYY, HH:mm UTC');
+    return moment(dateTime).fromNow();
 }
 
 function buildNewTableData(fullBaselineListData, IdToDelete) {

--- a/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
+++ b/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
@@ -45,7 +45,7 @@ class DriftTable extends Component {
     }
 
     formatDate(dateString) {
-        return moment.utc(dateString).format('MM/DD/YYYY H:mm:ss UTC');
+        return moment.utc(dateString).format('DD MMM YYYY, HH:mm UTC');
     }
 
     removeSystem(systemBaselineId) {


### PR DESCRIPTION
Add systems table can not be updated from our app, but must be done from Inventory.
The last sync for baselines table (add system modal and baselines page table) and time in system comparison table have been updated