### PR TITLE
Add search bar to Baselines table

### DIFF
--- a/src/SmartComponents/BaselinesPage/BaselinesPage.js
+++ b/src/SmartComponents/BaselinesPage/BaselinesPage.js
@@ -1,27 +1,96 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import debounce from 'lodash/debounce';
 
 import { Main, PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-components';
 import { Card, CardBody, Toolbar, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
+import { SimpleTableFilter } from '@redhat-cloud-services/frontend-components';
+import { AddCircleOIcon } from '@patternfly/react-icons';
+import { EmptyState, EmptyStateBody, EmptyStateIcon, Title } from '@patternfly/react-core';
 
 import BaselinesTable from '../BaselinesTable/BaselinesTable';
 import CreateBaselineButton from './CreateBaselineButton/CreateBaselineButton';
 import CreateBaseline from './CreateBaseline/CreateBaseline';
 import BaselinesKebab from './BaselinesKebab/BaselinesKebab';
 import EditBaseline from './EditBaseline/EditBaseline';
+import { baselinesTableActions } from '../BaselinesTable/redux';
 
 class BaselinesPage extends Component {
     constructor(props) {
         super(props);
+        this.state = { search: false };
+        this.handleSearch = this.handleSearch.bind(this);
     }
 
     async componentDidMount() {
         await window.insights.chrome.auth.getUser();
+        const { fetchBaselines } = this.props;
+
+        fetchBaselines();
+    }
+
+    handleSearch = debounce(function(search) {
+        this.setState({ search: true });
+        this.props.fetchBaselines(search);
+    }, 250)
+
+    renderToolbar() {
+        return (
+            <Toolbar className="drift-toolbar">
+                <ToolbarGroup>
+                    <ToolbarItem>
+                        <SimpleTableFilter buttonTitle={ null }
+                            onFilterChange={ this.handleSearch }
+                            placeholder="Search by name"
+                        />
+                    </ToolbarItem>
+                </ToolbarGroup>
+                <ToolbarGroup>
+                    <ToolbarItem>
+                        <CreateBaselineButton />
+                    </ToolbarItem>
+                    <ToolbarItem>
+                        <BaselinesKebab exportType='baseline list'/>
+                    </ToolbarItem>
+                </ToolbarGroup>
+            </Toolbar>
+        );
+    }
+
+    renderEmptyState() {
+        return (
+            <center>
+                <EmptyState>
+                    <EmptyStateIcon icon={ AddCircleOIcon } />
+                    <br></br>
+                    <Title size="lg">No baselines</Title>
+                    <EmptyStateBody>
+                        You currently have no baselines displayed.
+                        <br/>
+                        Please create a baseline to use in your System Comparison analysis.
+                    </EmptyStateBody>
+                    <CreateBaselineButton />
+                </EmptyState>
+            </center>
+        );
+    }
+
+    renderTable() {
+        const { baselineListLoading } = this.props;
+
+        return (
+            <CardBody>
+                { this.renderToolbar() }
+                <div>
+                    <BaselinesTable baselineListLoading={ baselineListLoading }/>
+                </div>
+            </CardBody>
+        );
     }
 
     render() {
-        const { creatingNewBaseline, baselineUUID, fullBaselineListData } = this.props;
+        const { creatingNewBaseline, baselineUUID, fullBaselineListData, baselineListLoading } = this.props;
 
         return (
             <React.Fragment>
@@ -46,25 +115,9 @@ class BaselinesPage extends Component {
                             </CardBody>
                             : null
                         }
-                        { !creatingNewBaseline && baselineUUID === ''
-                            ? <CardBody>
-                                { fullBaselineListData.length !== 0
-                                    ? <Toolbar className="drift-toolbar">
-                                        <ToolbarGroup>
-                                            <ToolbarItem>
-                                                <CreateBaselineButton />
-                                            </ToolbarItem>
-                                            <ToolbarItem>
-                                                <BaselinesKebab exportType='baseline list'/>
-                                            </ToolbarItem>
-                                        </ToolbarGroup>
-                                    </Toolbar>
-                                    : null
-                                }
-                                <div>
-                                    <BaselinesTable />
-                                </div>
-                            </CardBody>
+                        { (!creatingNewBaseline && baselineUUID === '')
+                            ? (fullBaselineListData.length === 0 && baselineListLoading === false)
+                                ? this.renderEmptyState() : this.renderTable()
                             : null
                         }
                     </Card>
@@ -75,17 +128,26 @@ class BaselinesPage extends Component {
 }
 
 BaselinesPage.propTypes = {
+    baselineListLoading: PropTypes.bool,
     creatingNewBaseline: PropTypes.bool,
     baselineUUID: PropTypes.string,
-    fullBaselineListData: PropTypes.array
+    fullBaselineListData: PropTypes.array,
+    fetchBaselines: PropTypes.func
 };
 
 function mapStateToProps(state) {
     return {
+        baselineListLoading: state.baselinesTableState.baselineListLoading,
         creatingNewBaseline: state.baselinesPageState.creatingNewBaseline,
         baselineUUID: state.baselinesTableState.baselineUUID,
         fullBaselineListData: state.baselinesTableState.fullBaselineListData
     };
 }
 
-export default connect(mapStateToProps, null)(BaselinesPage);
+function mapDispatchToProps(dispatch) {
+    return {
+        fetchBaselines: ((search) => dispatch(baselinesTableActions.fetchBaselines(search)))
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(BaselinesPage);

--- a/src/SmartComponents/BaselinesTable/BaselinesTable.js
+++ b/src/SmartComponents/BaselinesTable/BaselinesTable.js
@@ -1,25 +1,16 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { EmptyState, EmptyStateBody, EmptyStateIcon, Title } from '@patternfly/react-core';
 import { Table, TableBody, TableHeader } from '@patternfly/react-table';
-import { AddCircleOIcon } from '@patternfly/react-icons';
 import { Skeleton, SkeletonSize } from '@redhat-cloud-services/frontend-components';
 
 import BaselineTableKebab from './BaselineTableKebab/BaselineTableKebab';
-import CreateBaselineButton from '../BaselinesPage/CreateBaselineButton/CreateBaselineButton';
 import { baselinesTableActions } from './redux';
 
 class BaselinesTable extends Component {
     constructor(props) {
         super(props);
         this.onSelect = this.onSelect.bind(this);
-    }
-
-    componentDidMount() {
-        const { fetchBaselines } = this.props;
-
-        fetchBaselines();
     }
 
     onSelect(event, isSelected, rowId) {
@@ -115,33 +106,10 @@ class BaselinesTable extends Component {
         return table;
     }
 
-    renderEmptyState() {
-        return (
-            <center>
-                <EmptyState>
-                    <EmptyStateIcon icon={ AddCircleOIcon } />
-                    <br></br>
-                    <Title size="lg">No baselines</Title>
-                    <EmptyStateBody>
-                        You currently have no baselines displayed.
-                        <br/>
-                        Please create a baseline to use in your System Comparison analysis.
-                    </EmptyStateBody>
-                    <CreateBaselineButton />
-                </EmptyState>
-            </center>
-        );
-    }
-
     render() {
-        const { fullBaselineListData, baselineListLoading } = this.props;
-
         return (
             <React.Fragment>
-                { fullBaselineListData.length === 0 && baselineListLoading === false
-                    ? this.renderEmptyState()
-                    : this.renderTable()
-                }
+                { this.renderTable() }
             </React.Fragment>
         );
     }
@@ -154,13 +122,11 @@ BaselinesTable.propTypes = {
     baselineTableData: PropTypes.array,
     createBaselinesTable: PropTypes.func,
     selectBaseline: PropTypes.func,
-    addSystemModalOpened: PropTypes.bool,
-    fetchBaselines: PropTypes.func
+    addSystemModalOpened: PropTypes.bool
 };
 
 function mapStateToProps(state) {
     return {
-        baselineListLoading: state.baselinesTableState.baselineListLoading,
         baselineDeleteLoading: state.baselinesTableState.baselineDeleteLoading,
         fullBaselineListData: state.baselinesTableState.fullBaselineListData,
         baselineTableData: state.baselinesTableState.baselineTableData,
@@ -170,8 +136,7 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
     return {
-        selectBaseline: (rows) => dispatch(baselinesTableActions.selectBaseline(rows)),
-        fetchBaselines: () => dispatch(baselinesTableActions.fetchBaselines())
+        selectBaseline: (rows) => dispatch(baselinesTableActions.selectBaseline(rows))
     };
 }
 

--- a/src/SmartComponents/BaselinesTable/redux/actions.js
+++ b/src/SmartComponents/BaselinesTable/redux/actions.js
@@ -1,10 +1,10 @@
 import types from './types';
 import api from '../../../api';
 
-function fetchBaselines() {
+function fetchBaselines(search) {
     return {
         type: types.FETCH_BASELINE_LIST,
-        payload: api.getBaselineList()
+        payload: api.getBaselineList(search)
     };
 }
 

--- a/src/api.js
+++ b/src/api.js
@@ -6,13 +6,15 @@ async function post(path, body = {}) {
     return request.data;
 }
 
-async function getBaselines(path, body = {}) {
-    const request = await axios.get(BASELINE_API_ROOT.concat(path), body);
+async function getBaselines(path, getParams = {}) {
+    /*eslint-disable no-console*/
+    /*eslint-enable no-console*/
+    const request = await axios.get(BASELINE_API_ROOT.concat(path), { params: getParams });
     return request.data.data;
 }
 
-async function getBaseline(path, body = {}) {
-    const request = await axios.get(BASELINE_API_ROOT.concat(path), body);
+async function getBaseline(path) {
+    const request = await axios.get(BASELINE_API_ROOT.concat(path));
     return request.data.data[0];
 }
 
@@ -44,9 +46,15 @@ function getCompare(systemIds = [], baselineIds = []) {
     /*eslint-enable camelcase*/
 }
 
-function getBaselineList() {
+function getBaselineList(search = undefined) {
     /*eslint-disable camelcase*/
-    return getBaselines('/baselines', {});
+    let params = {};
+
+    if (search !== undefined) {
+        params = { display_name: search };
+    }
+
+    return getBaselines('/baselines', params);
     /*eslint-enable camelcase*/
 }
 


### PR DESCRIPTION
This change moves the empty state logic and fetching logic up to the
page itself and out of the table. This simplifies the table and lets
the page control the flow. Given the Page component is where all of
the parts are composed it necessitates that the logic of what to
present is controlled here.