### PR TITLE
Relocate loading icon on create baseline modal

### DIFF
--- a/src/SmartComponents/BaselinesPage/CreateBaselineModal/CreateBaselineModal.js
+++ b/src/SmartComponents/BaselinesPage/CreateBaselineModal/CreateBaselineModal.js
@@ -154,6 +154,7 @@ export class CreateBaselineModal extends Component {
 
         return (<React.Fragment>
             <b>Select system to copy from</b>
+            <br></br>
             <SystemsTable
                 selectedSystemIds={ [] }
                 createBaselineModal={ true }


### PR DESCRIPTION
If you click 'copy from an existing system' on the create baseline modal, you'll see the loading icon beside the text 'copy from an existing system'. This PR moves that icon below the text.