### PR TITLE
Switch to use of "qa" branch

### DIFF
--- a/.travis/custom_release.sh
+++ b/.travis/custom_release.sh
@@ -7,8 +7,6 @@ if [ "${TRAVIS_BRANCH}" = "master" ]; then
     echo
     echo "PUSHING ci-beta"
     .travis/release.sh "ci-beta"
-    rm -rf dist/.git
-    .travis/release.sh "qa-beta"
 
     echo "Rebuilding for stable branches"
     rm -rf dist/
@@ -17,10 +15,34 @@ if [ "${TRAVIS_BRANCH}" = "master" ]; then
     echo
     echo "PUSHING ci-stable"
     .travis/release.sh "ci-stable"
-    rm -rf dist/.git
+fi
+
+if [ "${TRAVIS_BRANCH}" = "qa" ]; then
+    echo
+    echo
+    echo "PUSHING qa-beta"
+    .travis/release.sh "qa-beta"
+
+    echo "Rebuilding for stable branches"
+    rm -rf dist/
+    BUILD_STABLE=true npm run travis:build
+    echo
+    echo
+    echo "PUSHING qa-stable"
     .travis/release.sh "qa-stable"
 fi
 
-if [[ "${TRAVIS_BRANCH}" = "prod-beta" || "${TRAVIS_BRANCH}" = "prod-stable" ]]; then
-    .travis/release.sh "${TRAVIS_BRANCH}"
+if [ "${TRAVIS_BRANCH}" = "prod" ]; then
+    echo
+    echo
+    echo "PUSHING prod-beta"
+    .travis/release.sh "prod-beta"
+
+    echo "Rebuilding for stable branches"
+    rm -rf dist/
+    BUILD_STABLE=true npm run travis:build
+    echo
+    echo
+    echo "PUSHING prod-stable"
+    .travis/release.sh "prod-stable"
 fi


### PR DESCRIPTION
Pushes to "qa" branch will now build and push to qa-beta and qa-stable.
This change moves the frontend closer to a model similar to our
backends.