### PR TITLE
Increase min-height of comparison table to avoid dropdown cutoff

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -160,6 +160,7 @@
   .drift-table-wrapper {
     overflow: auto;
     height: 100%;
+    min-height: 500px;
     margin-left: 24px;
     margin-right: 24px;
   }


### PR DESCRIPTION
This fixes a bug where a filter applied to the comparison table causes the height to adjust, thus cutting off the dropdown for historical profiles. I've adjusted the minimum height to 500 to avoid this.