### PR TITLE
Change wording on buttons and modals

### DIFF
--- a/src/SmartComponents/AddSystemModal/AddSystemModal.js
+++ b/src/SmartComponents/AddSystemModal/AddSystemModal.js
@@ -88,7 +88,7 @@ export class AddSystemModal extends Component {
             <React.Fragment>
                 <Modal
                     className="add-system-modal-dropdowns"
-                    title="Choose systems"
+                    title="Add to comparison"
                     isOpen={ addSystemModalOpened }
                     onClose={ this.cancelSelection }
                     width="auto"

--- a/src/SmartComponents/AddSystemModal/__tests__/__snapshots__/AddSystemModal.tests.js.snap
+++ b/src/SmartComponents/AddSystemModal/__tests__/__snapshots__/AddSystemModal.tests.js.snap
@@ -23,7 +23,7 @@ exports[`AddSystemModal should render correctly 1`] = `
     isSmall={false}
     onClose={[Function]}
     showClose={true}
-    title="Choose systems"
+    title="Add to comparison"
     width="auto"
   >
     <Component
@@ -223,7 +223,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                         >
                           <div
                             aria-describedby="pf-modal-0"
-                            aria-label="Choose systems"
+                            aria-label="Add to comparison"
                             aria-modal="true"
                             class="pf-c-modal-box add-system-modal-dropdowns"
                             role="dialog"
@@ -253,7 +253,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                               class="pf-c-title pf-m-2xl"
                             >
                                
-                              Choose systems
+                              Add to comparison
                                
                             </h1>
                             <div
@@ -507,7 +507,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                         >
                           <div
                             aria-describedby="pf-modal-1"
-                            aria-label="Choose systems"
+                            aria-label="Add to comparison"
                             aria-modal="true"
                             class="pf-c-modal-box add-system-modal-dropdowns"
                             role="dialog"
@@ -537,7 +537,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                               class="pf-c-title pf-m-2xl"
                             >
                                
-                              Choose systems
+                              Add to comparison
                                
                             </h1>
                             <div
@@ -789,7 +789,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                         >
                           <div
                             aria-describedby="pf-modal-2"
-                            aria-label="Choose systems"
+                            aria-label="Add to comparison"
                             aria-modal="true"
                             class="pf-c-modal-box add-system-modal-dropdowns"
                             role="dialog"
@@ -819,7 +819,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                               class="pf-c-title pf-m-2xl"
                             >
                                
-                              Choose systems
+                              Add to comparison
                                
                             </h1>
                             <div
@@ -1073,7 +1073,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                 isSmall={false}
                 onClose={[Function]}
                 showClose={true}
-                title="Choose systems"
+                title="Add to comparison"
                 width="auto"
               >
                 <Portal
@@ -1087,7 +1087,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                         >
                           <div
                             aria-describedby="pf-modal-2"
-                            aria-label="Choose systems"
+                            aria-label="Add to comparison"
                             aria-modal="true"
                             class="pf-c-modal-box add-system-modal-dropdowns"
                             role="dialog"
@@ -1117,7 +1117,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                               class="pf-c-title pf-m-2xl"
                             >
                                
-                              Choose systems
+                              Add to comparison
                                
                             </h1>
                             <div
@@ -1384,7 +1384,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                     isSmall={false}
                     onClose={[Function]}
                     showClose={true}
-                    title="Choose systems"
+                    title="Add to comparison"
                     width="auto"
                   >
                     <Backdrop>
@@ -1416,11 +1416,11 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                   "width": "auto",
                                 }
                               }
-                              title="Choose systems"
+                              title="Add to comparison"
                             >
                               <div
                                 aria-describedby="pf-modal-2"
-                                aria-label="Choose systems"
+                                aria-label="Add to comparison"
                                 aria-modal="true"
                                 className="pf-c-modal-box add-system-modal-dropdowns"
                                 role="dialog"
@@ -1521,7 +1521,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                       className="pf-c-title pf-m-2xl"
                                     >
                                        
-                                      Choose systems
+                                      Add to comparison
                                        
                                     </h1>
                                   </Title>
@@ -3415,7 +3415,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                         >
                           <div
                             aria-describedby="pf-modal-0"
-                            aria-label="Choose systems"
+                            aria-label="Add to comparison"
                             aria-modal="true"
                             class="pf-c-modal-box add-system-modal-dropdowns"
                             role="dialog"
@@ -3445,7 +3445,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                               class="pf-c-title pf-m-2xl"
                             >
                                
-                              Choose systems
+                              Add to comparison
                                
                             </h1>
                             <div
@@ -3699,7 +3699,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                 isSmall={false}
                 onClose={[Function]}
                 showClose={true}
-                title="Choose systems"
+                title="Add to comparison"
                 width="auto"
               >
                 <Portal
@@ -3713,7 +3713,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                         >
                           <div
                             aria-describedby="pf-modal-0"
-                            aria-label="Choose systems"
+                            aria-label="Add to comparison"
                             aria-modal="true"
                             class="pf-c-modal-box add-system-modal-dropdowns"
                             role="dialog"
@@ -3743,7 +3743,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                               class="pf-c-title pf-m-2xl"
                             >
                                
-                              Choose systems
+                              Add to comparison
                                
                             </h1>
                             <div
@@ -4010,7 +4010,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                     isSmall={false}
                     onClose={[Function]}
                     showClose={true}
-                    title="Choose systems"
+                    title="Add to comparison"
                     width="auto"
                   >
                     <Backdrop>
@@ -4042,11 +4042,11 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                   "width": "auto",
                                 }
                               }
-                              title="Choose systems"
+                              title="Add to comparison"
                             >
                               <div
                                 aria-describedby="pf-modal-0"
-                                aria-label="Choose systems"
+                                aria-label="Add to comparison"
                                 aria-modal="true"
                                 className="pf-c-modal-box add-system-modal-dropdowns"
                                 role="dialog"
@@ -4147,7 +4147,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                       className="pf-c-title pf-m-2xl"
                                     >
                                        
-                                      Choose systems
+                                      Add to comparison
                                        
                                     </h1>
                                   </Title>

--- a/src/SmartComponents/BaselinesPage/EditBaseline/EditBaselineNameModal/EditBaselineNameModal.js
+++ b/src/SmartComponents/BaselinesPage/EditBaseline/EditBaselineNameModal/EditBaselineNameModal.js
@@ -83,7 +83,7 @@ export class EditBaselineNameModal extends Component {
         return (
             <Modal
                 className='pf-c-modal-box'
-                title="Edit title"
+                title="Edit name"
                 isOpen={ modalOpened }
                 onClose={ this.cancelModal }
                 width="auto"

--- a/src/SmartComponents/BaselinesPage/EditBaseline/EditBaselineNameModal/__tests__/__snapshots__/EditBaselineNameModal.tests.js.snap
+++ b/src/SmartComponents/BaselinesPage/EditBaseline/EditBaselineNameModal/__tests__/__snapshots__/EditBaselineNameModal.tests.js.snap
@@ -28,7 +28,7 @@ exports[`EditBaselineNameModal should render correctly 1`] = `
   isSmall={false}
   onClose={[Function]}
   showClose={true}
-  title="Edit title"
+  title="Edit name"
   width="auto"
 >
   <div
@@ -152,7 +152,7 @@ exports[`EditBaselineNameModal should render mount correctly 1`] = `
             >
               <div
                 aria-describedby="pf-modal-0"
-                aria-label="Edit title"
+                aria-label="Edit name"
                 aria-modal="true"
                 class="pf-c-modal-box pf-c-modal-box"
                 role="dialog"
@@ -182,7 +182,7 @@ exports[`EditBaselineNameModal should render mount correctly 1`] = `
                   class="pf-c-title pf-m-2xl"
                 >
                    
-                  Edit title
+                  Edit name
                    
                 </h1>
                 <div
@@ -258,7 +258,7 @@ exports[`EditBaselineNameModal should render mount correctly 1`] = `
     isSmall={false}
     onClose={[Function]}
     showClose={true}
-    title="Edit title"
+    title="Edit name"
     width="auto"
   >
     <Portal
@@ -272,7 +272,7 @@ exports[`EditBaselineNameModal should render mount correctly 1`] = `
             >
               <div
                 aria-describedby="pf-modal-0"
-                aria-label="Edit title"
+                aria-label="Edit name"
                 aria-modal="true"
                 class="pf-c-modal-box pf-c-modal-box"
                 role="dialog"
@@ -302,7 +302,7 @@ exports[`EditBaselineNameModal should render mount correctly 1`] = `
                   class="pf-c-title pf-m-2xl"
                 >
                    
-                  Edit title
+                  Edit name
                    
                 </h1>
                 <div
@@ -396,7 +396,7 @@ exports[`EditBaselineNameModal should render mount correctly 1`] = `
         isSmall={false}
         onClose={[Function]}
         showClose={true}
-        title="Edit title"
+        title="Edit name"
         width="auto"
       >
         <Backdrop>
@@ -428,11 +428,11 @@ exports[`EditBaselineNameModal should render mount correctly 1`] = `
                       "width": "auto",
                     }
                   }
-                  title="Edit title"
+                  title="Edit name"
                 >
                   <div
                     aria-describedby="pf-modal-0"
-                    aria-label="Edit title"
+                    aria-label="Edit name"
                     aria-modal="true"
                     className="pf-c-modal-box pf-c-modal-box"
                     role="dialog"
@@ -533,7 +533,7 @@ exports[`EditBaselineNameModal should render mount correctly 1`] = `
                           className="pf-c-title pf-m-2xl"
                         >
                            
-                          Edit title
+                          Edit name
                            
                         </h1>
                       </Title>

--- a/src/SmartComponents/BaselinesPage/EditBaseline/EditBaselineToolbar/EditBaselineToolbar.js
+++ b/src/SmartComponents/BaselinesPage/EditBaseline/EditBaselineToolbar/EditBaselineToolbar.js
@@ -28,7 +28,7 @@ class EditBaselineToolbar extends Component {
                         <Button
                             variant='primary'
                             onClick={ this.handleAddFact }>
-                            Add fact
+                            Add fact or category
                         </Button>
                     </ToolbarItem>
                     <ToolbarItem>

--- a/src/SmartComponents/BaselinesPage/EditBaseline/__tests__/__snapshots__/EditBaseline.tests.js.snap
+++ b/src/SmartComponents/BaselinesPage/EditBaseline/__tests__/__snapshots__/EditBaseline.tests.js.snap
@@ -291,7 +291,7 @@ exports[`ConnectedEditBaseline should render correctly 1`] = `
                   isSmall={false}
                   onClose={[Function]}
                   showClose={true}
-                  title="Edit title"
+                  title="Edit name"
                   width="auto"
                 >
                   <Portal
@@ -324,7 +324,7 @@ exports[`ConnectedEditBaseline should render correctly 1`] = `
                       isSmall={false}
                       onClose={[Function]}
                       showClose={true}
-                      title="Edit title"
+                      title="Edit name"
                       width="auto"
                     />
                   </Portal>
@@ -515,7 +515,7 @@ exports[`ConnectedEditBaseline should render correctly 1`] = `
                                               component={[Function]}
                                               componentProps={
                                                 Object {
-                                                  "children": "Add fact",
+                                                  "children": "Add fact or category",
                                                   "onClick": [Function],
                                                   "variant": "primary",
                                                 }
@@ -541,7 +541,7 @@ exports[`ConnectedEditBaseline should render correctly 1`] = `
                                                   tabIndex={null}
                                                   type="button"
                                                 >
-                                                  Add fact
+                                                  Add fact or category
                                                 </button>
                                               </Button>
                                             </ComponentWithOuia>
@@ -1115,7 +1115,7 @@ exports[`ConnectedEditBaseline should render loading rows 1`] = `
                                               component={[Function]}
                                               componentProps={
                                                 Object {
-                                                  "children": "Add fact",
+                                                  "children": "Add fact or category",
                                                   "onClick": [Function],
                                                   "variant": "primary",
                                                 }
@@ -1141,7 +1141,7 @@ exports[`ConnectedEditBaseline should render loading rows 1`] = `
                                                   tabIndex={null}
                                                   type="button"
                                                 >
-                                                  Add fact
+                                                  Add fact or category
                                                 </button>
                                               </Button>
                                             </ComponentWithOuia>

--- a/src/SmartComponents/DriftPage/DriftTable/__tests__/__snapshots__/DriftTable.tests.js.snap
+++ b/src/SmartComponents/DriftPage/DriftTable/__tests__/__snapshots__/DriftTable.tests.js.snap
@@ -237,7 +237,7 @@ exports[`ConnectedDriftTable should render correctly 1`] = `
                       isSmall={false}
                       onClose={[Function]}
                       showClose={true}
-                      title="Choose systems"
+                      title="Add to comparison"
                       width="auto"
                     >
                       <Portal
@@ -264,7 +264,7 @@ exports[`ConnectedDriftTable should render correctly 1`] = `
                           isSmall={false}
                           onClose={[Function]}
                           showClose={true}
-                          title="Choose systems"
+                          title="Add to comparison"
                           width="auto"
                         />
                       </Portal>
@@ -640,7 +640,7 @@ exports[`ConnectedDriftTable should render loading rows 1`] = `
                       isSmall={false}
                       onClose={[Function]}
                       showClose={true}
-                      title="Choose systems"
+                      title="Add to comparison"
                       width="auto"
                     >
                       <Portal
@@ -667,7 +667,7 @@ exports[`ConnectedDriftTable should render loading rows 1`] = `
                           isSmall={false}
                           onClose={[Function]}
                           showClose={true}
-                          title="Choose systems"
+                          title="Add to comparison"
                           width="auto"
                         />
                       </Portal>
@@ -1560,7 +1560,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                       isSmall={false}
                       onClose={[Function]}
                       showClose={true}
-                      title="Choose systems"
+                      title="Add to comparison"
                       width="auto"
                     >
                       <Portal
@@ -1587,7 +1587,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                           isSmall={false}
                           onClose={[Function]}
                           showClose={true}
-                          title="Choose systems"
+                          title="Add to comparison"
                           width="auto"
                         />
                       </Portal>

--- a/src/SmartComponents/DriftPage/__tests__/__snapshots__/DriftPage.tests.js.snap
+++ b/src/SmartComponents/DriftPage/__tests__/__snapshots__/DriftPage.tests.js.snap
@@ -3028,7 +3028,7 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
                                             isSmall={false}
                                             onClose={[Function]}
                                             showClose={true}
-                                            title="Choose systems"
+                                            title="Add to comparison"
                                             width="auto"
                                           >
                                             <Portal
@@ -3055,7 +3055,7 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
                                                 isSmall={false}
                                                 onClose={[Function]}
                                                 showClose={true}
-                                                title="Choose systems"
+                                                title="Add to comparison"
                                                 width="auto"
                                               />
                                             </Portal>
@@ -7356,7 +7356,7 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                             isSmall={false}
                                             onClose={[Function]}
                                             showClose={true}
-                                            title="Choose systems"
+                                            title="Add to comparison"
                                             width="auto"
                                           >
                                             <Portal
@@ -7383,7 +7383,7 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                                 isSmall={false}
                                                 onClose={[Function]}
                                                 showClose={true}
-                                                title="Choose systems"
+                                                title="Add to comparison"
                                                 width="auto"
                                               />
                                             </Portal>


### PR DESCRIPTION
Fixes:
- Change 'Choose system' title to 'Add to comparison'
- Rename 'Edit title' to 'Edit name' in Baselines edit screen
- On the baseline edit page, change Add fact to 'Add/edit fact or category'