### PR TITLE
Fix copy existing system modal from disappearing

### DIFF
--- a/src/SmartComponents/BaselinesPage/CreateBaselineModal/CreateBaselineModal.js
+++ b/src/SmartComponents/BaselinesPage/CreateBaselineModal/CreateBaselineModal.js
@@ -10,8 +10,6 @@ import BaselinesTable from '../../BaselinesTable/BaselinesTable';
 import { createBaselineModalActions } from './redux';
 import { baselinesTableActions } from '../../BaselinesTable/redux';
 
-import _ from 'lodash';
-
 export class CreateBaselineModal extends Component {
     constructor(props) {
         super(props);
@@ -218,11 +216,12 @@ export class CreateBaselineModal extends Component {
         const { selectedBaselineIds, selectedHSPIds, entities } = this.props;
         const { baselineName, copyBaselineChecked, copySystemChecked } = this.state;
         let actions;
+        let selectedSystemIds = entities === undefined || entities.selectedSystemIds === undefined ? [] : entities.selectedSystemIds;
 
         if (baselineName === ''
             || (copyBaselineChecked && selectedBaselineIds.length === 0)
             || (copySystemChecked &&
-                ((_.isEmpty(entities.selectedSystemIds)) && (selectedHSPIds.length === 0))
+                (selectedSystemIds.length === 0 && selectedHSPIds.length === 0)
             )
         ) {
             actions = [


### PR DESCRIPTION
Steps to reproduce:
- Navigate to Baselines
- Click Create baseline
- Select Copy an existing baseline
- Enter baseline name
- Select Copy an existing system
- The modal disappears, an empty page is displayed..