### PR TITLE
Fix HSP and reference bugs

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -86,6 +86,10 @@
     background-color: rgb(237, 237, 237);
   }
 
+  .historical-system-profile-dropdown {
+    max-height: 21px;
+  }
+
   .historical-system-profile-header {
     border-top: 1px solid #CCC;
     background-color: #f9e0a2;
@@ -296,10 +300,6 @@
     }
   }
 
-  .historical-system-profile-dropdown {
-    max-height: 21px;
-  }
-
   .hsp-dropdown-icon {
     color: #0066CC;
   }
@@ -333,6 +333,13 @@
   min-width: 900px;
   max-width: 1200px;
   max-height: 600px;
+}
+
+.add-system-modal-dropdowns {
+  .pf-c-dropdown__menu {
+    max-height: 200px;
+    overflow-y: auto;
+  }
 }
 
 .drift-toolbar {

--- a/src/SmartComponents/AddSystemModal/AddSystemModal.js
+++ b/src/SmartComponents/AddSystemModal/AddSystemModal.js
@@ -56,9 +56,7 @@ export class AddSystemModal extends Component {
             entities.selectedSystemIds,
             selectedBaselineIds,
             selectedHSPIds,
-            entities.selectedSystemIds.includes(referenceId)
-                ? referenceId
-                : undefined
+            referenceId
         );
         toggleModal();
     }
