### PR TITLE
use baselines and systems when creating CSV header

### DIFF
--- a/src/SmartComponents/modules/reducers.js
+++ b/src/SmartComponents/modules/reducers.js
@@ -145,7 +145,7 @@ export function compareReducer(state = initialState, action) {
                 totalFacts: filteredFacts.length
             };
         case `${types.EXPORT_TO_CSV}`:
-            reducerHelpers.downloadCSV(state.sortedFilteredFacts, state.systems);
+            reducerHelpers.downloadCSV(state.sortedFilteredFacts, [ ...state.baselines, ...state.systems ]);
             return {
                 ...state
             };


### PR DESCRIPTION
Previously, only systems were used when creating the CSV file header.
Instead, use both systems and baselines if available.