### PR TITLE
Fix no empty state when viewing baseline

### DIFF
--- a/src/SmartComponents/BaselinesPage/EditBaseline/redux/reducers.js
+++ b/src/SmartComponents/BaselinesPage/EditBaseline/redux/reducers.js
@@ -172,7 +172,6 @@ export function editBaselineReducer(state = initialState, action) {
                 ...state,
                 editBaselineError: {},
                 inlineError: {},
-                editBaselineEmptyState: false,
                 baselineDataLoading: false
             };
         case `${types.EXPORT_BASELINE_DATA_TO_CSV}`:


### PR DESCRIPTION
To reproduce:
1. View a baseline with no facts (empty baseline)
2. Attempt to edit the baseline name, but simply cancel the edit
3. You shouldn't see the empty state for the baseline, but instead an empty table