### PR TITLE
Fix bulk select in Systems Table

### DIFF
--- a/src/SmartComponents/AddSystemModal/AddSystemModal.js
+++ b/src/SmartComponents/AddSystemModal/AddSystemModal.js
@@ -127,6 +127,7 @@ export class AddSystemModal extends Component {
                                 historicalProfiles={ historicalProfiles }
                                 hasMultiSelect={ true }
                                 hasInventoryReadPermissions={ hasInventoryReadPermissions }
+                                entities={ entities }
                             />
                         </Tab>
                         <Tab

--- a/src/SmartComponents/AddSystemModal/__tests__/__snapshots__/AddSystemModal.tests.js.snap
+++ b/src/SmartComponents/AddSystemModal/__tests__/__snapshots__/AddSystemModal.tests.js.snap
@@ -48,6 +48,7 @@ exports[`AddSystemModal should render correctly 1`] = `
         title="Systems"
       >
         <Connect(SystemsTable)
+          entities={Object {}}
           hasHistoricalDropdown={true}
           hasInventoryReadPermissions={true}
           hasMultiSelect={true}
@@ -13909,6 +13910,11 @@ Try changing your filter settings.
                                         title="Systems"
                                       >
                                         <Memo(Connect(SystemsTable))
+                                          entities={
+                                            Object {
+                                              "selectedSystemIds": Array [],
+                                            }
+                                          }
                                           hasHistoricalDropdown={true}
                                           hasInventoryReadPermissions={true}
                                           hasMultiSelect={true}
@@ -13934,6 +13940,11 @@ Try changing your filter settings.
                                           title="Systems"
                                         >
                                           <Memo(Connect(SystemsTable))
+                                            entities={
+                                              Object {
+                                                "selectedSystemIds": Array [],
+                                              }
+                                            }
                                             hasHistoricalDropdown={true}
                                             hasInventoryReadPermissions={true}
                                             hasMultiSelect={true}
@@ -13959,6 +13970,11 @@ Try changing your filter settings.
                                         tabIndex={0}
                                       >
                                         <Connect(SystemsTable)
+                                          entities={
+                                            Object {
+                                              "selectedSystemIds": Array [],
+                                            }
+                                          }
                                           hasHistoricalDropdown={true}
                                           hasInventoryReadPermissions={true}
                                           hasMultiSelect={true}
@@ -13972,10 +13988,16 @@ Try changing your filter settings.
                                         >
                                           <SystemsTable
                                             driftClearFilters={[Function]}
+                                            entities={
+                                              Object {
+                                                "selectedSystemIds": Array [],
+                                              }
+                                            }
                                             hasHistoricalDropdown={true}
                                             hasInventoryReadPermissions={true}
                                             hasMultiSelect={true}
                                             historicalProfiles={Array []}
+                                            selectEntities={[Function]}
                                             selectHistoricProfiles={[Function]}
                                             selectedSystemIds={
                                               Array [
@@ -23232,6 +23254,11 @@ Try changing your filter settings.
                                         title="Systems"
                                       >
                                         <Memo(Connect(SystemsTable))
+                                          entities={
+                                            Object {
+                                              "selectedSystemIds": Array [],
+                                            }
+                                          }
                                           hasHistoricalDropdown={true}
                                           hasInventoryReadPermissions={true}
                                           hasMultiSelect={true}
@@ -23257,6 +23284,11 @@ Try changing your filter settings.
                                           title="Systems"
                                         >
                                           <Memo(Connect(SystemsTable))
+                                            entities={
+                                              Object {
+                                                "selectedSystemIds": Array [],
+                                              }
+                                            }
                                             hasHistoricalDropdown={true}
                                             hasInventoryReadPermissions={true}
                                             hasMultiSelect={true}
@@ -23282,6 +23314,11 @@ Try changing your filter settings.
                                         tabIndex={0}
                                       >
                                         <Connect(SystemsTable)
+                                          entities={
+                                            Object {
+                                              "selectedSystemIds": Array [],
+                                            }
+                                          }
                                           hasHistoricalDropdown={true}
                                           hasInventoryReadPermissions={true}
                                           hasMultiSelect={true}
@@ -23295,10 +23332,16 @@ Try changing your filter settings.
                                         >
                                           <SystemsTable
                                             driftClearFilters={[Function]}
+                                            entities={
+                                              Object {
+                                                "selectedSystemIds": Array [],
+                                              }
+                                            }
                                             hasHistoricalDropdown={true}
                                             hasInventoryReadPermissions={true}
                                             hasMultiSelect={true}
                                             historicalProfiles={Array []}
+                                            selectEntities={[Function]}
                                             selectHistoricProfiles={[Function]}
                                             selectedSystemIds={
                                               Array [
@@ -30884,6 +30927,11 @@ Try changing your filter settings.
                                         title="Systems"
                                       >
                                         <Memo(Connect(SystemsTable))
+                                          entities={
+                                            Object {
+                                              "selectedSystemIds": Array [],
+                                            }
+                                          }
                                           hasHistoricalDropdown={true}
                                           hasInventoryReadPermissions={false}
                                           hasMultiSelect={true}
@@ -30909,6 +30957,11 @@ Try changing your filter settings.
                                           title="Systems"
                                         >
                                           <Memo(Connect(SystemsTable))
+                                            entities={
+                                              Object {
+                                                "selectedSystemIds": Array [],
+                                              }
+                                            }
                                             hasHistoricalDropdown={true}
                                             hasInventoryReadPermissions={false}
                                             hasMultiSelect={true}
@@ -30934,6 +30987,11 @@ Try changing your filter settings.
                                         tabIndex={0}
                                       >
                                         <Connect(SystemsTable)
+                                          entities={
+                                            Object {
+                                              "selectedSystemIds": Array [],
+                                            }
+                                          }
                                           hasHistoricalDropdown={true}
                                           hasInventoryReadPermissions={false}
                                           hasMultiSelect={true}
@@ -30947,10 +31005,16 @@ Try changing your filter settings.
                                         >
                                           <SystemsTable
                                             driftClearFilters={[Function]}
+                                            entities={
+                                              Object {
+                                                "selectedSystemIds": Array [],
+                                              }
+                                            }
                                             hasHistoricalDropdown={true}
                                             hasInventoryReadPermissions={false}
                                             hasMultiSelect={true}
                                             historicalProfiles={Array []}
+                                            selectEntities={[Function]}
                                             selectHistoricProfiles={[Function]}
                                             selectedSystemIds={
                                               Array [

--- a/src/SmartComponents/BaselinesPage/CreateBaselineModal/CreateBaselineModal.js
+++ b/src/SmartComponents/BaselinesPage/CreateBaselineModal/CreateBaselineModal.js
@@ -150,7 +150,7 @@ export class CreateBaselineModal extends Component {
     }
 
     renderCopySystem() {
-        const { hasInventoryReadPermissions, historicalProfiles } = this.props;
+        const { hasInventoryReadPermissions, entities, historicalProfiles } = this.props;
 
         return (<React.Fragment>
             <b>Select system to copy from</b>
@@ -161,6 +161,7 @@ export class CreateBaselineModal extends Component {
                 hasMultiSelect={ false }
                 historicalProfiles={ historicalProfiles }
                 hasInventoryReadPermissions={ hasInventoryReadPermissions }
+                entities={ entities }
             />
         </React.Fragment>
         );

--- a/src/SmartComponents/SystemsTable/__tests__/SystemsTable.tests.js
+++ b/src/SmartComponents/SystemsTable/__tests__/SystemsTable.tests.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { MemoryRouter } from 'react-router-dom';
+import configureStore from 'redux-mock-store';
+import { Provider } from 'react-redux';
+import toJson from 'enzyme-to-json';
+
+import ConnectedSystemsTable from '../SystemsTable';
+import { createMiddlewareListener } from '../../../store';
+import fixtures from './fixtures';
+
+const middlewareListener = createMiddlewareListener();
+middlewareListener.getMiddleware();
+
+describe('ConnectedSystemsTable', () => {
+    let initialState;
+    let mockStore;
+
+    beforeEach(() => {
+        mockStore = configureStore();
+        initialState = {
+            selectedSystemIds: [],
+            createBaselineModal: false,
+            hasHistoricalDropdown: false,
+            historicalProfiles: [],
+            hasMultiSelect: true,
+            entities: {
+                columns: fixtures.columns,
+                rows: fixtures.rows,
+                total: 3,
+                count: 3,
+                selectedSystemIds: []
+            },
+            setSelectedsystemIds: jest.fn(),
+            driftClearFilters: jest.fn(),
+            selectHistoricProfiles: jest.fn(),
+            updateColumns: jest.fn(),
+            selectEntities: jest.fn()
+        };
+    });
+
+    it('should render correctly', () => {
+        const store = mockStore(initialState);
+
+        const wrapper = mount(
+            <MemoryRouter keyLength={ 0 }>
+                <Provider store={ store }>
+                    <ConnectedSystemsTable />
+                </Provider>
+            </MemoryRouter>
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});

--- a/src/SmartComponents/SystemsTable/__tests__/__snapshots__/SystemsTable.tests.js.snap
+++ b/src/SmartComponents/SystemsTable/__tests__/__snapshots__/SystemsTable.tests.js.snap
@@ -1,0 +1,140 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ConnectedSystemsTable should render correctly 1`] = `
+<MemoryRouter
+  keyLength={0}
+>
+  <Router
+    history={
+      Object {
+        "action": "POP",
+        "block": [Function],
+        "canGo": [Function],
+        "createHref": [Function],
+        "entries": Array [
+          Object {
+            "hash": "",
+            "pathname": "/",
+            "search": "",
+            "state": undefined,
+          },
+        ],
+        "go": [Function],
+        "goBack": [Function],
+        "goForward": [Function],
+        "index": 0,
+        "length": 1,
+        "listen": [Function],
+        "location": Object {
+          "hash": "",
+          "pathname": "/",
+          "search": "",
+          "state": undefined,
+        },
+        "push": [Function],
+        "replace": [Function],
+      }
+    }
+  >
+    <Provider
+      store={
+        Object {
+          "clearActions": [Function],
+          "dispatch": [Function],
+          "getActions": [Function],
+          "getState": [Function],
+          "replaceReducer": [Function],
+          "subscribe": [Function],
+        }
+      }
+    >
+      <Connect(SystemsTable)>
+        <SystemsTable
+          driftClearFilters={[Function]}
+          selectEntities={[Function]}
+          selectHistoricProfiles={[Function]}
+          selectedSystemIds={Array []}
+          setSelectedSystemIds={[Function]}
+          updateColumns={[Function]}
+        >
+          <EmptyStateDisplay
+            color="#6a6e73"
+            icon={[Function]}
+            text={
+              Array [
+                "Contact your organization administrator(s) for more information.",
+              ]
+            }
+            title="You do not have access to the inventory"
+          >
+            <EmptyState
+              variant="large"
+            >
+              <div
+                className="pf-c-empty-state pf-m-lg"
+              >
+                <div
+                  className="pf-c-empty-state__content"
+                >
+                  <EmptyStateIcon
+                    className={null}
+                    color="#6a6e73"
+                    icon={[Function]}
+                  >
+                    <LockIcon
+                      aria-hidden="true"
+                      className="pf-c-empty-state__icon"
+                      color="#6a6e73"
+                      noVerticalAlign={false}
+                      size="sm"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        aria-labelledby={null}
+                        className="pf-c-empty-state__icon"
+                        fill="#6a6e73"
+                        height="1em"
+                        role="img"
+                        style={
+                          Object {
+                            "verticalAlign": "-0.125em",
+                          }
+                        }
+                        viewBox="0 0 448 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M400 224h-24v-72C376 68.2 307.8 0 224 0S72 68.2 72 152v72H48c-26.5 0-48 21.5-48 48v192c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V272c0-26.5-21.5-48-48-48zm-104 0H152v-72c0-39.7 32.3-72 72-72s72 32.3 72 72v72z"
+                          transform=""
+                        />
+                      </svg>
+                    </LockIcon>
+                  </EmptyStateIcon>
+                  <br />
+                  <Title
+                    headingLevel="h1"
+                    size="lg"
+                  >
+                    <h1
+                      className="pf-c-title pf-m-lg"
+                    >
+                      You do not have access to the inventory
+                    </h1>
+                  </Title>
+                  <EmptyStateBody>
+                    <div
+                      className="pf-c-empty-state__body"
+                    >
+                      Contact your organization administrator(s) for more information.
+                    </div>
+                  </EmptyStateBody>
+                </div>
+              </div>
+            </EmptyState>
+          </EmptyStateDisplay>
+        </SystemsTable>
+      </Connect(SystemsTable)>
+    </Provider>
+  </Router>
+</MemoryRouter>
+`;

