### PR TITLE
Allow persistent baseline select in modal

### DIFF
--- a/src/SmartComponents/AddSystemModal/AddSystemModal.js
+++ b/src/SmartComponents/AddSystemModal/AddSystemModal.js
@@ -56,12 +56,9 @@ class AddSystemModal extends Component {
     }
 
     changeActiveTab(event, tabIndex) {
-        const { selectActiveTab, setSelectedBaselines } = this.props;
+        const { selectActiveTab } = this.props;
 
         selectActiveTab(tabIndex);
-        if (tabIndex === 1) {
-            setSelectedBaselines(this.selectedBaselineIds());
-        }
     }
 
     render() {

--- a/src/SmartComponents/BaselinesTable/BaselinesTable.js
+++ b/src/SmartComponents/BaselinesTable/BaselinesTable.js
@@ -30,19 +30,17 @@ class BaselinesTable extends Component {
 
     onSelect(event, isSelected, rowId) {
         const { baselineTableData, selectBaseline } = this.props;
-        let rows;
+        let ids;
 
         if (rowId === -1) {
-            rows = baselineTableData.map(oneRow => {
-                oneRow.selected = isSelected;
-                return oneRow;
+            ids = baselineTableData.map(function(item) {
+                return item[0];
             });
         } else {
-            rows = [ ...baselineTableData ];
-            rows[rowId].selected = isSelected;
+            ids = [ baselineTableData[rowId][0] ];
         }
 
-        selectBaseline(rows);
+        selectBaseline(ids, isSelected);
     }
 
     renderLoadingRows() {
@@ -206,7 +204,7 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
     return {
-        selectBaseline: (rows) => dispatch(baselinesTableActions.selectBaseline(rows)),
+        selectBaseline: (id, isSelected) => dispatch(baselinesTableActions.selectBaseline(id, isSelected)),
         fetchBaselines: () => dispatch(baselinesTableActions.fetchBaselines())
     };
 }

--- a/src/SmartComponents/BaselinesTable/redux/__tests__/baselinesTableActions.tests.js
+++ b/src/SmartComponents/BaselinesTable/redux/__tests__/baselinesTableActions.tests.js
@@ -12,16 +12,12 @@ describe('baselines table actions', () => {
     });
 
     it('selectBaseline equals', () => {
-        let rows = [
-            [ 'arch baseline', '2019-07-10T19:48:29.125065Z' ],
-            [ 'cpu + mem baseline', '2019-07-10T19:48:29.130082Z' ]
-        ];
-
-        rows[0].selected = true;
-
-        expect(baselinesTableActions.selectBaseline(rows)).toEqual({
+        expect(baselinesTableActions.selectBaseline([ '1', '2' ], true)).toEqual({
             type: types.SELECT_BASELINE,
-            payload: rows
+            payload: {
+                ids: [ '1', '2' ],
+                isSelected: true
+            }
         });
     });
 

--- a/src/SmartComponents/BaselinesTable/redux/__tests__/baselinesTableReducer.tests.js
+++ b/src/SmartComponents/BaselinesTable/redux/__tests__/baselinesTableReducer.tests.js
@@ -85,10 +85,14 @@ describe('baselines table reducer', () => {
         expect(
             baselinesTableReducer({
                 baselineTableData: baselinesFixtures.baselineTableDataRows,
-                fullBaselineListData: baselinesFixtures.baselinesListPayloadResults
+                fullBaselineListData: baselinesFixtures.baselinesListPayloadResults,
+                selectedBaselineIds: []
             }, {
                 type: `${types.SELECT_BASELINE}`,
-                payload: newRowsWithOneSelected
+                payload: {
+                    ids: [ oneSelectedBaseline[0] ],
+                    isSelected: true
+                }
             })
         ).toEqual({
             fullBaselineListData: baselinesFixtures.baselinesListPayloadResults,
@@ -115,7 +119,10 @@ describe('baselines table reducer', () => {
                 selectedBaselineIds: oneSelectedBaseline
             }, {
                 type: `${types.SELECT_BASELINE}`,
-                payload: newRowsWithTwoSelected
+                payload: {
+                    ids: [ twoSelectedBaselines[1] ],
+                    isSelected: true
+                }
             })
         ).toEqual({
             fullBaselineListData: baselinesFixtures.baselinesListPayloadResults,
@@ -145,7 +152,10 @@ describe('baselines table reducer', () => {
                 selectedBaselineIds: twoSelectedBaselines
             }, {
                 type: `${types.SELECT_BASELINE}`,
-                payload: newRowsWithOneDeselected
+                payload: {
+                    ids: [ twoSelectedBaselines[1] ],
+                    isSelected: false
+                }
             })
         ).toEqual({
             fullBaselineListData: baselinesFixtures.baselinesListPayloadResults,

--- a/src/SmartComponents/BaselinesTable/redux/actions.js
+++ b/src/SmartComponents/BaselinesTable/redux/actions.js
@@ -8,10 +8,10 @@ function fetchBaselines(search) {
     };
 }
 
-function selectBaseline(rows) {
+function selectBaseline(ids, isSelected) {
     return {
         type: types.SELECT_BASELINE,
-        payload: rows
+        payload: { ids, isSelected }
     };
 }
 

--- a/src/SmartComponents/BaselinesTable/redux/baselinesTableReducer.js
+++ b/src/SmartComponents/BaselinesTable/redux/baselinesTableReducer.js
@@ -1,5 +1,6 @@
 import types from './types';
 import baselinesReducerHelpers from './helpers';
+import union from 'lodash/union';
 
 const initialState = {
     baselineListLoading: true,
@@ -40,10 +41,29 @@ export function baselinesTableReducer(state = initialState, action) {
                 baselineTableData: rows
             };
         case `${types.SELECT_BASELINE}`:
-            selectedBaselines = baselinesReducerHelpers.setBaselineArray(action.payload);
+            selectedBaselines = [ ...state.selectedBaselineIds ];
+
+            if (action.payload.ids.length === 0) {
+                selectedBaselines = [];
+            } else if (action.payload.isSelected) {
+                selectedBaselines = union(selectedBaselines.concat(action.payload.ids));
+            } else if (!action.payload.isSelected) {
+                selectedBaselines = selectedBaselines.filter(function(item) {
+                    return !action.payload.ids.includes(item);
+                });
+            }
+
+            newBaselineTableData = [ ...state.baselineTableData ];
+
+            newBaselineTableData.map(row => {
+                if (action.payload.ids.includes(row[0])) {
+                    row.selected = action.payload.isSelected;
+                }
+            });
+
             return {
                 ...state,
-                baselineTableData: action.payload,
+                baselineTableData: newBaselineTableData,
                 selectedBaselineIds: selectedBaselines
             };
         case `${types.SET_SELECTED_BASELINES}`:


### PR DESCRIPTION
This reworks the select logic in order to fix a bug where selecting a baseline in the system modal would not persist. Before this fix if you clicked on the System tab or performed a baseline search, any selected baselines would lose their selections. Now you should be able to switch back and forth or perform search without losing any selection.

This has failing tests and some code cleanup yet to be done. @johnsonm325 wanted you to see the changes I was proposing to the logic as this moves some of it out of the component and into redux.