### PR TITLE
Pass pf react core to inventory to properly render inventory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1872,9 +1872,9 @@
       }
     },
     "@redhat-cloud-services/frontend-components-utilities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-2.1.0.tgz",
-      "integrity": "sha512-CeEaT/LA9icJDEZZBfodTOwg7jsLpzivL0htCUJBw5YCsCMLQ141FDOQaSgFAv7R5ZTo+bqlo0RpvkC9G2Bl0w==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-2.1.2.tgz",
+      "integrity": "sha512-4q2CoR45ZODAn/bSaHiW7I8fKCRTRBNXHAsoimzkkQDRl7GJOjIlCuzvYpjX9gJitiQyolm7kzyksLS6KNAEkg==",
       "requires": {
         "@sentry/browser": "^5.4.0",
         "awesome-debounce-promise": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@patternfly/react-icons": "^4.5.0",
     "@patternfly/react-table": "^4.12.1",
     "@redhat-cloud-services/frontend-components": "2.1.1",
-    "@redhat-cloud-services/frontend-components-utilities": "2.1.0",
+    "@redhat-cloud-services/frontend-components-utilities": "2.1.2",
     "axios": "^0.18.1",
     "classnames": "^2.2.6",
     "jiff": "^0.7.3",

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -2,8 +2,8 @@ import React, { Fragment, useState, useEffect } from 'react';
 import * as reactRouterDom from 'react-router-dom';
 import * as ReactRedux from 'react-redux';
 import PropTypes from 'prop-types';
-import * as reactCore from '@patternfly/react-core';
 import * as reactIcons from '@patternfly/react-icons';
+import * as reactCore from '@patternfly/react-core';
 import { getRegistry } from '@redhat-cloud-services/frontend-components-utilities/files/Registry';
 import { connect } from 'react-redux';
 import * as pfReactTable from '@patternfly/react-table';
@@ -28,7 +28,8 @@ const SystemsTable = ({
             reactRouterDom,
             reactCore,
             reactIcons,
-            pfReactTable
+            pfReactTable,
+            pfReact: reactCore
         });
 
         driftClearFilters();


### PR DESCRIPTION
There is a new feature brewing in chrome, building chrome with webpack [1]. This PR passes newly required dependencies. In future we'll use Federated modules [2] so there won't be a need for these changes, but this is required as a mid-step solution.

[1] https://github.com/RedHatInsights/insights-chrome/pull/842
[2] https://webpack.js.org/concepts/module-federation/