### PR TITLE
Fix ghost selection comparison when removing a system

### DIFF
--- a/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
+++ b/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
@@ -77,13 +77,8 @@ class DriftTable extends Component {
     }
 
     fetchCompare(systemIds, baselineIds) {
-        if (systemIds.length > 0) {
-            this.systemIds = systemIds;
-        }
-
-        if (baselineIds.length > 0) {
-            this.baselineIds = baselineIds;
-        }
+        this.systemIds = systemIds;
+        this.baselineIds = baselineIds;
 
         if (systemIds.length > 0 || baselineIds.length > 0) {
             setHistory(this.props.history, systemIds, baselineIds);


### PR DESCRIPTION
If all systems and baselines were removed in a comparison, followed
by a comparison of just baselines the internal saved set of system
ids would not reset.