### PR TITLE
Correctly remove reference when removing reference from comparison

### DIFF
--- a/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
+++ b/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
@@ -160,7 +160,7 @@ export class DriftTable extends Component {
         return moment.utc(dateString).format('DD MMM YYYY, HH:mm UTC');
     }
 
-    removeSystem = (item) => {
+    async removeSystem(item) {
         if (item.type === 'system') {
             this.systemIds = this.systemIds.filter(id => id !== item.id);
 
@@ -175,8 +175,7 @@ export class DriftTable extends Component {
         }
 
         if (item.id === this.props.referenceId) {
-            this.referenceId = undefined;
-            this.props.updateReferenceId();
+            await this.props.updateReferenceId();
         }
 
         this.props.setSelectedHistoricProfiles(this.HSPIds);


### PR DESCRIPTION
Steps to reproduce:
1. Add two systems to comparison (system_A, system_B)
2. Set system_A as reference
3. Remove system_A by clicking X
ERROR 1: The URL still shows system_A as reference
4. Add system_A again
5. system_A is reference
Expected: When I remove the system that is reference from comparison, URL doesn't show a reference_id, and when I add the system again, it is not set as reference