### PR TITLE
Baselines list loads on breadcrumb click

### DIFF
--- a/src/SmartComponents/BaselinesPage/EditBaseline/EditBaseline.js
+++ b/src/SmartComponents/BaselinesPage/EditBaseline/EditBaseline.js
@@ -64,9 +64,10 @@ export class EditBaseline extends Component {
     }
 
     goToBaselinesList() {
-        const { history, clearBaselineData } = this.props;
+        const { clearBaselineData, fetchBaselines, history } = this.props;
 
         clearBaselineData('CHECKBOX');
+        fetchBaselines('CHECKBOX');
         history.push('/baselines');
     }
 
@@ -426,7 +427,8 @@ EditBaseline.propTypes = {
     inlineError: PropTypes.object,
     editBaselineEmptyState: PropTypes.bool,
     exportToCSV: PropTypes.func,
-    hasWritePermissions: PropTypes.bool
+    hasWritePermissions: PropTypes.bool,
+    fetchBaselines: PropTypes.func
 };
 
 function mapStateToProps(state) {
@@ -451,7 +453,8 @@ function mapDispatchToProps(dispatch) {
         clearErrorData: () => dispatch(editBaselineActions.clearErrorData()),
         exportToCSV: (exportData, baselineRowData)=> {
             dispatch(editBaselineActions.exportToCSV(exportData, baselineRowData));
-        }
+        },
+        fetchBaselines: (tableId, params) => dispatch(baselinesTableActions.fetchBaselines(tableId, params))
     };
 }
 

--- a/src/SmartComponents/BaselinesPage/EditBaseline/__tests__/EditBaseline.tests.js
+++ b/src/SmartComponents/BaselinesPage/EditBaseline/__tests__/EditBaseline.tests.js
@@ -220,7 +220,8 @@ describe('ConnectedEditBaseline', () => {
         wrapper.find('a').simulate('click');
         expect(actions).toEqual([
             { type: 'FETCH_BASELINE_DATA', payload: api.getBaselineData('blah') },
-            { type: 'CLEAR_BASELINE_DATA_CHECKBOX' }
+            { type: 'CLEAR_BASELINE_DATA_CHECKBOX' },
+            { type: 'FETCH_BASELINE_LIST_CHECKBOX', payload: api.getBaselineList('blah') }
         ]);
     });
 

--- a/src/SmartComponents/BaselinesPage/EditBaseline/__tests__/__snapshots__/EditBaseline.tests.js.snap
+++ b/src/SmartComponents/BaselinesPage/EditBaseline/__tests__/__snapshots__/EditBaseline.tests.js.snap
@@ -110,6 +110,7 @@ exports[`ConnectedEditBaseline should render correctly 1`] = `
             exportToCSV={[Function]}
             factModalOpened={false}
             fetchBaselineData={[Function]}
+            fetchBaselines={[Function]}
             history={
               Object {
                 "action": "POP",
@@ -1525,6 +1526,7 @@ exports[`ConnectedEditBaseline should render disabled button with empty baseline
             exportToCSV={[Function]}
             factModalOpened={false}
             fetchBaselineData={[Function]}
+            fetchBaselines={[Function]}
             history={
               Object {
                 "action": "POP",
@@ -2064,6 +2066,7 @@ exports[`ConnectedEditBaseline should render empty baseline 1`] = `
             exportToCSV={[Function]}
             factModalOpened={false}
             fetchBaselineData={[Function]}
+            fetchBaselines={[Function]}
             history={
               Object {
                 "action": "POP",
@@ -2659,6 +2662,7 @@ exports[`ConnectedEditBaseline should render expandable rows closed 1`] = `
             exportToCSV={[Function]}
             factModalOpened={false}
             fetchBaselineData={[Function]}
+            fetchBaselines={[Function]}
             history={
               Object {
                 "action": "POP",
@@ -5637,6 +5641,7 @@ exports[`ConnectedEditBaseline should render expandable rows opened 1`] = `
             exportToCSV={[Function]}
             factModalOpened={false}
             fetchBaselineData={[Function]}
+            fetchBaselines={[Function]}
             history={
               Object {
                 "action": "POP",
@@ -12280,6 +12285,7 @@ exports[`ConnectedEditBaseline should render loading rows 1`] = `
             exportToCSV={[Function]}
             factModalOpened={false}
             fetchBaselineData={[Function]}
+            fetchBaselines={[Function]}
             history={
               Object {
                 "action": "POP",
@@ -14008,6 +14014,7 @@ exports[`ConnectedEditBaseline should render with baseline facts 1`] = `
             exportToCSV={[Function]}
             factModalOpened={false}
             fetchBaselineData={[Function]}
+            fetchBaselines={[Function]}
             history={
               Object {
                 "action": "POP",


### PR DESCRIPTION
To reproduce:
- Go to Baselines page with an empty state (no baselines)
- Create a baseline
- From the edit baseline page, click the breadbrumb to go back to the baselines list

The baselines list will still show empty. If you refresh, you'll see the baseline you just created.

This fix will show the new baseline you created after you click the breadcrumb.