### PR TITLE
Change modal cancel buttons to links and change drift filter chip name

### DIFF
--- a/src/SmartComponents/BaselinesPage/CreateBaselineModal/CreateBaselineModal.js
+++ b/src/SmartComponents/BaselinesPage/CreateBaselineModal/CreateBaselineModal.js
@@ -216,7 +216,7 @@ export class CreateBaselineModal extends Component {
                 </Button>,
                 <Button
                     key="cancel"
-                    variant="secondary"
+                    variant="link"
                     onClick={ this.cancelModal }>
                     Cancel
                 </Button>
@@ -231,7 +231,7 @@ export class CreateBaselineModal extends Component {
                 </Button>,
                 <Button
                     key="cancel"
-                    variant="secondary"
+                    variant="link"
                     onClick={ this.cancelModal }>
                     Cancel
                 </Button>

--- a/src/SmartComponents/BaselinesPage/CreateBaselineModal/__tests__/__snapshots__/CreateBaselineModal.tests.js.snap
+++ b/src/SmartComponents/BaselinesPage/CreateBaselineModal/__tests__/__snapshots__/CreateBaselineModal.tests.js.snap
@@ -167,7 +167,7 @@ exports[`ConnectedCreateBaselineModal should render correctly 1`] = `
                   </Unknown>,
                   <Unknown
                     onClick={[Function]}
-                    variant="secondary"
+                    variant="link"
                   >
                     Cancel
                   </Unknown>,
@@ -320,7 +320,7 @@ exports[`ConnectedCreateBaselineModal should render correctly 1`] = `
                               Create baseline
                             </button>
                             <button
-                              class="pf-c-button pf-m-secondary"
+                              class="pf-c-button pf-m-link"
                               type="button"
                             >
                               Cancel
@@ -469,7 +469,7 @@ exports[`ConnectedCreateBaselineModal should render correctly 1`] = `
                               Create baseline
                             </button>
                             <button
-                              class="pf-c-button pf-m-secondary"
+                              class="pf-c-button pf-m-link"
                               type="button"
                             >
                               Cancel
@@ -619,7 +619,7 @@ exports[`ConnectedCreateBaselineModal should render correctly 1`] = `
                               Create baseline
                             </button>
                             <button
-                              class="pf-c-button pf-m-secondary"
+                              class="pf-c-button pf-m-link"
                               type="button"
                             >
                               Cancel
@@ -768,7 +768,7 @@ exports[`ConnectedCreateBaselineModal should render correctly 1`] = `
                               Create baseline
                             </button>
                             <button
-                              class="pf-c-button pf-m-secondary"
+                              class="pf-c-button pf-m-link"
                               type="button"
                             >
                               Cancel
@@ -916,7 +916,7 @@ exports[`ConnectedCreateBaselineModal should render correctly 1`] = `
                               Create baseline
                             </button>
                             <button
-                              class="pf-c-button pf-m-secondary"
+                              class="pf-c-button pf-m-link"
                               type="button"
                             >
                               Cancel
@@ -1079,7 +1079,7 @@ exports[`ConnectedCreateBaselineModal should render correctly 1`] = `
                               Create baseline
                             </button>
                             <button
-                              class="pf-c-button pf-m-secondary"
+                              class="pf-c-button pf-m-link"
                               type="button"
                             >
                               Cancel
@@ -1102,7 +1102,7 @@ exports[`ConnectedCreateBaselineModal should render correctly 1`] = `
                       </Unknown>,
                       <Unknown
                         onClick={[Function]}
-                        variant="secondary"
+                        variant="link"
                       >
                         Cancel
                       </Unknown>,
@@ -1472,7 +1472,7 @@ exports[`ConnectedCreateBaselineModal should render correctly 1`] = `
                                   <Component
                                     key="cancel"
                                     onClick={[Function]}
-                                    variant="secondary"
+                                    variant="link"
                                   >
                                     <ComponentWithOuia
                                       component={[Function]}
@@ -1480,7 +1480,7 @@ exports[`ConnectedCreateBaselineModal should render correctly 1`] = `
                                         Object {
                                           "children": "Cancel",
                                           "onClick": [Function],
-                                          "variant": "secondary",
+                                          "variant": "link",
                                         }
                                       }
                                       consumerContext={null}
@@ -1493,12 +1493,12 @@ exports[`ConnectedCreateBaselineModal should render correctly 1`] = `
                                             "ouiaId": null,
                                           }
                                         }
-                                        variant="secondary"
+                                        variant="link"
                                       >
                                         <button
                                           aria-disabled={null}
                                           aria-label={null}
-                                          className="pf-c-button pf-m-secondary"
+                                          className="pf-c-button pf-m-link"
                                           disabled={false}
                                           onClick={[Function]}
                                           tabIndex={null}
@@ -1540,7 +1540,7 @@ exports[`CreateBaselineModal should render correctly 1`] = `
       </Unknown>,
       <Unknown
         onClick={[Function]}
-        variant="secondary"
+        variant="link"
       >
         Cancel
       </Unknown>,
@@ -1641,7 +1641,7 @@ exports[`CreateBaselineModal should render mount correctly 1`] = `
         </Unknown>,
         <Unknown
           onClick={[Function]}
-          variant="secondary"
+          variant="link"
         >
           Cancel
         </Unknown>,
@@ -1677,7 +1677,7 @@ exports[`CreateBaselineModal should render mount correctly 1`] = `
             </Unknown>,
             <Unknown
               onClick={[Function]}
-              variant="secondary"
+              variant="link"
             >
               Cancel
             </Unknown>,

--- a/src/SmartComponents/BaselinesPage/DeleteBaselinesModal/DeleteBaselinesModal.js
+++ b/src/SmartComponents/BaselinesPage/DeleteBaselinesModal/DeleteBaselinesModal.js
@@ -71,7 +71,7 @@ export class DeleteBaselinesModal extends Component {
                     </Button>,
                     <Button
                         key="cancel"
-                        variant="secondary"
+                        variant="link"
                         onClick={ this.toggleModal }
                     >
                     Cancel

--- a/src/SmartComponents/BaselinesPage/DeleteBaselinesModal/__tests__/__snapshots__/DeleteBaselinesModal.tests.js.snap
+++ b/src/SmartComponents/BaselinesPage/DeleteBaselinesModal/__tests__/__snapshots__/DeleteBaselinesModal.tests.js.snap
@@ -65,7 +65,7 @@ exports[`ConnectedDeleteBaselinesModal should render correctly 1`] = `
                 </Unknown>,
                 <Unknown
                   onClick={[Function]}
-                  variant="secondary"
+                  variant="link"
                 >
                   Cancel
                 </Unknown>,
@@ -132,7 +132,7 @@ exports[`ConnectedDeleteBaselinesModal should render correctly 1`] = `
                             Delete baselines
                           </button>
                           <button
-                            class="pf-c-button pf-m-secondary"
+                            class="pf-c-button pf-m-link"
                             type="button"
                           >
                             Cancel
@@ -199,7 +199,7 @@ exports[`ConnectedDeleteBaselinesModal should render correctly 1`] = `
                             Delete baselines
                           </button>
                           <button
-                            class="pf-c-button pf-m-secondary"
+                            class="pf-c-button pf-m-link"
                             type="button"
                           >
                             Cancel
@@ -240,7 +240,7 @@ exports[`ConnectedDeleteBaselinesModal should render correctly 1`] = `
                     </Unknown>,
                     <Unknown
                       onClick={[Function]}
-                      variant="secondary"
+                      variant="link"
                     >
                       Cancel
                     </Unknown>,
@@ -279,7 +279,7 @@ exports[`DeleteBaselinesModal should render Delete baseline with baselineId 1`] 
       </Unknown>,
       <Unknown
         onClick={[Function]}
-        variant="secondary"
+        variant="link"
       >
         Cancel
       </Unknown>,
@@ -313,7 +313,7 @@ exports[`DeleteBaselinesModal should render correctly 1`] = `
       </Unknown>,
       <Unknown
         onClick={[Function]}
-        variant="secondary"
+        variant="link"
       >
         Cancel
       </Unknown>,
@@ -354,7 +354,7 @@ exports[`DeleteBaselinesModal should render mount correctly 1`] = `
         </Unknown>,
         <Unknown
           onClick={[Function]}
-          variant="secondary"
+          variant="link"
         >
           Cancel
         </Unknown>,
@@ -421,7 +421,7 @@ exports[`DeleteBaselinesModal should render mount correctly 1`] = `
                     Delete baselines
                   </button>
                   <button
-                    class="pf-c-button pf-m-secondary"
+                    class="pf-c-button pf-m-link"
                     type="button"
                   >
                     Cancel
@@ -503,7 +503,7 @@ exports[`DeleteBaselinesModal should render mount correctly 1`] = `
                     Delete baselines
                   </button>
                   <button
-                    class="pf-c-button pf-m-secondary"
+                    class="pf-c-button pf-m-link"
                     type="button"
                   >
                     Cancel
@@ -526,7 +526,7 @@ exports[`DeleteBaselinesModal should render mount correctly 1`] = `
             </Unknown>,
             <Unknown
               onClick={[Function]}
-              variant="secondary"
+              variant="link"
             >
               Cancel
             </Unknown>,
@@ -734,7 +734,7 @@ exports[`DeleteBaselinesModal should render mount correctly 1`] = `
                         <Component
                           key="cancel"
                           onClick={[Function]}
-                          variant="secondary"
+                          variant="link"
                         >
                           <ComponentWithOuia
                             component={[Function]}
@@ -742,7 +742,7 @@ exports[`DeleteBaselinesModal should render mount correctly 1`] = `
                               Object {
                                 "children": "Cancel",
                                 "onClick": [Function],
-                                "variant": "secondary",
+                                "variant": "link",
                               }
                             }
                             consumerContext={null}
@@ -755,12 +755,12 @@ exports[`DeleteBaselinesModal should render mount correctly 1`] = `
                                   "ouiaId": null,
                                 }
                               }
