### PR TITLE
Remove expanded rows in redux on clear comparison

### DIFF
--- a/src/SmartComponents/modules/__tests__/reducer-test.js
+++ b/src/SmartComponents/modules/__tests__/reducer-test.js
@@ -53,7 +53,8 @@ describe('compare reducer', () => {
                     { filter: 'DIFFERENT', display: 'Different', selected: true },
                     { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: false }
                 ],
-                factFilter: 'dog' }, {
+                factFilter: 'dog',
+                expandedRows: [ 'something', 'something-else' ]}, {
                 type: `${types.CLEAR_COMPARISON}` })
         ).toEqual({
             baselines: [],

--- a/src/SmartComponents/modules/reducers.js
+++ b/src/SmartComponents/modules/reducers.js
@@ -58,7 +58,8 @@ export function compareReducer(state = initialState, action) {
                 factFilter: state.factFilter,
                 factSort: state.factSort,
                 stateSort: state.stateSort,
-                perPage: state.perPage
+                perPage: state.perPage,
+                expandedRows: []
             };
         case types.CLEAR_COMPARISON_FILTERS:
             newStateFilters = [ ...state.stateFilters ];


### PR DESCRIPTION
Steps to reproduce:
1. Add several systems to the comparisons
2. Expand some/all subfacts
3. Click on "Clear all comparisons" button
4. Add new systems
5. Any subfacts previously expanded, remain expanded

On fix, step 5 all subfact will be collapsed