### PR TITLE
Remove alternative filter names from beta

### DIFF
--- a/src/SmartComponents/DriftPage/DriftFilterChips/DriftFilterChips.js
+++ b/src/SmartComponents/DriftPage/DriftFilterChips/DriftFilterChips.js
@@ -69,26 +69,14 @@ export class DriftFilterChips extends Component {
     removeChip = (chip) => {
         const { stateFilters, addStateFilter, filterByFact } = this.props;
 
-        if (insights.chrome.isBeta()) {
-            if (chip === 'Expected' || chip === 'Unexpected' || chip === 'Uncertain') {
-                stateFilters.forEach(function(stateFilter) {
-                    if (stateFilter.display === chip) {
-                        addStateFilter(stateFilter);
-                    }
-                });
-            } else {
-                filterByFact('');
-            }
+        if (chip === 'Same' || chip === 'Different' || chip === 'Incomplete data') {
+            stateFilters.forEach(function(stateFilter) {
+                if (stateFilter.display === chip) {
+                    addStateFilter(stateFilter);
+                }
+            });
         } else {
-            if (chip === 'Same' || chip === 'Different' || chip === 'Incomplete data') {
-                stateFilters.forEach(function(stateFilter) {
-                    if (stateFilter.display === chip) {
-                        addStateFilter(stateFilter);
-                    }
-                });
-            } else {
-                filterByFact('');
-            }
+            filterByFact('');
         }
     }
 

--- a/src/SmartComponents/modules/reducers.js
+++ b/src/SmartComponents/modules/reducers.js
@@ -29,18 +29,6 @@ const initialState = {
     emptyState: true
 };
 
-if (insights.chrome.isBeta()) {
-
-    initialState.stateFilters = [
-        { filter: 'SAME', display: 'Expected', selected: true },
-        { filter: 'DIFFERENT', display: 'Unexpected', selected: true },
-        { filter: 'INCOMPLETE_DATA', display: 'Uncertain', selected: true }
-    ];
-
-}
-
-;
-
 export function compareReducer(state = initialState, action) {
     let filteredFacts;
     let sortedFacts;


### PR DESCRIPTION
We decided not to go with the new names at this time, so removing them from beta.