### PR TITLE
Fix issue with removing system as reference

### DIFF
--- a/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
+++ b/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
@@ -189,6 +189,10 @@ export class DriftTable extends Component {
             this.HSPIds = this.HSPIds.filter(id => id !== item.id);
         }
 
+        if (item.id === newReferenceId) {
+            newReferenceId = undefined;
+        }
+
         selectHistoricProfiles(this.HSPIds);
         if (!this.systemIds.length && !this.baselineIds.length
             && !this.HSPIds.length && !referenceId && !isFirstReference) {


### PR DESCRIPTION
Two issues were fixed here.
First:

- Add two systems to comparison
- Make one a reference
- Remove the system that is the reference
Get an error.

Second:

- Select two systems for comparison
- Make one of them the reference
- Remove the other, then remove the reference host
An error: "must specify at least one of system, baseline, or HSP" is displayed. See screenshot.