### PR TITLE
Fix hsp-only compare and hsp dropdown in beta only

### DIFF
--- a/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
+++ b/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
@@ -65,9 +65,6 @@ export class DriftTable extends Component {
 
         /*eslint-disable camelcase*/
         historicalProfiles.forEach(function(hsp) {
-            let system = systems.find(item => item.id === hsp.system_id);
-            hsp.system_last_updated = system.last_updated;
-
             if (historicalGroups.hasOwnProperty(hsp.system_id)) {
                 historicalGroups[hsp.system_id].push(hsp);
             } else {

--- a/src/SmartComponents/DriftPage/DriftTable/__tests__/__snapshots__/DriftTable.tests.js.snap
+++ b/src/SmartComponents/DriftPage/DriftTable/__tests__/__snapshots__/DriftTable.tests.js.snap
@@ -1331,7 +1331,6 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                   "id": "9bbbefcc-8f23-4d97-07f2-142asdl234e8",
                   "last_updated": "2019-01-15T14:53:15.886891Z",
                   "system_id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
-                  "system_last_updated": "2019-01-15T14:53:15.886891Z",
                   "type": "historical-system-profile",
                 },
                 Object {
@@ -1339,7 +1338,6 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                   "id": "edmk59dj-fn42-dfjk-alv3-bmn2854mnn27",
                   "last_updated": "2019-01-15T15:25:16.304899Z",
                   "system_id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
-                  "system_last_updated": "2019-01-15T14:53:15.886891Z",
                   "type": "historical-system-profile",
                 },
               ]
@@ -1499,7 +1497,6 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                           "id": "9bbbefcc-8f23-4d97-07f2-142asdl234e8",
                           "last_updated": "2019-01-15T14:53:15.886891Z",
                           "system_id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
-                          "system_last_updated": "2019-01-15T14:53:15.886891Z",
                           "type": "historical-system-profile",
                         },
                         Object {
@@ -1507,7 +1504,6 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                           "id": "edmk59dj-fn42-dfjk-alv3-bmn2854mnn27",
                           "last_updated": "2019-01-15T15:25:16.304899Z",
                           "system_id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
-                          "system_last_updated": "2019-01-15T14:53:15.886891Z",
                           "type": "historical-system-profile",
                         },
                       ]

--- a/src/SmartComponents/HistoricalProfilesDropdown/HistoricalProfilesDropdown.js
+++ b/src/SmartComponents/HistoricalProfilesDropdown/HistoricalProfilesDropdown.js
@@ -12,7 +12,6 @@ import { historicProfilesActions } from '../HistoricalProfilesDropdown/redux';
 import HistoricalProfilesCheckbox from './HistoricalProfilesCheckbox/HistoricalProfilesCheckbox';
 import api from '../../api';
 import FetchHistoricalProfilesButton from './FetchHistoricalProfilesButton/FetchHistoricalProfilesButton';
-import moment from 'moment';
 
 export class HistoricalProfilesDropdown extends Component {
     constructor(props) {
@@ -47,18 +46,11 @@ export class HistoricalProfilesDropdown extends Component {
 
     async fetchData(system) {
         let fetchedData = await api.fetchHistoricalData(system.system_id ? system.system_id : system.id);
-
-        /*eslint-disable camelcase*/
-        const filteredProfiles = fetchedData.profiles.filter(profile =>
-            moment.utc(profile.captured_date).format('DD MMM YYYY, HH:mm UTC') !==
-            moment.utc(system.system_last_updated ? system.system_last_updated : system.last_updated).format('DD MMM YYYY, HH:mm UTC')
-        );
-        fetchedData.profiles = filteredProfiles;
+        fetchedData.profiles.shift();
 
         this.setState({
             historicalData: fetchedData
         });
-        /*eslint-enable camelcase*/
 
         this.setState({
             dropDownArray: this.createDropdownArray(this.state.historicalData)

--- a/src/SmartComponents/SystemsTable/reducers.js
+++ b/src/SmartComponents/SystemsTable/reducers.js
@@ -20,39 +20,41 @@ function selectedReducer(INVENTORY_ACTIONS, createBaselineModal, historicalProfi
 
             let rows = mergeArraysByKey([ action.payload.results, state.rows ]);
 
-            /*eslint-disable camelcase*/
-            if (!newColumns.find(({ key }) => key === 'historical_profiles') && hasHistoricalDropdown) {
-                newColumns.push({
-                    key: 'historical_profiles',
-                    title: 'Historical profiles',
-                    props: {
-                        width: 10
-                    }
+            if (insights.chrome.isBeta()) {
+                /*eslint-disable camelcase*/
+                if (!newColumns.find(({ key }) => key === 'historical_profiles') && hasHistoricalDropdown) {
+                    newColumns.push({
+                        key: 'historical_profiles',
+                        title: 'Historical profiles',
+                        props: {
+                            width: 10
+                        }
+                    });
+                }
+
+                rows.forEach(function(row) {
+                    let badgeCount = 0;
+                    let systemInfo = {
+                        id: row.id,
+                        last_updated: row.updated
+                    };
+
+                    historicalProfiles.forEach(function(profile) {
+                        if (profile.system_id === row.id) {
+                            badgeCount += 1;
+                        }
+                    });
+
+                    row.historical_profiles = <React.Fragment>
+                        <HistoricalProfilesDropdown
+                            system={ systemInfo }
+                            hasBadge={ true }
+                            badgeCount={ badgeCount }
+                        />
+                    </React.Fragment>;
                 });
+                /*eslint-enable camelcase*/
             }
-
-            rows.forEach(function(row) {
-                let badgeCount = 0;
-                let systemInfo = {
-                    id: row.id,
-                    last_updated: row.updated
-                };
-
-                historicalProfiles.forEach(function(profile) {
-                    if (profile.system_id === row.id) {
-                        badgeCount += 1;
-                    }
-                });
-
-                row.historical_profiles = <React.Fragment>
-                    <HistoricalProfilesDropdown
-                        system={ systemInfo }
-                        hasBadge={ true }
-                        badgeCount={ badgeCount }
-                    />
-                </React.Fragment>;
-            });
-            /*eslint-enable camelcase*/
 
             return {
                 ...state,


### PR DESCRIPTION
Because the most recent hsp timestamp is an exact match of the current system, I have opted to pop off the most recent hsp timestamp from the hsp fetched data instead of trying to match the hsp timestamp with the system timestamp.