### PR TITLE
Pass react redux to inventory loader as well

### DIFF
--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import * as reactRouterDom from 'react-router-dom';
+import * as ReactRedux from 'react-redux';
 import PropTypes from 'prop-types';
 import * as reactCore from '@patternfly/react-core';
 import * as reactIcons from '@patternfly/react-icons';
@@ -28,6 +29,7 @@ class SystemsTable extends Component {
 
     async fetchInventory() {
         const { inventoryConnector, mergeWithEntities, INVENTORY_ACTION_TYPES } = await insights.loadInventory({
+            ReactRedux,
             react: React,
             reactRouterDom,
             reactCore,


### PR DESCRIPTION
We are working on inventory refactoring, since we'd like to fully use hooks and such we have to use App's react dependency. With this being used react-redux needs to be passed from application as well. If you are cautious about the size of your bundle I can pick only the functions really required by inventory.