### PR TITLE
Fix regression with fact name in drift filter chips

### DIFF
--- a/src/SmartComponents/DriftPage/DriftFilterChips/DriftFilterChips.js
+++ b/src/SmartComponents/DriftPage/DriftFilterChips/DriftFilterChips.js
@@ -42,7 +42,7 @@ export class DriftFilterChips extends Component {
             }
 
             if (factFilter !== prevProps.factFilter) {
-                newFactChips = { category: 'Name', chips:
+                newFactChips = { category: 'Fact name', chips:
                     factFilter !== ''
                         ? [ factFilter ]
                         : []


### PR DESCRIPTION
When you apply a fact name filter on comparison table, the filter chips should show 'Fact name' instead of simply 'Name'. This fix was previously applied, but there was a regression. This PR fixes that regression.