### PR TITLE
Modernize inventory component by using function component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12485,6 +12485,7 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }
@@ -19254,11 +19255,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.11.0.tgz",
       "integrity": "sha512-gbBVYR2p8mnriqAwWx9LbuUrShnAuSCNnuPGyc7GJrMVQtPDAh8iLpv7FRuMPFb56KkaVZIYSz1PrjI9q0QPCw=="
     },
-    "react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-    },
     "react-popper": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.3.tgz",
@@ -19279,25 +19275,31 @@
       }
     },
     "react-redux": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.2.tgz",
-      "integrity": "sha512-Ns1G0XXc8hDyH/OcBHOxNgQx9ayH3SPxBnFCOidGKSle8pKihysQw2rG/PmciUQRoclhVBO8HMhiRmGXnDja9Q==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.0.tgz",
+      "integrity": "sha512-EvCAZYGfOLqwV7gh849xy9/pt55rJXPwmYvI4lilPM5rUT/1NxuuN59ipdBksRVSvz0KInbPnp4IfoXJXCqiDA==",
       "requires": {
-        "@babel/runtime": "^7.1.2",
+        "@babel/runtime": "^7.5.5",
         "hoist-non-react-statics": "^3.3.0",
-        "invariant": "^2.2.4",
-        "loose-envify": "^1.1.0",
-        "prop-types": "^15.6.1",
-        "react-is": "^16.6.0",
-        "react-lifecycles-compat": "^3.0.0"
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.9.0"
       },
       "dependencies": {
         "hoist-non-react-statics": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
-          "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+          "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
           "requires": {
             "react-is": "^16.7.0"
+          }
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "react": "16.11.0",
     "react-cookie": "^4.0.3",
     "react-dom": "16.9.0",
-    "react-redux": "^5.1.2",
+    "react-redux": "^7.2.0",
     "react-router-dom": "^5.1.2",
     "redux": "^4.0.5",
     "redux-logger": "^3.0.6"

--- a/src/SmartComponents/AddSystemModal/__tests__/__snapshots__/AddSystemModal.tests.js.snap
+++ b/src/SmartComponents/AddSystemModal/__tests__/__snapshots__/AddSystemModal.tests.js.snap
@@ -9488,9 +9488,21 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                             role="tabpanel"
                             tabindex="0"
                           >
-                            <div>
-                              Loading...
-                            </div>
+                            <span
+                              aria-valuetext="Loading..."
+                              class="pf-c-spinner pf-m-lg"
+                              role="progressbar"
+                            >
+                              <span
+                                class="pf-c-spinner__clipper"
+                              />
+                              <span
+                                class="pf-c-spinner__lead-ball"
+                              />
+                              <span
+                                class="pf-c-spinner__tail-ball"
+                              />
+                            </span>
                           </section>
                           <section
                             aria-labelledby="pf-tab-1-baselines-tab"
@@ -10328,9 +10340,21 @@ Try changing your filter settings.
                             role="tabpanel"
                             tabindex="0"
                           >
-                            <div>
-                              Loading...
-                            </div>
+                            <span
+                              aria-valuetext="Loading..."
+                              class="pf-c-spinner pf-m-lg"
+                              role="progressbar"
+                            >
+                              <span
+                                class="pf-c-spinner__clipper"
+                              />
+                              <span
+                                class="pf-c-spinner__lead-ball"
+                              />
+                              <span
+                                class="pf-c-spinner__tail-ball"
+                              />
+                            </span>
                           </section>
                           <section
                             aria-labelledby="pf-tab-1-baselines-tab"
@@ -11167,9 +11191,21 @@ Try changing your filter settings.
                             role="tabpanel"
                             tabindex="0"
                           >
-                            <div>
-                              Loading...
-                            </div>
+                            <span
+                              aria-valuetext="Loading..."
+                              class="pf-c-spinner pf-m-lg"
+                              role="progressbar"
+                            >
+                              <span
+                                class="pf-c-spinner__clipper"
+                              />
+                              <span
+                                class="pf-c-spinner__lead-ball"
+                              />
+                              <span
+                                class="pf-c-spinner__tail-ball"
+                              />
+                            </span>
                           </section>
                           <section
                             aria-labelledby="pf-tab-1-baselines-tab"
@@ -12022,9 +12058,21 @@ Try changing your filter settings.
                             role="tabpanel"
                             tabindex="0"
                           >
-                            <div>
-                              Loading...
-                            </div>
+                            <span
+                              aria-valuetext="Loading..."
+                              class="pf-c-spinner pf-m-lg"
+                              role="progressbar"
+                            >
+                              <span
+                                class="pf-c-spinner__clipper"
+                              />
+                              <span
+                                class="pf-c-spinner__lead-ball"
+                              />
+                              <span
+                                class="pf-c-spinner__tail-ball"
+                              />
+                            </span>
                           </section>
                           <section
                             aria-labelledby="pf-tab-1-baselines-tab"
@@ -13014,7 +13062,7 @@ Try changing your filter settings.
                                         id="systems-tab"
                                         title="Systems"
                                       >
-                                        <Connect(SystemsTable)
+                                        <Memo(Connect(SystemsTable))
                                           hasHistoricalDropdown={true}
                                           historicalProfiles={Array []}
                                           selectedSystemIds={
@@ -13037,7 +13085,7 @@ Try changing your filter settings.
                                           id="systems-tab"
                                           title="Systems"
                                         >
-                                          <Connect(SystemsTable)
+                                          <Memo(Connect(SystemsTable))
                                             hasHistoricalDropdown={true}
                                             historicalProfiles={Array []}
                                             selectedSystemIds={
@@ -13082,11 +13130,25 @@ Try changing your filter settings.
                                             }
                                             setSelectedSystemIds={[Function]}
                                           >
-                                            <InventoryCmp>
-                                              <div>
-                                                Loading...
-                                              </div>
-                                            </InventoryCmp>
+                                            <Spinner
+                                              size="lg"
+                                            >
+                                              <span
+                                                aria-valuetext="Loading..."
+                                                className="pf-c-spinner pf-m-lg"
+                                                role="progressbar"
+                                              >
+                                                <span
+                                                  className="pf-c-spinner__clipper"
+                                                />
+                                                <span
+                                                  className="pf-c-spinner__lead-ball"
+                                                />
+                                                <span
+                                                  className="pf-c-spinner__tail-ball"
+                                                />
+                                              </span>
+                                            </Spinner>
                                           </SystemsTable>
                                         </Connect(SystemsTable)>
                                       </section>
@@ -13100,7 +13162,7 @@ Try changing your filter settings.
                                         id="baselines-tab"
                                         title="Baselines"
                                       >
-                                        <Connect(BaselinesTable)
+                                        <Memo(Connect(BaselinesTable))
                                           columns={
                                             Array [
                                               Object {
@@ -13139,7 +13201,7 @@ Try changing your filter settings.
                                           id="baselines-tab"
                                           title="Baselines"
                                         >
-                                          <Connect(BaselinesTable)
+                                          <Memo(Connect(BaselinesTable))
                                             columns={
                                               Array [
                                                 Object {
@@ -16959,9 +17021,21 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                             role="tabpanel"
                             tabindex="0"
                           >
-                            <div>
-                              Loading...
-                            </div>
+                            <span
+                              aria-valuetext="Loading..."
+                              class="pf-c-spinner pf-m-lg"
+                              role="progressbar"
+                            >
+                              <span
+                                class="pf-c-spinner__clipper"
+                              />
+                              <span
+                                class="pf-c-spinner__lead-ball"
+                              />
+                              <span
+                                class="pf-c-spinner__tail-ball"
+                              />
+                            </span>
                           </section>
                           <section
                             aria-labelledby="pf-tab-1-baselines-tab"
@@ -17814,9 +17888,21 @@ Try changing your filter settings.
                             role="tabpanel"
                             tabindex="0"
                           >
-                            <div>
-                              Loading...
-                            </div>
+                            <span
+                              aria-valuetext="Loading..."
+                              class="pf-c-spinner pf-m-lg"
+                              role="progressbar"
+                            >
+                              <span
+                                class="pf-c-spinner__clipper"
+                              />
+                              <span
+                                class="pf-c-spinner__lead-ball"
+                              />
+                              <span
+                                class="pf-c-spinner__tail-ball"
+                              />
+                            </span>
                           </section>
                           <section
                             aria-labelledby="pf-tab-1-baselines-tab"
@@ -18807,7 +18893,7 @@ Try changing your filter settings.
                                         id="systems-tab"
                                         title="Systems"
                                       >
-                                        <Connect(SystemsTable)
+                                        <Memo(Connect(SystemsTable))
                                           hasHistoricalDropdown={true}
                                           historicalProfiles={Array []}
                                           selectedSystemIds={
@@ -18830,7 +18916,7 @@ Try changing your filter settings.
                                           id="systems-tab"
                                           title="Systems"
                                         >
-                                          <Connect(SystemsTable)
+                                          <Memo(Connect(SystemsTable))
                                             hasHistoricalDropdown={true}
                                             historicalProfiles={Array []}
                                             selectedSystemIds={
@@ -18875,11 +18961,25 @@ Try changing your filter settings.
                                             }
                                             setSelectedSystemIds={[Function]}
                                           >
-                                            <InventoryCmp>
-                                              <div>
-                                                Loading...
-                                              </div>
-                                            </InventoryCmp>
+                                            <Spinner
+                                              size="lg"
+                                            >
+                                              <span
+                                                aria-valuetext="Loading..."
+                                                className="pf-c-spinner pf-m-lg"
+                                                role="progressbar"
+                                              >
+                                                <span
+                                                  className="pf-c-spinner__clipper"
+                                                />
+                                                <span
+                                                  className="pf-c-spinner__lead-ball"
+                                                />
+                                                <span
+                                                  className="pf-c-spinner__tail-ball"
+                                                />
+                                              </span>
+                                            </Spinner>
                                           </SystemsTable>
                                         </Connect(SystemsTable)>
                                       </section>
@@ -18893,7 +18993,7 @@ Try changing your filter settings.
                                         id="baselines-tab"
                                         title="Baselines"
                                       >
-                                        <Connect(BaselinesTable)
+                                        <Memo(Connect(BaselinesTable))
                                           columns={
                                             Array [
                                               Object {
@@ -18932,7 +19032,7 @@ Try changing your filter settings.
                                           id="baselines-tab"
                                           title="Baselines"
                                         >
-                                          <Connect(BaselinesTable)
+                                          <Memo(Connect(BaselinesTable))
                                             columns={
                                               Array [
                                                 Object {

--- a/src/SmartComponents/BaselinesPage/EditBaseline/__tests__/__snapshots__/EditBaseline.tests.js.snap
+++ b/src/SmartComponents/BaselinesPage/EditBaseline/__tests__/__snapshots__/EditBaseline.tests.js.snap
@@ -1216,7 +1216,7 @@ exports[`ConnectedEditBaseline should render correctly 1`] = `
                                 colSpan="3"
                               >
                                 <EmptyStateDisplay
-                                  button={<Connect(AddFactButton) />}
+                                  button={<Memo(Connect(AddFactButton)) />}
                                   text={
                                     Array [
                                       "No facts or categories have been added to this baseline yet.",
@@ -2707,7 +2707,7 @@ exports[`EditBaseline should render correctly 1`] = `
               colSpan="3"
             >
               <EmptyStateDisplay
-                button={<Connect(AddFactButton) />}
+                button={<Memo(Connect(AddFactButton)) />}
                 text={
                   Array [
                     "No facts or categories have been added to this baseline yet.",

--- a/src/SmartComponents/DriftPage/DriftTable/__tests__/__snapshots__/DriftTable.tests.js.snap
+++ b/src/SmartComponents/DriftPage/DriftTable/__tests__/__snapshots__/DriftTable.tests.js.snap
@@ -287,7 +287,7 @@ exports[`ConnectedDriftTable should render correctly 1`] = `
             </Connect(AddSystemModal)>
             <EmptyStateDisplay
               button={
-                <Connect(AddSystemButton)
+                <Memo(Connect(AddSystemButton))
                   isTable={false}
                 />
               }


### PR DESCRIPTION
New inventory component heavily relies on hooks including hooks from react-redux to make the component more performant. Drift was using older version of react-redux so I've updated it to newest version (there are no breaking changes) and inventory is now working again.

@ehelms I've also included the showTags prop since we are messing in the same file as #331