-                              variant="secondary"
+                              variant="link"
                             >
                               <button
                                 aria-disabled={null}
                                 aria-label={null}
-                                className="pf-c-button pf-m-secondary"
+                                className="pf-c-button pf-m-link"
                                 disabled={false}
                                 onClick={[Function]}
                                 tabIndex={null}

--- a/src/SmartComponents/BaselinesPage/EditBaseline/DeleteFactModal/DeleteFactModal.js
+++ b/src/SmartComponents/BaselinesPage/EditBaseline/DeleteFactModal/DeleteFactModal.js
@@ -49,7 +49,7 @@ class DeleteFactModal extends Component {
                     </Button>,
                     <Button
                         key="cancel"
-                        variant="secondary"
+                        variant="link"
                         onClick={ this.props.toggleModal }
                     >
                     Cancel

--- a/src/SmartComponents/BaselinesPage/EditBaseline/EditBaselineNameModal/EditBaselineNameModal.js
+++ b/src/SmartComponents/BaselinesPage/EditBaseline/EditBaselineNameModal/EditBaselineNameModal.js
@@ -96,7 +96,7 @@ export class EditBaselineNameModal extends Component {
                     </Button>,
                     <Button
                         key="cancel"
-                        variant="secondary"
+                        variant="link"
                         onClick={ this.cancelModal }>
                         Cancel
                     </Button>

--- a/src/SmartComponents/BaselinesPage/EditBaseline/EditBaselineNameModal/__tests__/__snapshots__/EditBaselineNameModal.tests.js.snap
+++ b/src/SmartComponents/BaselinesPage/EditBaseline/EditBaselineNameModal/__tests__/__snapshots__/EditBaselineNameModal.tests.js.snap
@@ -12,7 +12,7 @@ exports[`EditBaselineNameModal should render correctly 1`] = `
       </Unknown>,
       <Unknown
         onClick={[Function]}
-        variant="secondary"
+        variant="link"
       >
         Cancel
       </Unknown>,
@@ -132,7 +132,7 @@ exports[`EditBaselineNameModal should render mount correctly 1`] = `
         </Unknown>,
         <Unknown
           onClick={[Function]}
-          variant="secondary"
+          variant="link"
         >
           Cancel
         </Unknown>,
@@ -235,7 +235,7 @@ exports[`EditBaselineNameModal should render mount correctly 1`] = `
                     Save
                   </button>
                   <button
-                    class="pf-c-button pf-m-secondary"
+                    class="pf-c-button pf-m-link"
                     type="button"
                   >
                     Cancel
@@ -353,7 +353,7 @@ exports[`EditBaselineNameModal should render mount correctly 1`] = `
                     Save
                   </button>
                   <button
-                    class="pf-c-button pf-m-secondary"
+                    class="pf-c-button pf-m-link"
                     type="button"
                   >
                     Cancel
@@ -376,7 +376,7 @@ exports[`EditBaselineNameModal should render mount correctly 1`] = `
             </Unknown>,
             <Unknown
               onClick={[Function]}
-              variant="secondary"
+              variant="link"
             >
               Cancel
             </Unknown>,
@@ -657,7 +657,7 @@ exports[`EditBaselineNameModal should render mount correctly 1`] = `
                         <Component
                           key="cancel"
                           onClick={[Function]}
-                          variant="secondary"
+                          variant="link"
                         >
                           <ComponentWithOuia
                             component={[Function]}
@@ -665,7 +665,7 @@ exports[`EditBaselineNameModal should render mount correctly 1`] = `
                               Object {
                                 "children": "Cancel",
                                 "onClick": [Function],
-                                "variant": "secondary",
+                                "variant": "link",
                               }
                             }
                             consumerContext={null}
@@ -678,12 +678,12 @@ exports[`EditBaselineNameModal should render mount correctly 1`] = `
                                   "ouiaId": null,
                                 }
                               }