--- a/src/SmartComponents/SystemsTable/__tests__/fixtures.js
+++ b/src/SmartComponents/SystemsTable/__tests__/fixtures.js
@@ -1,0 +1,35 @@
+const rows = ([
+    {
+        id: 'ec67f65c-2bc8-4ce8-82e2-6a27cada8d31',
+        tags: [
+            { namespace: 'insights-client', key: 'group', value: 'XmygroupX' }
+        ],
+        updated: '2020-10-13T16:17:56.253419+00:00'
+    },
+    {
+        id: '7672c0c3-db27-4b59-ace9-5724d5a2dd1b',
+        tags: [
+            { namespace: 'insights-client', key: 'group', value: 'XmygroupX' }
+        ],
+        updated: '2020-10-13T16:17:54.952780+00:00'
+    },
+    {
+        id: '45ef6cea-b80f-46b6-90fc-00363a6f3b70',
+        tags: [
+            { namespace: 'insights-client', key: 'group', value: 'XmygroupX' }
+        ],
+        updated: '2020-10-13T16:17:54.686193+00:00'
+    }
+]);
+
+const columns = ([
+    { key: 'display_name', title: 'Name' },
+    { key: 'tags', title: 'Tags' },
+    { key: 'updated', title: 'Last seen' },
+    { key: 'historical_profiles', title: 'Historical profiles' }
+]);
+
+export default {
+    rows,
+    columns
+};

