### PR TITLE
Introduce more focused fact modals based on type of fact

### DIFF
--- a/src/SmartComponents/BaselinesPage/EditBaseline/EditBaseline.js
+++ b/src/SmartComponents/BaselinesPage/EditBaseline/EditBaseline.js
@@ -106,7 +106,7 @@ class EditBaseline extends Component {
             row.push(<td className={ expandedRows.includes(fact.name) ? 'nested-fact' : '' }>
                 { this.renderExpandableRowButton(fact.name) } { fact.name }</td>);
             row.push(<td></td>);
-            row.push(editBaselineHelpers.renderKebab(fact.name, '', fact));
+            row.push(editBaselineHelpers.renderKebab({ factName: fact.name, fact, isCategory: true }));
             rows.push(<tr>{ row }</tr>);
 
             if (expandedRows.includes(fact.name)) {
@@ -116,14 +116,14 @@ class EditBaseline extends Component {
                         <p className="child-row">{ subFact.name }</p>
                     </td>);
                     row.push(<td>{ subFact.value }</td>);
-                    row.push(editBaselineHelpers.renderKebab(subFact.name, subFact.value, fact));
+                    row.push(editBaselineHelpers.renderKebab({ factName: subFact.name, factValue: subFact.value, fact, isSubFact: true }));
                     rows.push(<tr>{ row }</tr>);
                 });
             }
         } else {
             row.push(<td>{ fact.name }</td>);
             row.push(<td>{ fact.value }</td>);
-            row.push(editBaselineHelpers.renderKebab(fact.name, fact.value, fact));
+            row.push(editBaselineHelpers.renderKebab({ factName: fact.name, factValue: fact.value, fact }));
             rows.push(<tr>{ row }</tr>);
         }
 

--- a/src/SmartComponents/BaselinesPage/EditBaseline/FactKebab/FactKebab.js
+++ b/src/SmartComponents/BaselinesPage/EditBaseline/FactKebab/FactKebab.js
@@ -27,13 +27,15 @@ class FactKebab extends Component {
     }
 
     editFact() {
-        const { toggleFactModal, setFactData, factName, factValue, fact } = this.props;
+        const { toggleFactModal, setFactData, factName, factValue, fact, isCategory, isSubFact } = this.props;
 
         toggleFactModal();
         setFactData({
             factName,
             factValue,
-            fact
+            fact,
+            isCategory,
+            isSubFact
         });
     }
 
