### PR TITLE
Update HSP badge count on Bulk Select 'Select none'

### DIFF
--- a/src/SmartComponents/HistoricalProfilesDropdown/HistoricalProfilesDropdown.js
+++ b/src/SmartComponents/HistoricalProfilesDropdown/HistoricalProfilesDropdown.js
@@ -42,6 +42,12 @@ export class HistoricalProfilesDropdown extends Component {
         this.onSingleSelect = this.onSingleSelect.bind(this);
     }
 
+    componentDidUpdate(prevProps) {
+        if (this.props.selectedHSPIds.length !== prevProps.selectedHSPIds.length) {
+            this.updateBadgeCount();
+        }
+    }
+
     async onSelect(checked, profile) {
         const { selectHistoricProfiles, selectSystem, selectedHSPIds } = this.props;
         let newSelectedHSPIds = [ ...selectedHSPIds ];
@@ -193,7 +199,7 @@ export class HistoricalProfilesDropdown extends Component {
 
     updateBadgeCount = () => {
         this.setState({
-            badgeCount: this.state.historicalData.profiles.filter((hsp) => {
+            badgeCount: this.state.historicalData?.profiles.filter((hsp) => {
                 return this.props.selectedHSPIds.includes(hsp.id);
             }).length
         });

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -37,6 +37,13 @@ export const SystemsTable = ({
     const sidsFilter = ReactRedux.useSelector(({ globalFilterState }) => globalFilterState?.sidsFilter);
     const store = ReactRedux.useStore();
 
+    const deselectHistoricalProfiles = () => {
+        if (!hasMultiSelect) {
+            updateColumns('display_name');
+            selectHistoricProfiles([]);
+        }
+    };
+
     const onSelect = (event) => {
         let toSelect = [];
         switch (event) {
@@ -54,13 +61,6 @@ export const SystemsTable = ({
         }
 
         selectEntities(toSelect);
-    };
-
-    const deselectHistoricalProfiles = () => {
-        if (!hasMultiSelect) {
-            updateColumns('display_name');
-            selectHistoricProfiles([]);
-        }
     };
 
     const fetchInventory = async () => {


### PR DESCRIPTION
- Open Add to comparison modal
- Select several HSPs
- Click Select all
- Click Deselect all

The HSP selector shows no. of selected HSPs even though none are selected.

This fix updates the badge count when using the bulk select 'Select none' to 0.