@@ -88,6 +86,7 @@ export class AddSystemModal extends Component {
         return (
             <React.Fragment>
                 <Modal
+                    className="add-system-modal-dropdowns"
                     title="Choose systems"
                     isOpen={ addSystemModalOpened }
                     onClose={ this.cancelSelection }

--- a/src/SmartComponents/AddSystemModal/__tests__/__snapshots__/AddSystemModal.tests.js.snap
+++ b/src/SmartComponents/AddSystemModal/__tests__/__snapshots__/AddSystemModal.tests.js.snap
@@ -15,7 +15,7 @@ exports[`AddSystemModal should render correctly 1`] = `
     }
     appendTo={<body />}
     ariaDescribedById=""
-    className=""
+    className="add-system-modal-dropdowns"
     hideTitle={false}
     isFooterLeftAligned={true}
     isLarge={false}
@@ -221,7 +221,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                             aria-describedby="pf-modal-0"
                             aria-label="Choose systems"
                             aria-modal="true"
-                            class="pf-c-modal-box"
+                            class="pf-c-modal-box add-system-modal-dropdowns"
                             role="dialog"
                             style="width: auto;"
                           >
@@ -502,7 +502,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                             aria-describedby="pf-modal-1"
                             aria-label="Choose systems"
                             aria-modal="true"
-                            class="pf-c-modal-box"
+                            class="pf-c-modal-box add-system-modal-dropdowns"
                             role="dialog"
                             style="width: auto;"
                           >
@@ -775,7 +775,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                   </body>
                 }
                 ariaDescribedById=""
-                className=""
+                className="add-system-modal-dropdowns"
                 hideTitle={false}
                 isFooterLeftAligned={true}
                 isLarge={false}
@@ -799,7 +799,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                             aria-describedby="pf-modal-1"
                             aria-label="Choose systems"
                             aria-modal="true"
-                            class="pf-c-modal-box"
+                            class="pf-c-modal-box add-system-modal-dropdowns"
                             role="dialog"
                             style="width: auto;"
                           >
@@ -1083,7 +1083,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                       ]
                     }
                     ariaDescribedById=""
-                    className=""
+                    className="add-system-modal-dropdowns"
                     hideTitle={false}
                     id="pf-modal-1"
                     isFooterLeftAligned={true}
@@ -1115,7 +1115,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                             className="pf-l-bullseye"
                           >
                             <ModalBox
-                              className=""
+                              className="add-system-modal-dropdowns"
                               id="pf-modal-1"
                               isLarge={false}
                               isSmall={false}
@@ -1130,7 +1130,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                 aria-describedby="pf-modal-1"
                                 aria-label="Choose systems"
                                 aria-modal="true"
-                                className="pf-c-modal-box"
+                                className="pf-c-modal-box add-system-modal-dropdowns"
                                 role="dialog"
                                 style={
                                   Object {
@@ -3121,7 +3121,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                             aria-describedby="pf-modal-0"
                             aria-label="Choose systems"
                             aria-modal="true"
-                            class="pf-c-modal-box"
+                            class="pf-c-modal-box add-system-modal-dropdowns"
                             role="dialog"
                             style="width: auto;"
                           >
@@ -3394,7 +3394,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                   </body>
                 }
                 ariaDescribedById=""
-                className=""
+                className="add-system-modal-dropdowns"
                 hideTitle={false}
                 isFooterLeftAligned={true}
                 isLarge={false}
@@ -3418,7 +3418,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                             aria-describedby="pf-modal-0"
                             aria-label="Choose systems"
                             aria-modal="true"
-                            class="pf-c-modal-box"
+                            class="pf-c-modal-box add-system-modal-dropdowns"
                             role="dialog"
                             style="width: auto;"
                           >
@@ -3702,7 +3702,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                       ]
                     }
                     ariaDescribedById=""
-                    className=""
+                    className="add-system-modal-dropdowns"
                     hideTitle={false}
                     id="pf-modal-0"
                     isFooterLeftAligned={true}
@@ -3734,7 +3734,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                             className="pf-l-bullseye"
                           >
                             <ModalBox
-                              className=""
+                              className="add-system-modal-dropdowns"
                               id="pf-modal-0"
                               isLarge={false}
                               isSmall={false}
@@ -3749,7 +3749,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                 aria-describedby="pf-modal-0"
                                 aria-label="Choose systems"
                                 aria-modal="true"
-                                className="pf-c-modal-box"
+                                className="pf-c-modal-box add-system-modal-dropdowns"
                                 role="dialog"
                                 style={
                                   Object {

--- a/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
+++ b/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
-import { EmptyState, EmptyStateBody, EmptyStateIcon, Title, Tooltip } from '@patternfly/react-core';
+import { DropdownDirection, EmptyState, EmptyStateBody, EmptyStateIcon, Title, Tooltip } from '@patternfly/react-core';
 import queryString from 'query-string';
 import { ClockIcon, TimesIcon, ExclamationTriangleIcon, PlusCircleIcon, ServerIcon, BlueprintIcon } from '@patternfly/react-icons';
 import { AngleDownIcon, AngleRightIcon, LongArrowAltUpIcon, LongArrowAltDownIcon, ArrowsAltVIcon } from '@patternfly/react-icons';
@@ -162,6 +162,10 @@ export class DriftTable extends Component {
             this.baselineIds = this.baselineIds.filter(id => id !== item.id);
         } else if (item.type === 'historical-system-profile') {
             this.HSPIds = this.HSPIds.filter(id => id !== item.id);
+        }
+
+        if (item.id === this.referenceId) {
+            this.referenceId = undefined;
         }
 
         this.props.setSelectedHistoricProfiles(this.HSPIds);
@@ -354,6 +358,9 @@ export class DriftTable extends Component {
                                     ? <HistoricalProfilesDropdown
                                         system={ item }
                                         systemIds={ this.systemIds }
+                                        referenceId={ referenceId }
+                                        fetchCompare={ this.fetchCompare }
+                                        dropdownDirection={ DropdownDirection.down }
                                     />
                                     : null
                                 : null

--- a/src/SmartComponents/DriftPage/DriftTable/__tests__/__snapshots__/DriftTable.tests.js.snap
+++ b/src/SmartComponents/DriftPage/DriftTable/__tests__/__snapshots__/DriftTable.tests.js.snap
@@ -229,7 +229,7 @@ exports[`ConnectedDriftTable should render correctly 1`] = `
                         </body>
                       }
                       ariaDescribedById=""
-                      className=""
+                      className="add-system-modal-dropdowns"
                       hideTitle={false}
                       isFooterLeftAligned={true}
                       isLarge={false}
@@ -255,7 +255,7 @@ exports[`ConnectedDriftTable should render correctly 1`] = `
                             ]
                           }
                           ariaDescribedById=""
-                          className=""
+                          className="add-system-modal-dropdowns"
                           hideTitle={false}
                           id="pf-modal-0"
                           isFooterLeftAligned={true}
@@ -632,7 +632,7 @@ exports[`ConnectedDriftTable should render loading rows 1`] = `
                         </body>
                       }
                       ariaDescribedById=""
-                      className=""
+                      className="add-system-modal-dropdowns"
                       hideTitle={false}
                       isFooterLeftAligned={true}
                       isLarge={false}