--- a/src/store/__tests__/reducer-test.js
+++ b/src/store/__tests__/reducer-test.js
@@ -118,4 +118,66 @@ describe('compare reducer', () => {
             rows: []
         });
     });
+
+    it('should handle 0 SELECT_ENTITY false', () => {
+        expect(
+            reducer({
+                selectedSystemIds: [ '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9', '9c83bfcc-8t7a-47c7-b4r2-142fg52e89e1' ],
+                rows: [{ id: '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9' }, { id: '9c83bfcc-8t7a-47c7-b4r2-142fg52e89e1' }]
+            }, {
+                payload:
+                    {
+                        id: 0, selected: false
+                    },
+                type: types.SELECT_ENTITY
+            })
+        ).toEqual({
+            selectedSystemIds: [],
+            rows: [{ id: '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9' }, { id: '9c83bfcc-8t7a-47c7-b4r2-142fg52e89e1' }]
+        });
+    });
+
+    it('should handle 0 SELECT_ENTITY false on without bulk select', () => {
+        expect(
+            reducer({
+                selectedSystemIds: [
+                    '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9',
+                    '9c83bfcc-8t7a-47c7-b4r2-142fg52e89e1',
+                    '2c84bfvc-8t9q-52r9-b4c3-847fg51l09e1'
+                ],
+                rows: [{ id: '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9' }, { id: '9c83bfcc-8t7a-47c7-b4r2-142fg52e89e1' }]
+            }, {
+                payload:
+                    {
+                        id: 0, selected: false
+                    },
+                type: types.SELECT_ENTITY
+            })
+        ).toEqual({
+            selectedSystemIds: [ '2c84bfvc-8t9q-52r9-b4c3-847fg51l09e1' ],
+            rows: [{ id: '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9' }, { id: '9c83bfcc-8t7a-47c7-b4r2-142fg52e89e1' }]
+        });
+    });
+
+    it('should handle 0 SELECT_ENTITY false on bulk select', () => {
+        expect(
+            reducer({
+                selectedSystemIds: [
+                    '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9',
+                    '9c83bfcc-8t7a-47c7-b4r2-142fg52e89e1',
+                    '2c84bfvc-8t9q-52r9-b4c3-847fg51l09e1'
+                ],
+                rows: [{ id: '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9' }, { id: '9c83bfcc-8t7a-47c7-b4r2-142fg52e89e1' }]
+            }, {
+                payload:
+                    {
+                        id: 0, selected: false, bulk: true
+                    },
+                type: types.SELECT_ENTITY
+            })
+        ).toEqual({
+            selectedSystemIds: [],
+            rows: [{ id: '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9' }, { id: '9c83bfcc-8t7a-47c7-b4r2-142fg52e89e1' }]
+        });
+    });
 });

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -132,8 +132,12 @@ function selectedReducer(
                         });
                         selectedSystemIds = [ ...new Set(selectedSystemIds.concat(ids)) ];
                     } else {
-                        for (let i = 0; i < state.rows.length; i += 1) {
-                            selectedSystemIds = selectedSystemIds.filter(item => item !== state.rows[i].id);
+                        if (action.payload.bulk) {
+                            selectedSystemIds = [];
+                        } else {
+                            for (let i = 0; i < state.rows.length; i += 1) {
+                                selectedSystemIds = selectedSystemIds.filter(item => item !== state.rows[i].id);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Bulk selector in systems table on add systems modal should work to be able to select an entire page of systems. If you select an entire page and then go to the next page, those selections will still be selected. It keeps a running total. Because the api requests paginated data, you cannot select the entire inventory system at once.

Definitely mess around with this and try to break it. Try adding filters, sorting and selecting/deselecting things to make sure I'm not missing a key part here.

The bulk selector in the systems table on the create baseline modal should be disabled as you can only select a single system to copy from.