@@ -53,35 +55,23 @@ class FactKebab extends Component {
     }
 
     addFact() {
-        const { toggleFactModal, setFactData, fact } = this.props;
+        const { toggleFactModal, setFactData, fact, isCategory } = this.props;
 
         toggleFactModal();
         setFactData({
             factName: '',
             factValue: '',
-            fact
+            fact,
+            isSubFact: isCategory
         });
     }
 
     render() {
         const { isOpen } = this.state;
-        const { factValue, fact } = this.props;
-        const dropdownItems = [
-            <DropdownItem
-                key="edit"
-                component="button"
-                onClick={ this.editFact }>
-                { fact.values && factValue === '' ? 'Edit category' : 'Edit fact' }
-            </DropdownItem>,
-            <DropdownItem
-                key="delete"
-                component="button"
-                onClick={ this.deleteFact }>
-                { fact.values && factValue === '' ? 'Delete category' : 'Delete fact' }
-            </DropdownItem>
-        ];
+        const { isCategory } = this.props;
+        const dropdownItems = [];
 
-        if (fact.values && factValue === '') {
+        if (isCategory === true) {
             dropdownItems.push(
                 <DropdownItem
                     key="add fact"
@@ -91,6 +81,21 @@ class FactKebab extends Component {
                 </DropdownItem>
             );
         }
+
+        dropdownItems.push(
+            <DropdownItem
+                key="edit"
+                component="button"
+                onClick={ this.editFact }>
+                { isCategory ? 'Edit category' : 'Edit fact' }
+            </DropdownItem>,
+            <DropdownItem
+                key="delete"
+                component="button"
+                onClick={ this.deleteFact }>
+                { isCategory ? 'Delete category' : 'Delete fact' }
+            </DropdownItem>
+        );
 
         return (
             <Dropdown
@@ -110,6 +115,8 @@ FactKebab.propTypes = {
     factName: PropTypes.string,
     factValue: PropTypes.string,
     fact: PropTypes.object,
+    isCategory: PropTypes.bool,
+    isSubFact: PropTypes.bool,
     toggleFactModal: PropTypes.func,
     setFactData: PropTypes.func,
     baselineData: PropTypes.obj,

--- a/src/SmartComponents/BaselinesPage/EditBaseline/FactModal/FactModal.js
+++ b/src/SmartComponents/BaselinesPage/EditBaseline/FactModal/FactModal.js
@@ -22,17 +22,15 @@ class FactModal extends Component {
         this.state = {
             factName: this.props.factName,
             factValue: this.props.factValue,
-            factData: this.props.factData
+            factData: this.props.factData,
+            isCategory: this.props.isCategory
         };
 
-        if (this.props.factName !== '' && this.props.factValue === '') {
-            this.state.categoryCheck = true;
-        } else {
-            this.state.categoryCheck = false;
-        }
+        this.state.isAddFact = this.props.factName === '' && this.props.factValue === '';
+        this.state.isEditFact = this.props.factName !== '' && this.props.factValue !== '';
 
-        this.handleChange = (checked) => {
-            this.setState({ categoryCheck: checked });
+        this.handleChange = checked => {
+            this.setState({ isCategory: checked });
         };
 
         this.handleNewName = value => {
@@ -51,10 +49,10 @@ class FactModal extends Component {
     }
 
     confirmModal() {
-        const { toggleFactModal, factName, factValue } = this.props;
+        const { toggleFactModal } = this.props;
+        const { isAddFact } = this.state;
 
-        if ((factName === '' && factValue === '')
-        || (factName === undefined && factValue === undefined)) {
+        if (isAddFact) {
             this.addFact();
         } else {
             this.editFact();
@@ -64,17 +62,17 @@ class FactModal extends Component {
     }
 
     addFact() {
-        const { categoryCheck, factName, factValue, factData } = this.state;
+        const { isCategory, factName, factValue, factData } = this.state;
 
-        let newFactData = editBaselineHelpers.buildNewFactData(categoryCheck, factName, factValue, factData);
+        let newFactData = editBaselineHelpers.buildNewFactData(isCategory, factName, factValue, factData);
         this.patchFact(newFactData, factData);
     }
 
     editFact() {
-        const { categoryCheck, factName, factValue, factData } = this.state;
+        const { isCategory, factName, factValue, factData } = this.state;
 
         let editedFactData = editBaselineHelpers.buildEditedFactData(
-            categoryCheck, this.props.factName, factName, this.props.factValue, factValue, factData
+            isCategory, this.props.factName, factName, this.props.factValue, factValue, factData
         );
 
         this.patchFact(editedFactData, factData);
@@ -88,122 +86,100 @@ class FactModal extends Component {
     }
 
     renderCategoryCheckbox() {
-        const { categoryCheck } = this.state;
-        const { factName, factValue, factData } = this.props;
-        let categoryCheckBody;
+        const { isCategory, isEditFact } = this.state;
 
-        if (factName !== '' && factValue === '') {
-            categoryCheckBody = <Checkbox
-                label="This is a category"
-                aria-label="controlled checkbox example"
-                id="categoryCheck"
-                name="isCategory"
-                defaultChecked
-                isDisabled
-            />;
-        } else if ((factName !== '' && factValue !== '')
-            || (factName === '' && factValue === '' && !Array.isArray(factData))) {
-            categoryCheckBody = <Checkbox
-                label="This is a category"
-                aria-label="controlled checkbox example"
-                id="categoryCheck"
-                name="isCategory"
-                isDisabled
-            />;
-        } else {
-            categoryCheckBody = <Checkbox
-                label="This is a category"
-                isChecked={ categoryCheck }
-                onChange={ this.handleChange }
-                aria-label="controlled checkbox example"
-                id="categoryCheck"
-                name="isCategory"
-            />;
-        }
-
-        return categoryCheckBody;
+        return <Checkbox
+            aria-label="controlled checkbox example"
+            label="This is a category"
+            id="isCategory"
+            name="isCategory"
+            onChange={ this.handleChange }
+            isChecked={ isCategory }
+            isDisabled={ isCategory && isEditFact }
+        />;
     }
 
     renderFactInput() {
-        const { categoryCheck, factName } = this.state;
-        let factInputBody;
+        const { factName, isCategory } = this.state;
 
-        factInputBody = <div className="fact-value">
-            <Form>
-                <FormGroup
-                    label={ categoryCheck ? 'Category name' : 'Fact name' }
-                    isRequired
-                    fieldId='fact name'>
-                    <TextInput
-                        value={ factName }
-                        type="text"
-                        placeholder="Name"
-                        onChange={ this.handleNewName }
-                        isValid={ factName !== '' && factName !== undefined ? true : false }
-                        aria-label="fact name"
-                    />
-                </FormGroup>
-            </Form>
-        </div>;
-
-        return factInputBody;
+        return (
+            <div className="fact-value">
+                <Form>
+                    <FormGroup
+                        label={ isCategory ? 'Category name' : 'Fact name' }
+                        isRequired
+                        fieldId='fact name'>
+                        <TextInput
+                            value={ factName }
+                            type="text"
+                            placeholder="Name"
+                            onChange={ this.handleNewName }
+                            isValid={ factName !== '' && factName !== undefined ? true : false }
+                            aria-label="fact name"
+                        />
+                    </FormGroup>
+                </Form>
+            </div>
+        );
     }
 
     renderValueInput() {
-        const { categoryCheck, factValue } = this.state;
-        let valueInput;
-        let valueInputBody;
+        const { factValue } = this.state;
 
-        if (categoryCheck) {
-            valueInput = <TextInput
-                type="text"
-                aria-label="value"
-                isDisabled
-            />;
-        } else {
-            valueInput = <TextInput
-                value={ factValue }
-                type="text"
-                placeholder="Value"
-                onChange={ this.handleNewValue }
-                isValid={ factValue !== '' && factValue !== undefined ? true : false }
-                aria-label="value"
-            />;
-        }
-
-        valueInputBody = <div className="fact-value">
-            <Form>
-                { categoryCheck
-                    ? <FormGroup
-                        label='Value'
-                        fieldId='fact value'>
-                        { valueInput }
-                    </FormGroup>
-                    : <FormGroup
+        return (
+            <div className="fact-value">
+                <Form>
+                    <FormGroup
                         label='Value'
                         isRequired
                         fieldId='fact value'>
-                        { valueInput }
+                        <TextInput
+                            value={ factValue }
+                            type="text"
+                            placeholder="Value"
+                            onChange={ this.handleNewValue }
+                            isValid={ factValue !== '' && factValue !== undefined ? true : false }
+                            aria-label="value"
+                        />
                     </FormGroup>
-                }
-            </Form>
-        </div>;
-
-        return valueInputBody;
-
+                </Form>
+            </div>
+        );
     }
 
     renderModalBody() {
+        const { isSubFact } = this.props;
+        const { isAddFact, isCategory } = this.state;
         let modalBody;
 
         modalBody = <React.Fragment>
-            { this.renderCategoryCheckbox() }
+            { (isAddFact && !isSubFact) || isCategory ? this.renderCategoryCheckbox() : null }
             { this.renderFactInput() }
             <br></br>
-            { this.renderValueInput() }
+            { isCategory ? null : this.renderValueInput() }
         </React.Fragment>;
 
         return modalBody;
+    }
+
+    title() {
+        const { isSubFact } = this.props;
+        const { isAddFact, isEditFact, isCategory } = this.state;
+        let title = 'Add fact';
+
+        if (isEditFact === true && !isCategory && !isSubFact) {
+            title = 'Edit fact';
+        } else if (isAddFact === true && isCategory === true) {
+            title = 'Add category';
+        } else if (isAddFact === true && isSubFact === true) {
+            title = 'Add sub fact';
+        } else if (isEditFact === true && isSubFact === true) {
+            title = 'Edit sub fact';
+        } else if (isCategory === true) {
+            title = 'Edit category';
+        }
+
+        return title;
     }
 
     render() {
@@ -212,7 +188,7 @@ class FactModal extends Component {
         return (
             <Modal
                 className="small-modal-body"
-                title="Add/edit fact"
+                title={ this.title() }
                 isOpen={ factModalOpened }
                 onClose={ this.cancelFact }
                 width="auto"
@@ -244,6 +220,8 @@ FactModal.propTypes = {
     factName: PropTypes.string,
     factValue: PropTypes.string,
     factData: PropTypes.obj,
+    isCategory: PropTypes.bool,
+    isSubFact: PropTypes.bool,
     baselineData: PropTypes.obj,
     patchBaseline: PropTypes.func
 };
@@ -254,6 +232,8 @@ function mapStateToProps(state) {
         factName: state.factModalState.factName,
         factValue: state.factModalState.factValue,
         factData: state.factModalState.factData,
+        isCategory: state.factModalState.isCategory,
+        isSubFact: state.factModalState.isSubFact,
         baselineData: state.baselinesTableState.baselineData
     };
 }

--- a/src/SmartComponents/BaselinesPage/EditBaseline/FactModal/redux/reducers.js
+++ b/src/SmartComponents/BaselinesPage/EditBaseline/FactModal/redux/reducers.js
@@ -4,7 +4,9 @@ const initialState = {
     factModalOpened: false,
     factName: '',
     factValue: '',
-    factData: []
+    factData: [],
+    isCategory: false,
+    isSubFact: false
 };
 
 export function factModalReducer(state = initialState, action) {
@@ -19,7 +21,9 @@ export function factModalReducer(state = initialState, action) {
                 ...state,
                 factName: action.payload.factName,
                 factValue: action.payload.factValue,
-                factData: action.payload.fact
+                factData: action.payload.fact,
+                isCategory: action.payload.isCategory,
+                isSubFact: action.payload.isSubFact
             };
 
         default:

--- a/src/SmartComponents/BaselinesPage/EditBaseline/helpers.js
+++ b/src/SmartComponents/BaselinesPage/EditBaseline/helpers.js
@@ -2,13 +2,15 @@ import React from 'react';
 import jiff from 'jiff';
 import FactKebab from './FactKebab/FactKebab';
 
-function renderKebab(factName, factValue, fact) {
+function renderKebab({ factName, factValue, fact, isCategory, isSubFact } = {}) {
     return <td>
-        { <FactKebab
+        <FactKebab
             factName={ factName }
             factValue={ factValue }
-            fact={ fact } />
-        }
+            fact={ fact }
+            isCategory={ isCategory }
+            isSubFact={ isSubFact }
+        />
     </td>;
 }
 


### PR DESCRIPTION
This makes the various incarnations of the fact modal target
their use case more. For example, when editing a category the
title will reflect such. The same for sub facts.

This is essentially a no break test of functionality for creating and editing facts and categories. The titles of the modal should reflect the action as well as the options present reflect the kind of item being created or edited.

 * Add Fact
 * Add Category
 * Edit Fact
 * Edit Sub Fact
 * Edit Category