@@ -658,7 +658,7 @@ exports[`ConnectedDriftTable should render loading rows 1`] = `
                             ]
                           }
                           ariaDescribedById=""
-                          className=""
+                          className="add-system-modal-dropdowns"
                           hideTitle={false}
                           id="pf-modal-2"
                           isFooterLeftAligned={true}
@@ -1552,7 +1552,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                         </body>
                       }
                       ariaDescribedById=""
-                      className=""
+                      className="add-system-modal-dropdowns"
                       hideTitle={false}
                       isFooterLeftAligned={true}
                       isLarge={false}
@@ -1578,7 +1578,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                             ]
                           }
                           ariaDescribedById=""
-                          className=""
+                          className="add-system-modal-dropdowns"
                           hideTitle={false}
                           id="pf-modal-1"
                           isFooterLeftAligned={true}

--- a/src/SmartComponents/DriftPage/__tests__/__snapshots__/DriftPage.tests.js.snap
+++ b/src/SmartComponents/DriftPage/__tests__/__snapshots__/DriftPage.tests.js.snap
@@ -3014,7 +3014,7 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
                                               </body>
                                             }
                                             ariaDescribedById=""
-                                            className=""
+                                            className="add-system-modal-dropdowns"
                                             hideTitle={false}
                                             isFooterLeftAligned={true}
                                             isLarge={false}
@@ -3040,7 +3040,7 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
                                                   ]
                                                 }
                                                 ariaDescribedById=""
-                                                className=""
+                                                className="add-system-modal-dropdowns"
                                                 hideTitle={false}
                                                 id="pf-modal-0"
                                                 isFooterLeftAligned={true}
@@ -7142,7 +7142,7 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                               </body>
                                             }
                                             ariaDescribedById=""
-                                            className=""
+                                            className="add-system-modal-dropdowns"
                                             hideTitle={false}
                                             isFooterLeftAligned={true}
                                             isLarge={false}
@@ -7168,7 +7168,7 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                                   ]
                                                 }
                                                 ariaDescribedById=""
-                                                className=""
+                                                className="add-system-modal-dropdowns"
                                                 hideTitle={false}
                                                 id="pf-modal-1"
                                                 isFooterLeftAligned={true}

--- a/src/SmartComponents/HistoricalProfilesDropdown/HistoricalProfilesDropdown.js
+++ b/src/SmartComponents/HistoricalProfilesDropdown/HistoricalProfilesDropdown.js
@@ -5,9 +5,7 @@ import { Badge, Dropdown, DropdownItem, DropdownToggle, DropdownPosition } from 
 import { HistoryIcon } from '@patternfly/react-icons';
 import PropTypes from 'prop-types';
 import { Skeleton, SkeletonSize } from '@redhat-cloud-services/frontend-components';
-import { setHistory } from '../../Utilities/SetHistory';
 
-import { compareActions } from '../modules';
 import { historicProfilesActions } from '../HistoricalProfilesDropdown/redux';
 import HistoricalProfilesCheckbox from './HistoricalProfilesCheckbox/HistoricalProfilesCheckbox';
 import api from '../../api';
@@ -38,10 +36,9 @@ export class HistoricalProfilesDropdown extends Component {
     }
 
     fetchCompare = () => {
-        const { systemIds, selectedBaselineIds, selectedHSPIds, fetchCompare, history } = this.props;
+        const { systemIds, selectedBaselineIds, selectedHSPIds, referenceId, fetchCompare } = this.props;
 
-        setHistory(history, systemIds, selectedBaselineIds, selectedHSPIds);
-        fetchCompare(systemIds, selectedBaselineIds, selectedHSPIds);
+        fetchCompare(systemIds, selectedBaselineIds, selectedHSPIds, referenceId);
     }
 
     async fetchData(system) {
@@ -142,6 +139,7 @@ export class HistoricalProfilesDropdown extends Component {
                     isOpen={ isOpen }
                     isPlain
                     position={ DropdownPosition.right }
+                    direction={ this.props.dropdownDirection }
                     dropdownItems={ dropDownArray }
                 />
                 { hasBadge ? this.renderBadge() : null }
@@ -154,13 +152,14 @@ HistoricalProfilesDropdown.propTypes = {
     fetchHistoricalData: PropTypes.func,
     system: PropTypes.object,
     fetchCompare: PropTypes.func,
-    history: PropTypes.object,
     systemIds: PropTypes.array,
     selectedHSPIds: PropTypes.array,
     selectedBaselineIds: PropTypes.array,
     selectHistoricProfiles: PropTypes.func,
     hasBadge: PropTypes.bool,
-    badgeCount: PropTypes.number
+    badgeCount: PropTypes.number,
+    referenceId: PropTypes.string,
+    dropdownDirection: PropTypes.object
 };
 
 function mapStateToProps(state) {
@@ -172,9 +171,6 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
     return {
-        fetchCompare: ((systemIds, selectedBaselineIds, selectedHSPIds) =>
-            dispatch(compareActions.fetchCompare(systemIds, selectedBaselineIds, selectedHSPIds))
-        ),
         selectHistoricProfiles: (historicProfileIds) => dispatch(historicProfilesActions.selectHistoricProfiles(historicProfileIds))
     };
 }

--- a/src/SmartComponents/HistoricalProfilesDropdown/__tests__/HistoricalProfilesDropdown.tests.js
+++ b/src/SmartComponents/HistoricalProfilesDropdown/__tests__/HistoricalProfilesDropdown.tests.js
@@ -5,6 +5,7 @@ import configureStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import toJson from 'enzyme-to-json';
 
+import { DropdownDirection } from '@patternfly/react-core';
 import ConnectedHistoricalProfilesDropdown, { HistoricalProfilesDropdown } from '../HistoricalProfilesDropdown';
 
 describe('HistoricalProfilesDropdown', () => {
@@ -13,7 +14,8 @@ describe('HistoricalProfilesDropdown', () => {
     beforeEach(() => {
         props = {
             selectedHSPIds: [],
-            selectedBaselineIds: []
+            selectedBaselineIds: [],
+            dropdownDirection: DropdownDirection.down
         };
     });
 
@@ -29,6 +31,16 @@ describe('HistoricalProfilesDropdown', () => {
             <HistoricalProfilesDropdown { ...props }/>
         );
         expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    describe('API', () => {
+        it('should render DropdownDirection.up', () => {
+            props.dropdownDirection = DropdownDirection.up;
+            const wrapper = shallow(
+                <HistoricalProfilesDropdown { ...props }/>
+            );
+            expect(wrapper.find('Dropdown').prop('direction')).toBe('up');
+        });
     });
 });
 

--- a/src/SmartComponents/HistoricalProfilesDropdown/__tests__/__snapshots__/HistoricalProfilesDropdown.tests.js.snap
+++ b/src/SmartComponents/HistoricalProfilesDropdown/__tests__/__snapshots__/HistoricalProfilesDropdown.tests.js.snap
@@ -98,7 +98,6 @@ exports[`ConnectedHistoricalProfilesDropdown should render correctly 1`] = `
           }
         >
           <HistoricalProfilesDropdown
