### PR TITLE
Enable Add Fact Button when baseline only has an empty category

### DIFF
--- a/src/SmartComponents/BaselinesPage/EditBaseline/EditBaselineToolbar/EditBaselineToolbar.js
+++ b/src/SmartComponents/BaselinesPage/EditBaseline/EditBaselineToolbar/EditBaselineToolbar.js
@@ -62,7 +62,7 @@ export class EditBaselineToolbar extends Component {
                     </ToolbarItem>
                     <ToolbarItem>
                         <AddFactButton
-                            isDisabled={ totalFacts > 0 ? false : true }
+                            isDisabled={ isDisabled }
                             hasWritePermissions={ hasWritePermissions }
                         />
                     </ToolbarItem>


### PR DESCRIPTION
Steps to reproduce:
- Create a baseline from scratch
- Add a category to the baseline

The add fact or category button is inactive