### PR TITLE
Removes HSP as reference when parent system removed from comparison

### DIFF
--- a/src/SmartComponents/DriftPage/DriftTable/__tests__/DriftTable.tests.js
+++ b/src/SmartComponents/DriftPage/DriftTable/__tests__/DriftTable.tests.js
@@ -228,13 +228,17 @@ describe('ConnectedDriftTable', () => {
         initialState.historicProfilesState.selectedHSPIds = [
             '9bbbefcc-8f23-4d97-07f2-142asdl234e8', 'edmk59dj-fn42-dfjk-alv3-bmn2854mnn27'
         ];
+        let setIsFirstReference = jest.fn();
 
         const store = mockStore(initialState);
 
         const wrapper = mount(
             <MemoryRouter keyLength={ 0 }>
                 <Provider store={ store }>
-                    <ConnectedDriftTable updateReferenceId={ updateReferenceId } />
+                    <ConnectedDriftTable
+                        updateReferenceId={ updateReferenceId }
+                        setIsFirstReference={ setIsFirstReference }
+                    />
                 </Provider>
             </MemoryRouter>
         );


### PR DESCRIPTION
- Add two systems to comparison
- Add hsps of one system to comparison
- Make an hsp the reference
- Remove the original system
- Verify all hsps have been removed

The hsp is removed but its reference id stays in the URL and that prompts a blocking error message.

This fix removes the system along with its hsps and no reference is set in URL.

This fix also updates some incorrect behaviors with automatic reference being set on a baseline. The general rule is:

If there is NOTHING being compared, and a baseline & system is added, the baseline should be set as reference.
If there is something there already, don’t auto-set.

Previously, if a system was added to a comparison, and then a baseline was added, we automatically referenced the baseline. But in this case, something was 'there already', so it should not have automatically referenced it. This fixes that.