### PR TITLE
Fixes Empty system names in create baseline modal

### DIFF
--- a/src/SmartComponents/BaselinesPage/CreateBaselineModal/CreateBaselineModal.js
+++ b/src/SmartComponents/BaselinesPage/CreateBaselineModal/CreateBaselineModal.js
@@ -150,6 +150,8 @@ export class CreateBaselineModal extends Component {
     }
 
     renderCopySystem() {
+        const { historicalProfiles } = this.props;
+
         return (<React.Fragment>
             <b>Select system to copy from</b>
             <SystemsTable
@@ -157,7 +159,7 @@ export class CreateBaselineModal extends Component {
                 createBaselineModal={ true }
                 hasHistoricalDropdown={ true }
                 hasMultiSelect={ false }
-                historicalProfiles={ this.props.historicalProfiles }
+                historicalProfiles={ historicalProfiles }
             />
         </React.Fragment>
         );

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -99,7 +99,8 @@ SystemsTable.propTypes = {
     hasHistoricalDropdown: PropTypes.bool,
     historicalProfiles: PropTypes.array,
     hasMultiSelect: PropTypes.bool,
-    updateColumns: PropTypes.func
+    updateColumns: PropTypes.func,
+    selectedHSPIds: PropTypes.array
 };
 
 SystemsTable.defaultProps = {

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -64,13 +64,17 @@ function selectedReducer(
             }
 
             /* Hide link on systems table */
-            newColumns.forEach(function(column) {
+            newColumns.forEach(function(column, index) {
                 if (!column.props) {
                     column.props = {};
                 }
 
-                if (column.key === 'display_name') {
+                if (column.key === 'display_name' || column.key === 'display_selected_hsp') {
                     column.props.width = 20;
+                    if (newColumns.find(({ key }) => key === 'display_selected_hsp')) {
+                        let displaySelectedHSP = newColumns.splice(newColumns.findIndex(({ key }) => key === 'display_selected_hsp'), 1);
+                        newColumns.splice(index, 1, displaySelectedHSP[0]);
+                    }
                 } else {
                     column.props.width = 10;
                 }
@@ -83,7 +87,9 @@ function selectedReducer(
             return {
                 ...state,
                 columns: newColumns,
-                rows
+                rows: state.selectedHSP
+                    ? helpers.buildSystemsTableWithSelectedHSP(rows, state.selectedHSP, deselectHistoricalProfiles)
+                    : rows
             };
         },
         [types.UPDATE_COLUMNS]: (state, action) => {
@@ -165,7 +171,8 @@ function selectedReducer(
                 ...state,
                 rows: helpers.buildSystemsTableWithSelectedHSP([ ...state.rows ], action.payload, deselectHistoricalProfiles),
                 columns: newColumns,
-                selectedSystemIds: []
+                selectedSystemIds: [],
+                selectedHSP: action.payload
             };
         }
     });


### PR DESCRIPTION
Steps to reproduce:
1. Baselines -> Create baseline -> Copy an existing system
2. Find a system with hsps and select an hsp, but don't create the baseline
3. Select Copy an existing baseline
4. Select Copy an existing system. The name column is blank for all systems.