### PR TITLE
Fix disabled create baseline button if there are no existing baselines

### DIFF
--- a/src/SmartComponents/BaselinesPage/BaselinesPage.js
+++ b/src/SmartComponents/BaselinesPage/BaselinesPage.js
@@ -107,8 +107,8 @@ export class BaselinesPage extends Component {
         );
     }
 
-    renderEmptyState = () => {
-        const { baselineError, revertBaselineFetch } = this.props;
+    renderEmptyState = (hasBaselinesWritePermissions) => {
+        const { baselineError, emptyState, loading, revertBaselineFetch } = this.props;
         const { emptyStateMessage, errorMessage } = this.state;
 
         if (!baselineError.status) {
@@ -116,7 +116,11 @@ export class BaselinesPage extends Component {
                 icon={ AddCircleOIcon }
                 title={ 'No baselines' }
                 text={ emptyStateMessage }
-                button={ <CreateBaselineButton /> }
+                button={ <CreateBaselineButton
+                    emptyState={ emptyState }
+                    hasWritePermissions={ hasBaselinesWritePermissions }
+                    loading={ loading } />
+                }
             />;
         } else if (baselineError.status !== 200 && baselineError.status !== undefined) {
             return <EmptyStateDisplay
@@ -161,7 +165,7 @@ export class BaselinesPage extends Component {
                                     text={ [ 'Contact your organization administrator(s) for more information.' ] }
                                 />
                                 : emptyState && !loading
-                                    ? this.renderEmptyState()
+                                    ? this.renderEmptyState(value.permissions.baselinesWrite)
                                     : <React.Fragment>
                                         <ErrorAlert
                                             error={ !emptyState && baselineError ? baselineError : {} }

--- a/src/SmartComponents/BaselinesPage/CreateBaselineButton/CreateBaselineButton.js
+++ b/src/SmartComponents/BaselinesPage/CreateBaselineButton/CreateBaselineButton.js
@@ -27,7 +27,8 @@ export class CreateBaselineButton extends Component {
     }
 
     render() {
-        const { hasWritePermissions, loading } = this.props;
+        const { emptyState, hasWritePermissions, loading } = this.props;
+
         return (
             <React.Fragment>
                 { !hasWritePermissions && hasWritePermissions !== undefined
@@ -36,7 +37,7 @@ export class CreateBaselineButton extends Component {
                             <div>You do not have permissions to perform this action</div>
                         }
                     >
-                        <div>
+                        <div className={ emptyState ? 'tooltip-button-margin' : null }>
                             <Button
                                 id='create-baseline-button'
                                 variant='primary'
@@ -50,7 +51,7 @@ export class CreateBaselineButton extends Component {
                         id='create-baseline-button'
                         variant='primary'
                         onClick={ this.createBaseline }
-                        isDisabled={ loading || !hasWritePermissions }>
+                        isDisabled={ loading }>
                         Create baseline
                     </Button>
                 }
@@ -65,7 +66,8 @@ CreateBaselineButton.propTypes = {
     history: PropTypes.object,
     addSystemModalOpened: PropTypes.bool,
     loading: PropTypes.bool,
-    hasWritePermissions: PropTypes.bool
+    hasWritePermissions: PropTypes.bool,
+    emptyState: PropTypes.bool
 };
 
 function mapStateToProps(state) {

--- a/src/SmartComponents/BaselinesPage/CreateBaselineButton/__tests__/CreateBaselineButton.tests.js
+++ b/src/SmartComponents/BaselinesPage/CreateBaselineButton/__tests__/CreateBaselineButton.tests.js
@@ -13,7 +13,8 @@ describe('CreateBaselineButton', () => {
     beforeEach(() => {
         props = {
             addSystemModalOpened: false,
-            hasWritePermissions: true
+            hasWritePermissions: true,
+            loading: false
         };
     });
 

--- a/src/SmartComponents/BaselinesPage/CreateBaselineButton/__tests__/__snapshots__/CreateBaselineButton.tests.js.snap
+++ b/src/SmartComponents/BaselinesPage/CreateBaselineButton/__tests__/__snapshots__/CreateBaselineButton.tests.js.snap
@@ -154,7 +154,6 @@ exports[`ConnectedCreateBaselineButton should render correctly 1`] = `
           >
             <Button
               id="create-baseline-button"
-              isDisabled={false}
               onClick={[Function]}
               variant="primary"
             >
@@ -198,6 +197,7 @@ exports[`CreateBaselineButton should render mount correctly 1`] = `
 <CreateBaselineButton
   addSystemModalOpened={false}
   hasWritePermissions={true}
+  loading={false}
 >
   <Button
     id="create-baseline-button"

--- a/src/SmartComponents/BaselinesPage/__tests__/__snapshots__/BaselinesPage.tests.js.snap
+++ b/src/SmartComponents/BaselinesPage/__tests__/__snapshots__/BaselinesPage.tests.js.snap
@@ -5291,7 +5291,13 @@ exports[`ConnectedBaselinesPage should render empty state 1`] = `
                   page-type=""
                 >
                   <EmptyStateDisplay
-                    button={<withRouter(Connect(CreateBaselineButton)) />}
+                    button={
+                      <withRouter(Connect(CreateBaselineButton))
+                        emptyState={true}
+                        hasWritePermissions={true}
+                        loading={false}
+                      />
+                    }
                     icon={[Function]}
                     text={
                       Array [
@@ -5363,8 +5369,14 @@ exports[`ConnectedBaselinesPage should render empty state 1`] = `
 Create a baseline to use in your Comparison analysis.
                             </div>
                           </EmptyStateBody>
-                          <withRouter(Connect(CreateBaselineButton))>
+                          <withRouter(Connect(CreateBaselineButton))
+                            emptyState={true}
+                            hasWritePermissions={true}
+                            loading={false}
+                          >
                             <Connect(CreateBaselineButton)
+                              emptyState={true}
+                              hasWritePermissions={true}
                               history={
                                 Object {
                                   "action": "POP",
@@ -5395,6 +5407,7 @@ Create a baseline to use in your Comparison analysis.
                                   "replace": [Function],
                                 }
                               }
+                              loading={false}
                               location={
                                 Object {
                                   "hash": "",
@@ -5414,6 +5427,8 @@ Create a baseline to use in your Comparison analysis.
                             >
                               <CreateBaselineButton
                                 addSystemModalOpened={false}
+                                emptyState={true}
+                                hasWritePermissions={true}
                                 history={
                                   Object {
                                     "action": "POP",
@@ -5444,6 +5459,7 @@ Create a baseline to use in your Comparison analysis.
                                     "replace": [Function],
                                   }
                                 }
+                                loading={false}
                                 location={
                                   Object {
                                     "hash": "",
@@ -5465,21 +5481,20 @@ Create a baseline to use in your Comparison analysis.
                               >
                                 <Button
                                   id="create-baseline-button"
-                                  isDisabled={true}
+                                  isDisabled={false}
                                   onClick={[Function]}
                                   variant="primary"
                                 >
                                   <button
-                                    aria-disabled={true}
+                                    aria-disabled={false}
                                     aria-label={null}
-                                    className="pf-c-button pf-m-primary pf-m-disabled"
+                                    className="pf-c-button pf-m-primary"
                                     data-ouia-component-id={17}
                                     data-ouia-component-type="PF4/Button"
                                     data-ouia-safe={true}
-                                    disabled={true}
+                                    disabled={false}
                                     id="create-baseline-button"
                                     onClick={[Function]}
-                                    tabIndex={null}
                                     type="button"
                                   >
                                     Create baseline

--- a/src/SmartComponents/BaselinesTable/BaselinesToolbar/__test__/__snapshots__/BaselinesToolbar.test.js.snap
+++ b/src/SmartComponents/BaselinesTable/BaselinesToolbar/__test__/__snapshots__/BaselinesToolbar.test.js.snap
@@ -888,7 +888,6 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
                                   >
                                     <Button
                                       id="create-baseline-button"
-                                      isDisabled={false}
                                       onClick={[Function]}
                                       variant="primary"
                                     >

--- a/src/SmartComponents/BaselinesTable/__tests__/__snapshots__/BaselinesTable.tests.js.snap
+++ b/src/SmartComponents/BaselinesTable/__tests__/__snapshots__/BaselinesTable.tests.js.snap
@@ -43140,6 +43140,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                             trigger={
                                               <div
                                                 aria-describedby="pf-tooltip-1"
+                                                className={null}
                                               >
                                                 <Button
                                                   id="create-baseline-button"
@@ -43158,6 +43159,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                             >
                                               <div
                                                 aria-describedby="pf-tooltip-1"
+                                                className={null}
                                               >
                                                 <Button
                                                   id="create-baseline-button"


### PR DESCRIPTION
When there is an empty baselines list and the user has baselines write permissions, the create baselines button is disabled when it should not be.