-            fetchCompare={[Function]}
             history={
               Object {
                 "action": "POP",
@@ -235,6 +234,7 @@ exports[`ConnectedHistoricalProfilesDropdown should render correctly 1`] = `
                   component={[Function]}
                   componentProps={
                     Object {
+                      "direction": undefined,
                       "dropdownItems": Array [
                         <Skeleton
                           className="hsp-dropdown-loading hsp-button"
@@ -479,6 +479,7 @@ exports[`ConnectedHistoricalProfilesDropdown should render correctly 1`] = `
 exports[`HistoricalProfilesDropdown should render correctly 1`] = `
 <Fragment>
   <Dropdown
+    direction="down"
     dropdownItems={
       Array [
         <Skeleton
@@ -524,10 +525,12 @@ exports[`HistoricalProfilesDropdown should render correctly 1`] = `
 
 exports[`HistoricalProfilesDropdown should render mount correctly 1`] = `
 <HistoricalProfilesDropdown
+  dropdownDirection="down"
   selectedBaselineIds={Array []}
   selectedHSPIds={Array []}
 >
   <Dropdown
+    direction="down"
     dropdownItems={
       Array [
         <Skeleton
@@ -569,6 +572,7 @@ exports[`HistoricalProfilesDropdown should render mount correctly 1`] = `
     }
   >
     <Component
+      direction="down"
       dropdownItems={
         Array [
           <Skeleton
@@ -613,6 +617,7 @@ exports[`HistoricalProfilesDropdown should render mount correctly 1`] = `
         component={[Function]}
         componentProps={
           Object {
+            "direction": "down",
             "dropdownItems": Array [
               <Skeleton
                 className="hsp-dropdown-loading hsp-button"

--- a/src/SmartComponents/SystemsTable/reducers.js
+++ b/src/SmartComponents/SystemsTable/reducers.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { DropdownDirection } from '@patternfly/react-core';
 import { mergeArraysByKey } from '@redhat-cloud-services/frontend-components-utilities/files/helpers';
 import { applyReducerHash } from '@redhat-cloud-services/frontend-components-utilities/files/ReducerRegistry';
 import HistoricalProfilesDropdown from '../HistoricalProfilesDropdown/HistoricalProfilesDropdown';
@@ -51,6 +52,7 @@ function selectedReducer(INVENTORY_ACTIONS, createBaselineModal, historicalProfi
                             system={ systemInfo }
                             hasBadge={ true }
                             badgeCount={ badgeCount }
+                            dropdownDirection={ DropdownDirection.up }
                         />
                     </React.Fragment>;
                 });


### PR DESCRIPTION
Fixes:

- Adding/Removing reference removes HSPs added post initial modal selection from URL
- Adding HSPs via table removes reference_id from URL
- HSP close 'x' does not work as expected
- Closing system/baseline where reference_id is set does not remove reference_id from URL
- Baseline marked as reference doesn't persist when adding more systems/baselines
- HSPs selector gets truncated on system selection modal