-                              variant="secondary"
+                              variant="link"
                             >
                               <button
                                 aria-disabled={null}
                                 aria-label={null}
-                                className="pf-c-button pf-m-secondary"
+                                className="pf-c-button pf-m-link"
                                 disabled={false}
                                 onClick={[Function]}
                                 tabIndex={null}

--- a/src/SmartComponents/BaselinesPage/EditBaseline/FactModal/FactModal.js
+++ b/src/SmartComponents/BaselinesPage/EditBaseline/FactModal/FactModal.js
@@ -219,7 +219,7 @@ class FactModal extends Component {
                     </Button>,
                     <Button
                         key="cancel"
-                        variant="secondary"
+                        variant="link"
                         onClick={ this.cancelFact }>
                         Cancel
                     </Button>

--- a/src/SmartComponents/BaselinesPage/EditBaseline/__tests__/__snapshots__/EditBaseline.tests.js.snap
+++ b/src/SmartComponents/BaselinesPage/EditBaseline/__tests__/__snapshots__/EditBaseline.tests.js.snap
@@ -270,7 +270,7 @@ exports[`ConnectedEditBaseline should render correctly 1`] = `
                       </Unknown>,
                       <Unknown
                         onClick={[Function]}
-                        variant="secondary"
+                        variant="link"
                       >
                         Cancel
                       </Unknown>,
@@ -306,7 +306,7 @@ exports[`ConnectedEditBaseline should render correctly 1`] = `
                           </Unknown>,
                           <Unknown
                             onClick={[Function]}
-                            variant="secondary"
+                            variant="link"
                           >
                             Cancel
                           </Unknown>,

--- a/src/SmartComponents/BaselinesPage/__tests__/__snapshots__/BaselinesPage.tests.js.snap
+++ b/src/SmartComponents/BaselinesPage/__tests__/__snapshots__/BaselinesPage.tests.js.snap
@@ -365,7 +365,7 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                         </Unknown>,
                         <Unknown
                           onClick={[Function]}
-                          variant="secondary"
+                          variant="link"
                         >
                           Cancel
                         </Unknown>,
@@ -401,7 +401,7 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                             </Unknown>,
                             <Unknown
                               onClick={[Function]}
-                              variant="secondary"
+                              variant="link"
                             >
                               Cancel
                             </Unknown>,
@@ -3684,7 +3684,7 @@ exports[`ConnectedBaselinesPage should render empty state 1`] = `
                         </Unknown>,
                         <Unknown
                           onClick={[Function]}
-                          variant="secondary"
+                          variant="link"
                         >
                           Cancel
                         </Unknown>,
@@ -3721,7 +3721,7 @@ exports[`ConnectedBaselinesPage should render empty state 1`] = `
                             </Unknown>,
                             <Unknown
                               onClick={[Function]}
-                              variant="secondary"
+                              variant="link"
                             >
                               Cancel
                             </Unknown>,

--- a/src/SmartComponents/DriftPage/DriftFilterChips/DriftFilterChips.js
+++ b/src/SmartComponents/DriftPage/DriftFilterChips/DriftFilterChips.js
@@ -12,7 +12,7 @@ export class DriftFilterChips extends Component {
         this.state = {
             chipGroup: [
                 { category: 'State', chips: this.setStateChips(this.props.stateFilters) },
-                { category: 'Name', chips:
+                { category: 'Fact name', chips:
                     this.props.factFilter !== ''
                         ? [ this.props.factFilter ]
                         : []
@@ -43,7 +43,7 @@ export class DriftFilterChips extends Component {
         }
 
         if (factFilter !== prevProps.factFilter) {
-            newFactFilter = { category: 'Name', chips:
+            newFactFilter = { category: 'Fact name', chips:
                 factFilter !== ''
                     ? [ factFilter ]
                     : []

--- a/src/SmartComponents/DriftPage/DriftFilterChips/__tests__/__snapshots__/DriftFilterChips.tests.js.snap
+++ b/src/SmartComponents/DriftPage/DriftFilterChips/__tests__/__snapshots__/DriftFilterChips.tests.js.snap
@@ -517,8 +517,8 @@ exports[`ConnectedDriftFilterChips should render all states true 1`] = `
             </GenerateId>
           </ChipGroupToolbarItem>
           <ChipGroupToolbarItem
-            categoryName="Name"
-            key=".$Name"
+            categoryName="Fact name"
+            key=".$Fact name"
           >
             <GenerateId
               prefix="pf-random-id-"
@@ -531,14 +531,14 @@ exports[`ConnectedDriftFilterChips should render all states true 1`] = `
                     className="pf-c-chip-group__label"
                     id="pf-random-id-4"
                   >
-                    Name
+                    Fact name
                   </h4>
                   <ul
                     className="pf-c-chip-group"
                   >
                     <Component
                       component="li"
-                      key=".$Name3"
+                      key=".$Fact name3"
                       onClick={[Function]}
                     >
                       <ComponentWithOuia
@@ -736,8 +736,8 @@ exports[`ConnectedDriftFilterChips should render correctly 1`] = `
             key=".$State"
           />
           <ChipGroupToolbarItem
-            categoryName="Name"
-            key=".$Name"
+            categoryName="Fact name"
+            key=".$Fact name"
           />
         </InnerChipGroup>
       </ChipGroup>
@@ -760,8 +760,8 @@ exports[`DriftFilterChips should render correctly 1`] = `
     key="State"
   />
   <ChipGroupToolbarItem
-    categoryName="Name"
-    key="Name"
+    categoryName="Fact name"
+    key="Fact name"
   />
 </ChipGroup>
 `;

--- a/src/SmartComponents/DriftPage/__tests__/__snapshots__/DriftPage.tests.js.snap
+++ b/src/SmartComponents/DriftPage/__tests__/__snapshots__/DriftPage.tests.js.snap
@@ -2666,8 +2666,8 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
                                                   </GenerateId>
                                                 </ChipGroupToolbarItem>
                                                 <ChipGroupToolbarItem
-                                                  categoryName="Name"
-                                                  key=".$Name"
+                                                  categoryName="Fact name"
+                                                  key=".$Fact name"
                                                 >
                                                   <GenerateId
                                                     prefix="pf-random-id-"
@@ -2680,14 +2680,14 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
                                                           className="pf-c-chip-group__label"
                                                           id="pf-random-id-4"
                                                         >
-                                                          Name
+                                                          Fact name
                                                         </h4>
                                                         <ul
                                                           className="pf-c-chip-group"
                                                         >
                                                           <Component
                                                             component="li"
-                                                            key=".$Name3"
+                                                            key=".$Fact name3"
                                                             onClick={[Function]}
                                                           >
                                                             <ComponentWithOuia
@@ -6995,8 +6995,8 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                                   </GenerateId>
                                                 </ChipGroupToolbarItem>
                                                 <ChipGroupToolbarItem
-                                                  categoryName="Name"
-                                                  key=".$Name"
+                                                  categoryName="Fact name"
+                                                  key=".$Fact name"
                                                 >
                                                   <GenerateId
                                                     prefix="pf-random-id-"
@@ -7009,14 +7009,14 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                                           className="pf-c-chip-group__label"
                                                           id="pf-random-id-10"
                                                         >
-                                                          Name
+                                                          Fact name
                                                         </h4>
                                                         <ul
                                                           className="pf-c-chip-group"
                                                         >
                                                           <Component
                                                             component="li"
-                                                            key=".$Name3"
+                                                            key=".$Fact name3"
                                                             onClick={[Function]}
                                                           >
                                                             <ComponentWithOuia


### PR DESCRIPTION
Fixes:
- Cancel button style in modals needs to be updated to be "link" style
- Rename filter for fact name to 'Fact name'