### PR TITLE
Fixes delay in fact filter when a lot of comparisons are being made

### DIFF
--- a/src/SmartComponents/DriftPage/SearchBar/SearchBar.js
+++ b/src/SmartComponents/DriftPage/SearchBar/SearchBar.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { TextInput } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
+import _ from 'lodash';
 
 import { compareActions } from '../../modules';
 
@@ -10,13 +11,19 @@ export class SearchBar extends Component {
         super(props);
     }
 
+    updateFactFilter() {
+        const { changeFactFilter } = this.props;
+        let factFilter = document.getElementById('filterByFact').value;
+        changeFactFilter(factFilter);
+    }
+
     render() {
         return (
             <React.Fragment>
                 <TextInput
+                    id="filterByFact"
                     placeholder="Filter by Fact"
-                    value={ this.props.factFilter }
-                    onChange={ this.props.changeFactFilter }
+                    onChange={ _.debounce(this.props.changeFactFilter, 250) }
                     aria-label="filter by fact"
                 />
             </React.Fragment>
@@ -25,20 +32,13 @@ export class SearchBar extends Component {
 }
 
 SearchBar.propTypes = {
-    factFilter: PropTypes.string,
     changeFactFilter: PropTypes.func
 };
 
-function mapStateToProps(state) {
-    return {
-        factFilter: state.compareState.factFilter
-    };
-}
-
 function mapDispatchToProps(dispatch) {
     return {
-        changeFactFilter: (value) => dispatch(compareActions.filterByFact(value))
+        changeFactFilter: (factFilter) => dispatch(compareActions.filterByFact(factFilter))
     };
 }
 
-export default (connect(mapStateToProps, mapDispatchToProps)(SearchBar));
+export default (connect(null, mapDispatchToProps)(SearchBar));


### PR DESCRIPTION
Bug: Add a lot of systems to a comparison (20+) then start typing in the fact filter bar. Each letter will fire off an action and will freeze up the system as it sorts the entire list.

Fix: There should be a 1000 millisecond delay after typing before the action fires off. If you continue typing, the timer will reset.