### PR TITLE
Add tooltips to icons in comparison table

### DIFF
--- a/src/SmartComponents/BaselinesTable/BaselinesTable.js
+++ b/src/SmartComponents/BaselinesTable/BaselinesTable.js
@@ -218,9 +218,6 @@ export class BaselinesTable extends Component {
                         text={ [ 'Contact your organization administrator(s) for more information.' ] }
                     />;
                 } else {
-                    /*eslint-disable*/
-                    console.log(columns);
-                    /*eslint-enable*/
                     tableRows = this.renderRows(hasWritePermissions);
 
                     table = <Table

--- a/src/SmartComponents/DriftPage/DriftTable/ComparisonHeader/ComparisonHeader.js
+++ b/src/SmartComponents/DriftPage/DriftTable/ComparisonHeader/ComparisonHeader.js
@@ -53,11 +53,26 @@ class ComparisonHeader extends Component {
 
         masterList.forEach(item => {
             if (item.type === 'system') {
-                typeIcon = <ServerIcon/>;
+                typeIcon = <Tooltip
+                    position='top'
+                    content={ <div>System</div> }
+                >
+                    <ServerIcon/>
+                </Tooltip>;
             } else if (item.type === 'baseline') {
-                typeIcon = <BlueprintIcon/>;
+                typeIcon = <Tooltip
+                    position='top'
+                    content={ <div>Baseline</div> }
+                >
+                    <BlueprintIcon/>
+                </Tooltip>;
             } else if (item.type === 'historical-system-profile') {
-                typeIcon = <ClockIcon />;
+                typeIcon = <Tooltip
+                    position='top'
+                    content={ <div>Historical system</div> }
+                >
+                    <ClockIcon />
+                </Tooltip>;
             }
 
             row.push(
@@ -83,7 +98,7 @@ class ComparisonHeader extends Component {
                         <div className="system-updated-and-reference">
                             <ReferenceSelector
                                 updateReferenceId={ updateReferenceId }
-                                id={ item.id }
+                                item={ item }
                                 isReference= { item.id === referenceId }
                             />
                             { item.system_profile_exists === false ?

--- a/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
+++ b/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
@@ -292,7 +292,7 @@ export class DriftTable extends Component {
             );
             row.push(
                 <td className="fact-state sticky-column fixed-column-2">
-                    <StateIcon factState={ fact.state }/>
+                    <StateIcon fact={ fact }/>
                 </td>
             );
 
@@ -312,7 +312,7 @@ export class DriftTable extends Component {
             row.push(<td className="sticky-column fixed-column-1">{ fact.name }</td>);
             row.push(
                 <td className="fact-state sticky-column fixed-column-2">
-                    <StateIcon factState={ fact.state }/>
+                    <StateIcon fact={ fact }/>
                 </td>
             );
 
@@ -330,7 +330,7 @@ export class DriftTable extends Component {
         row.push(<td className="nested-fact sticky-column fixed-column-1">
             <p className="child-row">{ fact.name }</p>
         </td>);
-        row.push(<td className="fact-state sticky-column fixed-column-2"><StateIcon factState={ fact.state }/></td>);
+        row.push(<td className="fact-state sticky-column fixed-column-2"><StateIcon fact={ fact }/></td>);
 
         row = row.concat(this.findSystem(fact));
 

--- a/src/SmartComponents/DriftPage/DriftTable/ReferenceSelector/ReferenceSelector.js
+++ b/src/SmartComponents/DriftPage/DriftTable/ReferenceSelector/ReferenceSelector.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { Tooltip } from '@patternfly/react-core';
 import { OutlinedStarIcon, StarIcon } from '@patternfly/react-icons';
 import PropTypes from 'prop-types';
 
@@ -11,8 +12,8 @@ class ReferenceSelector extends Component {
         };
     }
 
-    render() {
-        const { updateReferenceId, id } = this.props;
+    renderIcon() {
+        const { updateReferenceId, item } = this.props;
         const { isReference } = this.state;
 
         return (
@@ -23,8 +24,35 @@ class ReferenceSelector extends Component {
                 />
                 : <OutlinedStarIcon
                     className='reference-selector pointer'
-                    onClick={ () => updateReferenceId(id) }
+                    onClick={ () => updateReferenceId(item.id) }
                 />
+        );
+    }
+
+    renderMessage() {
+        const { isReference } = this.state;
+        const { item } = this.props;
+        let type = item.type;
+
+        if (item.type === 'historical-system-profile') {
+            type = 'historical system';
+        }
+
+        if (isReference) {
+            return <div>This is the reference the other items are being compared against.</div>;
+        } else {
+            return <div>Use this { type } as a reference to compare.</div>;
+        }
+    }
+
+    render() {
+        return (
+            <Tooltip
+                position='top'
+                content={ this.renderMessage() }
+            >
+                { this.renderIcon() }
+            </Tooltip>
         );
     }
 }
@@ -32,7 +60,7 @@ class ReferenceSelector extends Component {
 ReferenceSelector.propTypes = {
     isReference: PropTypes.bool,
     updateReferenceId: PropTypes.func,
-    id: PropTypes.string
+    item: PropTypes.object
 };
 
 export default ReferenceSelector;

--- a/src/SmartComponents/DriftPage/DriftTable/ReferenceSelector/__tests__/ReferenceSelector.tests.js
+++ b/src/SmartComponents/DriftPage/DriftTable/ReferenceSelector/__tests__/ReferenceSelector.tests.js
@@ -10,7 +10,7 @@ describe('ReferenceSelector', () => {
     beforeEach(() => {
         props = {
             isReference: false,
-            id: 'abcd1234',
+            item: { id: 'abcd1234' },
             updateReferenceId: jest.fn()
         };
     });

--- a/src/SmartComponents/DriftPage/DriftTable/ReferenceSelector/__tests__/__snapshots__/ReferenceSelector.tests.js.snap
+++ b/src/SmartComponents/DriftPage/DriftTable/ReferenceSelector/__tests__/__snapshots__/ReferenceSelector.tests.js.snap
@@ -1,20 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ReferenceSelector should render correctly 1`] = `
-<OutlinedStarIcon
-  className="reference-selector pointer"
-  color="currentColor"
-  noVerticalAlign={false}
-  onClick={[Function]}
-  size="sm"
-/>
-`;
-
-exports[`ReferenceSelector should render mount correctly with isReference false 1`] = `
-<ReferenceSelector
-  id="abcd1234"
-  isReference={false}
-  updateReferenceId={[MockFunction]}
+<Tooltip
+  content={
+    <div>
+      Use this 
+       as a reference to compare.
+    </div>
+  }
+  position="top"
 >
   <OutlinedStarIcon
     className="reference-selector pointer"
@@ -22,64 +16,258 @@ exports[`ReferenceSelector should render mount correctly with isReference false 
     noVerticalAlign={false}
     onClick={[Function]}
     size="sm"
+  />
+</Tooltip>
+`;
+
+exports[`ReferenceSelector should render mount correctly with isReference false 1`] = `
+<ReferenceSelector
+  isReference={false}
+  item={
+    Object {
+      "id": "abcd1234",
+    }
+  }
+  updateReferenceId={[MockFunction]}
+>
+  <Tooltip
+    content={
+      <div>
+        Use this 
+         as a reference to compare.
+      </div>
+    }
+    position="top"
   >
-    <svg
-      aria-hidden={true}
-      aria-labelledby={null}
-      className="reference-selector pointer"
-      fill="currentColor"
-      height="1em"
-      onClick={[Function]}
-      role="img"
-      style={
+    <Popper
+      appendTo={[Function]}
+      distance={15}
+      enableFlip={true}
+      flipBehavior={
+        Array [
+          "top",
+          "right",
+          "bottom",
+          "left",
+          "top",
+          "right",
+          "bottom",
+        ]
+      }
+      isVisible={false}
+      onBlur={[Function]}
+      onDocumentClick={false}
+      onDocumentKeyDown={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onTriggerEnter={[Function]}
+      placement="top"
+      popper={
+        <div
+          className="pf-c-tooltip"
+          id="pf-tooltip-1"
+          role="tooltip"
+          style={
+            Object {
+              "maxWidth": null,
+              "opacity": 0,
+              "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
+            }
+          }
+        >
+          <TooltipArrow />
+          <TooltipContent
+            isLeftAligned={false}
+          >
+            <div>
+              Use this 
+               as a reference to compare.
+            </div>
+          </TooltipContent>
+        </div>
+      }
+      popperMatchesTriggerWidth={false}
+      positionModifiers={
         Object {
-          "verticalAlign": "-0.125em",
+          "bottom": "pf-m-bottom",
+          "left": "pf-m-left",
+          "right": "pf-m-right",
+          "top": "pf-m-top",
         }
       }
-      viewBox="0 0 576 512"
-      width="1em"
+      trigger={
+        <OutlinedStarIcon
+          aria-describedby="pf-tooltip-1"
+          className="reference-selector pointer"
+          color="currentColor"
+          noVerticalAlign={false}
+          onClick={[Function]}
+          size="sm"
+        />
+      }
+      zIndex={9999}
     >
-      <path
-        d="M528.1 171.5L382 150.2 316.7 17.8c-11.7-23.6-45.6-23.9-57.4 0L194 150.2 47.9 171.5c-26.2 3.8-36.7 36.1-17.7 54.6l105.7 103-25 145.5c-4.5 26.3 23.2 46 46.4 33.7L288 439.6l130.7 68.7c23.2 12.2 50.9-7.4 46.4-33.7l-25-145.5 105.7-103c19-18.5 8.5-50.8-17.7-54.6zM388.6 312.3l23.7 138.4L288 385.4l-124.3 65.3 23.7-138.4-100.6-98 139-20.2 62.2-126 62.2 126 139 20.2-100.6 98z"
-      />
-    </svg>
-  </OutlinedStarIcon>
+      <FindRefWrapper
+        onFoundRef={[Function]}
+      >
+        <OutlinedStarIcon
+          aria-describedby="pf-tooltip-1"
+          className="reference-selector pointer"
+          color="currentColor"
+          noVerticalAlign={false}
+          onClick={[Function]}
+          size="sm"
+        >
+          <svg
+            aria-describedby="pf-tooltip-1"
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="reference-selector pointer"
+            fill="currentColor"
+            height="1em"
+            onClick={[Function]}
+            role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
+            viewBox="0 0 576 512"
+            width="1em"
+          >
+            <path
+              d="M528.1 171.5L382 150.2 316.7 17.8c-11.7-23.6-45.6-23.9-57.4 0L194 150.2 47.9 171.5c-26.2 3.8-36.7 36.1-17.7 54.6l105.7 103-25 145.5c-4.5 26.3 23.2 46 46.4 33.7L288 439.6l130.7 68.7c23.2 12.2 50.9-7.4 46.4-33.7l-25-145.5 105.7-103c19-18.5 8.5-50.8-17.7-54.6zM388.6 312.3l23.7 138.4L288 385.4l-124.3 65.3 23.7-138.4-100.6-98 139-20.2 62.2-126 62.2 126 139 20.2-100.6 98z"
+            />
+          </svg>
+        </OutlinedStarIcon>
+      </FindRefWrapper>
+    </Popper>
+  </Tooltip>
 </ReferenceSelector>
 `;
 
 exports[`ReferenceSelector should render mount correctly with isReference true 1`] = `
 <ReferenceSelector
-  id="abcd1234"
   isReference={true}
+  item={
+    Object {
+      "id": "abcd1234",
+    }
+  }
   updateReferenceId={[MockFunction]}
 >
-  <StarIcon
-    className="reference-selector pointer"
-    color="currentColor"
-    noVerticalAlign={false}
-    onClick={[Function]}
-    size="sm"
+  <Tooltip
+    content={
+      <div>
+        This is the reference the other items are being compared against.
+      </div>
+    }
+    position="top"
   >
-    <svg
-      aria-hidden={true}
-      aria-labelledby={null}
-      className="reference-selector pointer"
-      fill="currentColor"
-      height="1em"
-      onClick={[Function]}
-      role="img"
-      style={
+    <Popper
+      appendTo={[Function]}
+      distance={15}
+      enableFlip={true}
+      flipBehavior={
+        Array [
+          "top",
+          "right",
+          "bottom",
+          "left",
+          "top",
+          "right",
+          "bottom",
+        ]
+      }
+      isVisible={false}
+      onBlur={[Function]}
+      onDocumentClick={false}
+      onDocumentKeyDown={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onTriggerEnter={[Function]}
+      placement="top"
+      popper={
+        <div
+          className="pf-c-tooltip"
+          id="pf-tooltip-2"
+          role="tooltip"
+          style={
+            Object {
+              "maxWidth": null,
+              "opacity": 0,
+              "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
+            }
+          }
+        >
+          <TooltipArrow />
+          <TooltipContent
+            isLeftAligned={false}
+          >
+            <div>
+              This is the reference the other items are being compared against.
+            </div>
+          </TooltipContent>
+        </div>
+      }
+      popperMatchesTriggerWidth={false}
+      positionModifiers={
         Object {
-          "verticalAlign": "-0.125em",
+          "bottom": "pf-m-bottom",
+          "left": "pf-m-left",
+          "right": "pf-m-right",
+          "top": "pf-m-top",
         }
       }
-      viewBox="0 0 576 512"
-      width="1em"
+      trigger={
+        <StarIcon
+          aria-describedby="pf-tooltip-2"
+          className="reference-selector pointer"
+          color="currentColor"
+          noVerticalAlign={false}
+          onClick={[Function]}
+          size="sm"
+        />
+      }
+      zIndex={9999}
     >
-      <path
-        d="M259.3 17.8L194 150.2 47.9 171.5c-26.2 3.8-36.7 36.1-17.7 54.6l105.7 103-25 145.5c-4.5 26.3 23.2 46 46.4 33.7L288 439.6l130.7 68.7c23.2 12.2 50.9-7.4 46.4-33.7l-25-145.5 105.7-103c19-18.5 8.5-50.8-17.7-54.6L382 150.2 316.7 17.8c-11.7-23.6-45.6-23.9-57.4 0z"
-      />
-    </svg>
-  </StarIcon>
+      <FindRefWrapper
+        onFoundRef={[Function]}
+      >
+        <StarIcon
+          aria-describedby="pf-tooltip-2"
+          className="reference-selector pointer"
+          color="currentColor"
+          noVerticalAlign={false}
+          onClick={[Function]}
+          size="sm"
+        >
+          <svg
+            aria-describedby="pf-tooltip-2"
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="reference-selector pointer"
+            fill="currentColor"
+            height="1em"
+            onClick={[Function]}
+            role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
+            viewBox="0 0 576 512"
+            width="1em"
+          >
+            <path
+              d="M259.3 17.8L194 150.2 47.9 171.5c-26.2 3.8-36.7 36.1-17.7 54.6l105.7 103-25 145.5c-4.5 26.3 23.2 46 46.4 33.7L288 439.6l130.7 68.7c23.2 12.2 50.9-7.4 46.4-33.7l-25-145.5 105.7-103c19-18.5 8.5-50.8-17.7-54.6L382 150.2 316.7 17.8c-11.7-23.6-45.6-23.9-57.4 0z"
+            />
+          </svg>
+        </StarIcon>
+      </FindRefWrapper>
+    </Popper>
+  </Tooltip>
 </ReferenceSelector>
 `;

--- a/src/SmartComponents/DriftPage/DriftTable/__tests__/__snapshots__/DriftTable.tests.js.snap
+++ b/src/SmartComponents/DriftPage/DriftTable/__tests__/__snapshots__/DriftTable.tests.js.snap
@@ -1331,6 +1331,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                       "value": "3",
                     },
                   ],
+                  "tooltip": "Different - At least one system fact value in this row differs.",
                 },
                 Object {
                   "name": "bios_uuid",
@@ -1775,30 +1776,112 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                           <div
                             className="drift-header-icon"
                           >
-                            <BlueprintIcon
-                              color="currentColor"
-                              noVerticalAlign={false}
-                              size="sm"
+                            <Tooltip
+                              content={
+                                <div>
+                                  Baseline
+                                </div>
+                              }
+                              position="top"
                             >
-                              <svg
-                                aria-hidden={true}
-                                aria-labelledby={null}
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                style={
+                              <Popper
+                                appendTo={[Function]}
+                                distance={15}
+                                enableFlip={true}
+                                flipBehavior={
+                                  Array [
+                                    "top",
+                                    "right",
+                                    "bottom",
+                                    "left",
+                                    "top",
+                                    "right",
+                                    "bottom",
+                                  ]
+                                }
+                                isVisible={false}
+                                onBlur={[Function]}
+                                onDocumentClick={false}
+                                onDocumentKeyDown={[Function]}
+                                onFocus={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                onTriggerEnter={[Function]}
+                                placement="top"
+                                popper={
+                                  <div
+                                    className="pf-c-tooltip"
+                                    id="pf-tooltip-1"
+                                    role="tooltip"
+                                    style={
+                                      Object {
+                                        "maxWidth": null,
+                                        "opacity": 0,
+                                        "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
+                                      }
+                                    }
+                                  >
+                                    <TooltipArrow />
+                                    <TooltipContent
+                                      isLeftAligned={false}
+                                    >
+                                      <div>
+                                        Baseline
+                                      </div>
+                                    </TooltipContent>
+                                  </div>
+                                }
+                                popperMatchesTriggerWidth={false}
+                                positionModifiers={
                                   Object {
-                                    "verticalAlign": "-0.125em",
+                                    "bottom": "pf-m-bottom",
+                                    "left": "pf-m-left",
+                                    "right": "pf-m-right",
+                                    "top": "pf-m-top",
                                   }
                                 }
-                                viewBox="0 0 1024 1024"
-                                width="1em"
+                                trigger={
+                                  <BlueprintIcon
+                                    aria-describedby="pf-tooltip-1"
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  />
+                                }
+                                zIndex={9999}
                               >
-                                <path
-                                  d="M0,767.3 L0,640 L64,640 L64,752.3 C64,760.584271 70.7157288,767.3 79,767.3 L128,768.1 L128,832.1 L64,831.3 C28.6674863,831.266922 0.0330777378,802.632514 0,767.3 Z M64,0 L191.3,0 L191.3,64 L79,64 C70.7157288,64 64,70.7157288 64,79 L64,192 L0,192 L0,64 C0.0330777378,28.6674863 28.6674863,0.0330777378 64,0 Z M0,384 L64,384 L64,256 L0,256 L0,384 Z M0,576 L64,576 L64,448 L0,448 L0,576 Z M832,64.7 L832,128 L768,128 L768,79.7 C768,71.4157288 761.284271,64.7 753,64.7 L640,64.7 L640,0.7 L768,0.7 C803.332514,0.733077738 831.966922,29.3674863 832,64.7 Z M448,64.7 L576,64.7 L576,0.7 L448,0.7 L448,64.7 Z M256,64.7 L384,64.7 L384,0.7 L256,0.7 L256,64.7 Z M960,192 L256,192 C220.667486,192.033078 192.033078,220.667486 192,256 L192,960 C192.033078,995.332514 220.667486,1023.96692 256,1024 L960,1024 C995.332514,1023.96692 1023.96692,995.332514 1024,960 L1024,256 C1023.96692,220.667486 995.332514,192.033078 960,192 Z M960,945 C960,953.284271 953.284271,960 945,960 L271,960 C262.715729,960 256,953.284271 256,945 L256,271 C256,262.715729 262.715729,256 271,256 L945,256 C953.284271,256 960,262.715729 960,271 L960,945 Z"
-                                />
-                              </svg>
-                            </BlueprintIcon>
+                                <FindRefWrapper
+                                  onFoundRef={[Function]}
+                                >
+                                  <BlueprintIcon
+                                    aria-describedby="pf-tooltip-1"
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  >
+                                    <svg
+                                      aria-describedby="pf-tooltip-1"
+                                      aria-hidden={true}
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M0,767.3 L0,640 L64,640 L64,752.3 C64,760.584271 70.7157288,767.3 79,767.3 L128,768.1 L128,832.1 L64,831.3 C28.6674863,831.266922 0.0330777378,802.632514 0,767.3 Z M64,0 L191.3,0 L191.3,64 L79,64 C70.7157288,64 64,70.7157288 64,79 L64,192 L0,192 L0,64 C0.0330777378,28.6674863 28.6674863,0.0330777378 64,0 Z M0,384 L64,384 L64,256 L0,256 L0,384 Z M0,576 L64,576 L64,448 L0,448 L0,576 Z M832,64.7 L832,128 L768,128 L768,79.7 C768,71.4157288 761.284271,64.7 753,64.7 L640,64.7 L640,0.7 L768,0.7 C803.332514,0.733077738 831.966922,29.3674863 832,64.7 Z M448,64.7 L576,64.7 L576,0.7 L448,0.7 L448,64.7 Z M256,64.7 L384,64.7 L384,0.7 L256,0.7 L256,64.7 Z M960,192 L256,192 C220.667486,192.033078 192.033078,220.667486 192,256 L192,960 C192.033078,995.332514 220.667486,1023.96692 256,1024 L960,1024 C995.332514,1023.96692 1023.96692,995.332514 1024,960 L1024,256 C1023.96692,220.667486 995.332514,192.033078 960,192 Z M960,945 C960,953.284271 953.284271,960 945,960 L271,960 C262.715729,960 256,953.284271 256,945 L256,271 C256,262.715729 262.715729,256 271,256 L945,256 C953.284271,256 960,262.715729 960,271 L960,945 Z"
+                                      />
+                                    </svg>
+                                  </BlueprintIcon>
+                                </FindRefWrapper>
+                              </Popper>
+                            </Tooltip>
                           </div>
                           <div
                             className="system-name"
@@ -1809,38 +1892,133 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                             className="system-updated-and-reference"
                           >
                             <ReferenceSelector
-                              id="9bbbefcc-8f23-4d97-07f2-142asdl234e9"
                               isReference={false}
+                              item={
+                                Object {
+                                  "display_name": "baseline1",
+                                  "id": "9bbbefcc-8f23-4d97-07f2-142asdl234e9",
+                                  "last_updated": "2019-01-15T14:53:15.886891Z",
+                                  "type": "baseline",
+                                }
+                              }
                               updateReferenceId={[Function]}
                             >
-                              <OutlinedStarIcon
-                                className="reference-selector pointer"
-                                color="currentColor"
-                                noVerticalAlign={false}
-                                onClick={[Function]}
-                                size="sm"
+                              <Tooltip
+                                content={
+                                  <div>
+                                    Use this 
+                                    baseline
+                                     as a reference to compare.
+                                  </div>
+                                }
+                                position="top"
                               >
-                                <svg
-                                  aria-hidden={true}
-                                  aria-labelledby={null}
-                                  className="reference-selector pointer"
-                                  fill="currentColor"
-                                  height="1em"
-                                  onClick={[Function]}
-                                  role="img"
-                                  style={
+                                <Popper
+                                  appendTo={[Function]}
+                                  distance={15}
+                                  enableFlip={true}
+                                  flipBehavior={
+                                    Array [
+                                      "top",
+                                      "right",
+                                      "bottom",
+                                      "left",
+                                      "top",
+                                      "right",
+                                      "bottom",
+                                    ]
+                                  }
+                                  isVisible={false}
+                                  onBlur={[Function]}
+                                  onDocumentClick={false}
+                                  onDocumentKeyDown={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  onTriggerEnter={[Function]}
+                                  placement="top"
+                                  popper={
+                                    <div
+                                      className="pf-c-tooltip"
+                                      id="pf-tooltip-2"
+                                      role="tooltip"
+                                      style={
+                                        Object {
+                                          "maxWidth": null,
+                                          "opacity": 0,
+                                          "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
+                                        }
+                                      }
+                                    >
+                                      <TooltipArrow />
+                                      <TooltipContent
+                                        isLeftAligned={false}
+                                      >
+                                        <div>
+                                          Use this 
+                                          baseline
+                                           as a reference to compare.
+                                        </div>
+                                      </TooltipContent>
+                                    </div>
+                                  }
+                                  popperMatchesTriggerWidth={false}
+                                  positionModifiers={
                                     Object {
-                                      "verticalAlign": "-0.125em",
+                                      "bottom": "pf-m-bottom",
+                                      "left": "pf-m-left",
+                                      "right": "pf-m-right",
+                                      "top": "pf-m-top",
                                     }
                                   }
-                                  viewBox="0 0 576 512"
-                                  width="1em"
+                                  trigger={
+                                    <OutlinedStarIcon
+                                      aria-describedby="pf-tooltip-2"
+                                      className="reference-selector pointer"
+                                      color="currentColor"
+                                      noVerticalAlign={false}
+                                      onClick={[Function]}
+                                      size="sm"
+                                    />
+                                  }
+                                  zIndex={9999}
                                 >
-                                  <path
-                                    d="M528.1 171.5L382 150.2 316.7 17.8c-11.7-23.6-45.6-23.9-57.4 0L194 150.2 47.9 171.5c-26.2 3.8-36.7 36.1-17.7 54.6l105.7 103-25 145.5c-4.5 26.3 23.2 46 46.4 33.7L288 439.6l130.7 68.7c23.2 12.2 50.9-7.4 46.4-33.7l-25-145.5 105.7-103c19-18.5 8.5-50.8-17.7-54.6zM388.6 312.3l23.7 138.4L288 385.4l-124.3 65.3 23.7-138.4-100.6-98 139-20.2 62.2-126 62.2 126 139 20.2-100.6 98z"
-                                  />
-                                </svg>
-                              </OutlinedStarIcon>
+                                  <FindRefWrapper
+                                    onFoundRef={[Function]}
+                                  >
+                                    <OutlinedStarIcon
+                                      aria-describedby="pf-tooltip-2"
+                                      className="reference-selector pointer"
+                                      color="currentColor"
+                                      noVerticalAlign={false}
+                                      onClick={[Function]}
+                                      size="sm"
+                                    >
+                                      <svg
+                                        aria-describedby="pf-tooltip-2"
+                                        aria-hidden={true}
+                                        aria-labelledby={null}
+                                        className="reference-selector pointer"
+                                        fill="currentColor"
+                                        height="1em"
+                                        onClick={[Function]}
+                                        role="img"
+                                        style={
+                                          Object {
+                                            "verticalAlign": "-0.125em",
+                                          }
+                                        }
+                                        viewBox="0 0 576 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M528.1 171.5L382 150.2 316.7 17.8c-11.7-23.6-45.6-23.9-57.4 0L194 150.2 47.9 171.5c-26.2 3.8-36.7 36.1-17.7 54.6l105.7 103-25 145.5c-4.5 26.3 23.2 46 46.4 33.7L288 439.6l130.7 68.7c23.2 12.2 50.9-7.4 46.4-33.7l-25-145.5 105.7-103c19-18.5 8.5-50.8-17.7-54.6zM388.6 312.3l23.7 138.4L288 385.4l-124.3 65.3 23.7-138.4-100.6-98 139-20.2 62.2-126 62.2 126 139 20.2-100.6 98z"
+                                        />
+                                      </svg>
+                                    </OutlinedStarIcon>
+                                  </FindRefWrapper>
+                                </Popper>
+                              </Tooltip>
                             </ReferenceSelector>
                             15 Jan 2019, 14:53 UTC
                           </div>
@@ -1888,30 +2066,112 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                           <div
                             className="drift-header-icon"
                           >
-                            <BlueprintIcon
-                              color="currentColor"
-                              noVerticalAlign={false}
-                              size="sm"
+                            <Tooltip
+                              content={
+                                <div>
+                                  Baseline
+                                </div>
+                              }
+                              position="top"
                             >
-                              <svg
-                                aria-hidden={true}
-                                aria-labelledby={null}
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                style={
+                              <Popper
+                                appendTo={[Function]}
+                                distance={15}
+                                enableFlip={true}
+                                flipBehavior={
+                                  Array [
+                                    "top",
+                                    "right",
+                                    "bottom",
+                                    "left",
+                                    "top",
+                                    "right",
+                                    "bottom",
+                                  ]
+                                }
+                                isVisible={false}
+                                onBlur={[Function]}
+                                onDocumentClick={false}
+                                onDocumentKeyDown={[Function]}
+                                onFocus={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                onTriggerEnter={[Function]}
+                                placement="top"
+                                popper={
+                                  <div
+                                    className="pf-c-tooltip"
+                                    id="pf-tooltip-3"
+                                    role="tooltip"
+                                    style={
+                                      Object {
+                                        "maxWidth": null,
+                                        "opacity": 0,
+                                        "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
+                                      }
+                                    }
+                                  >
+                                    <TooltipArrow />
+                                    <TooltipContent
+                                      isLeftAligned={false}
+                                    >
+                                      <div>
+                                        Baseline
+                                      </div>
+                                    </TooltipContent>
+                                  </div>
+                                }
+                                popperMatchesTriggerWidth={false}
+                                positionModifiers={
                                   Object {
-                                    "verticalAlign": "-0.125em",
+                                    "bottom": "pf-m-bottom",
+                                    "left": "pf-m-left",
+                                    "right": "pf-m-right",
+                                    "top": "pf-m-top",
                                   }
                                 }
-                                viewBox="0 0 1024 1024"
-                                width="1em"
+                                trigger={
+                                  <BlueprintIcon
+                                    aria-describedby="pf-tooltip-3"
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  />
+                                }
+                                zIndex={9999}
                               >
-                                <path
-                                  d="M0,767.3 L0,640 L64,640 L64,752.3 C64,760.584271 70.7157288,767.3 79,767.3 L128,768.1 L128,832.1 L64,831.3 C28.6674863,831.266922 0.0330777378,802.632514 0,767.3 Z M64,0 L191.3,0 L191.3,64 L79,64 C70.7157288,64 64,70.7157288 64,79 L64,192 L0,192 L0,64 C0.0330777378,28.6674863 28.6674863,0.0330777378 64,0 Z M0,384 L64,384 L64,256 L0,256 L0,384 Z M0,576 L64,576 L64,448 L0,448 L0,576 Z M832,64.7 L832,128 L768,128 L768,79.7 C768,71.4157288 761.284271,64.7 753,64.7 L640,64.7 L640,0.7 L768,0.7 C803.332514,0.733077738 831.966922,29.3674863 832,64.7 Z M448,64.7 L576,64.7 L576,0.7 L448,0.7 L448,64.7 Z M256,64.7 L384,64.7 L384,0.7 L256,0.7 L256,64.7 Z M960,192 L256,192 C220.667486,192.033078 192.033078,220.667486 192,256 L192,960 C192.033078,995.332514 220.667486,1023.96692 256,1024 L960,1024 C995.332514,1023.96692 1023.96692,995.332514 1024,960 L1024,256 C1023.96692,220.667486 995.332514,192.033078 960,192 Z M960,945 C960,953.284271 953.284271,960 945,960 L271,960 C262.715729,960 256,953.284271 256,945 L256,271 C256,262.715729 262.715729,256 271,256 L945,256 C953.284271,256 960,262.715729 960,271 L960,945 Z"
-                                />
-                              </svg>
-                            </BlueprintIcon>
+                                <FindRefWrapper
+                                  onFoundRef={[Function]}
+                                >
+                                  <BlueprintIcon
+                                    aria-describedby="pf-tooltip-3"
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  >
+                                    <svg
+                                      aria-describedby="pf-tooltip-3"
+                                      aria-hidden={true}
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M0,767.3 L0,640 L64,640 L64,752.3 C64,760.584271 70.7157288,767.3 79,767.3 L128,768.1 L128,832.1 L64,831.3 C28.6674863,831.266922 0.0330777378,802.632514 0,767.3 Z M64,0 L191.3,0 L191.3,64 L79,64 C70.7157288,64 64,70.7157288 64,79 L64,192 L0,192 L0,64 C0.0330777378,28.6674863 28.6674863,0.0330777378 64,0 Z M0,384 L64,384 L64,256 L0,256 L0,384 Z M0,576 L64,576 L64,448 L0,448 L0,576 Z M832,64.7 L832,128 L768,128 L768,79.7 C768,71.4157288 761.284271,64.7 753,64.7 L640,64.7 L640,0.7 L768,0.7 C803.332514,0.733077738 831.966922,29.3674863 832,64.7 Z M448,64.7 L576,64.7 L576,0.7 L448,0.7 L448,64.7 Z M256,64.7 L384,64.7 L384,0.7 L256,0.7 L256,64.7 Z M960,192 L256,192 C220.667486,192.033078 192.033078,220.667486 192,256 L192,960 C192.033078,995.332514 220.667486,1023.96692 256,1024 L960,1024 C995.332514,1023.96692 1023.96692,995.332514 1024,960 L1024,256 C1023.96692,220.667486 995.332514,192.033078 960,192 Z M960,945 C960,953.284271 953.284271,960 945,960 L271,960 C262.715729,960 256,953.284271 256,945 L256,271 C256,262.715729 262.715729,256 271,256 L945,256 C953.284271,256 960,262.715729 960,271 L960,945 Z"
+                                      />
+                                    </svg>
+                                  </BlueprintIcon>
+                                </FindRefWrapper>
+                              </Popper>
+                            </Tooltip>
                           </div>
                           <div
                             className="system-name"
@@ -1922,38 +2182,133 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                             className="system-updated-and-reference"
                           >
                             <ReferenceSelector
-                              id="fdmk59dj-fn42-dfjk-alv3-bmn2854mnn29"
                               isReference={false}
+                              item={
+                                Object {
+                                  "display_name": "baseline2",
+                                  "id": "fdmk59dj-fn42-dfjk-alv3-bmn2854mnn29",
+                                  "last_updated": "2019-01-15T15:25:16.304899Z",
+                                  "type": "baseline",
+                                }
+                              }
                               updateReferenceId={[Function]}
                             >
-                              <OutlinedStarIcon
-                                className="reference-selector pointer"
-                                color="currentColor"
-                                noVerticalAlign={false}
-                                onClick={[Function]}
-                                size="sm"
+                              <Tooltip
+                                content={
+                                  <div>
+                                    Use this 
+                                    baseline
+                                     as a reference to compare.
+                                  </div>
+                                }
+                                position="top"
                               >
-                                <svg
-                                  aria-hidden={true}
-                                  aria-labelledby={null}
-                                  className="reference-selector pointer"
-                                  fill="currentColor"
-                                  height="1em"
-                                  onClick={[Function]}
-                                  role="img"
-                                  style={
+                                <Popper
+                                  appendTo={[Function]}
+                                  distance={15}
+                                  enableFlip={true}
+                                  flipBehavior={
+                                    Array [
+                                      "top",
+                                      "right",
+                                      "bottom",
+                                      "left",
+                                      "top",
+                                      "right",
+                                      "bottom",
+                                    ]
+                                  }
+                                  isVisible={false}
+                                  onBlur={[Function]}
+                                  onDocumentClick={false}
+                                  onDocumentKeyDown={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  onTriggerEnter={[Function]}
+                                  placement="top"
+                                  popper={
+                                    <div
+                                      className="pf-c-tooltip"
+                                      id="pf-tooltip-4"
+                                      role="tooltip"
+                                      style={
+                                        Object {
+                                          "maxWidth": null,
+                                          "opacity": 0,
+                                          "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
+                                        }
+                                      }
+                                    >
+                                      <TooltipArrow />
+                                      <TooltipContent
+                                        isLeftAligned={false}
+                                      >
+                                        <div>
+                                          Use this 
+                                          baseline
+                                           as a reference to compare.
+                                        </div>
+                                      </TooltipContent>
+                                    </div>
+                                  }
+                                  popperMatchesTriggerWidth={false}
+                                  positionModifiers={
                                     Object {
-                                      "verticalAlign": "-0.125em",
+                                      "bottom": "pf-m-bottom",
+                                      "left": "pf-m-left",
+                                      "right": "pf-m-right",
+                                      "top": "pf-m-top",
                                     }
                                   }
-                                  viewBox="0 0 576 512"
-                                  width="1em"
+                                  trigger={
+                                    <OutlinedStarIcon
+                                      aria-describedby="pf-tooltip-4"
+                                      className="reference-selector pointer"
+                                      color="currentColor"
+                                      noVerticalAlign={false}
+                                      onClick={[Function]}
+                                      size="sm"
+                                    />
+                                  }
+                                  zIndex={9999}
                                 >
-                                  <path
-                                    d="M528.1 171.5L382 150.2 316.7 17.8c-11.7-23.6-45.6-23.9-57.4 0L194 150.2 47.9 171.5c-26.2 3.8-36.7 36.1-17.7 54.6l105.7 103-25 145.5c-4.5 26.3 23.2 46 46.4 33.7L288 439.6l130.7 68.7c23.2 12.2 50.9-7.4 46.4-33.7l-25-145.5 105.7-103c19-18.5 8.5-50.8-17.7-54.6zM388.6 312.3l23.7 138.4L288 385.4l-124.3 65.3 23.7-138.4-100.6-98 139-20.2 62.2-126 62.2 126 139 20.2-100.6 98z"
-                                  />
-                                </svg>
-                              </OutlinedStarIcon>
+                                  <FindRefWrapper
+                                    onFoundRef={[Function]}
+                                  >
+                                    <OutlinedStarIcon
+                                      aria-describedby="pf-tooltip-4"
+                                      className="reference-selector pointer"
+                                      color="currentColor"
+                                      noVerticalAlign={false}
+                                      onClick={[Function]}
+                                      size="sm"
+                                    >
+                                      <svg
+                                        aria-describedby="pf-tooltip-4"
+                                        aria-hidden={true}
+                                        aria-labelledby={null}
+                                        className="reference-selector pointer"
+                                        fill="currentColor"
+                                        height="1em"
+                                        onClick={[Function]}
+                                        role="img"
+                                        style={
+                                          Object {
+                                            "verticalAlign": "-0.125em",
+                                          }
+                                        }
+                                        viewBox="0 0 576 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M528.1 171.5L382 150.2 316.7 17.8c-11.7-23.6-45.6-23.9-57.4 0L194 150.2 47.9 171.5c-26.2 3.8-36.7 36.1-17.7 54.6l105.7 103-25 145.5c-4.5 26.3 23.2 46 46.4 33.7L288 439.6l130.7 68.7c23.2 12.2 50.9-7.4 46.4-33.7l-25-145.5 105.7-103c19-18.5 8.5-50.8-17.7-54.6zM388.6 312.3l23.7 138.4L288 385.4l-124.3 65.3 23.7-138.4-100.6-98 139-20.2 62.2-126 62.2 126 139 20.2-100.6 98z"
+                                        />
+                                      </svg>
+                                    </OutlinedStarIcon>
+                                  </FindRefWrapper>
+                                </Popper>
+                              </Tooltip>
                             </ReferenceSelector>
                             15 Jan 2019, 15:25 UTC
                           </div>
@@ -2001,30 +2356,112 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                           <div
                             className="drift-header-icon"
                           >
-                            <ServerIcon
-                              color="currentColor"
-                              noVerticalAlign={false}
-                              size="sm"
+                            <Tooltip
+                              content={
+                                <div>
+                                  System
+                                </div>
+                              }
+                              position="top"
                             >
-                              <svg
-                                aria-hidden={true}
-                                aria-labelledby={null}
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                style={
+                              <Popper
+                                appendTo={[Function]}
+                                distance={15}
+                                enableFlip={true}
+                                flipBehavior={
+                                  Array [
+                                    "top",
+                                    "right",
+                                    "bottom",
+                                    "left",
+                                    "top",
+                                    "right",
+                                    "bottom",
+                                  ]
+                                }
+                                isVisible={false}
+                                onBlur={[Function]}
+                                onDocumentClick={false}
+                                onDocumentKeyDown={[Function]}
+                                onFocus={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                onTriggerEnter={[Function]}
+                                placement="top"
+                                popper={
+                                  <div
+                                    className="pf-c-tooltip"
+                                    id="pf-tooltip-5"
+                                    role="tooltip"
+                                    style={
+                                      Object {
+                                        "maxWidth": null,
+                                        "opacity": 0,
+                                        "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
+                                      }
+                                    }
+                                  >
+                                    <TooltipArrow />
+                                    <TooltipContent
+                                      isLeftAligned={false}
+                                    >
+                                      <div>
+                                        System
+                                      </div>
+                                    </TooltipContent>
+                                  </div>
+                                }
+                                popperMatchesTriggerWidth={false}
+                                positionModifiers={
                                   Object {
-                                    "verticalAlign": "-0.125em",
+                                    "bottom": "pf-m-bottom",
+                                    "left": "pf-m-left",
+                                    "right": "pf-m-right",
+                                    "top": "pf-m-top",
                                   }
                                 }
-                                viewBox="0 0 512 512"
-                                width="1em"
+                                trigger={
+                                  <ServerIcon
+                                    aria-describedby="pf-tooltip-5"
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  />
+                                }
+                                zIndex={9999}
                               >
-                                <path
-                                  d="M480 160H32c-17.673 0-32-14.327-32-32V64c0-17.673 14.327-32 32-32h448c17.673 0 32 14.327 32 32v64c0 17.673-14.327 32-32 32zm-48-88c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm-64 0c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm112 248H32c-17.673 0-32-14.327-32-32v-64c0-17.673 14.327-32 32-32h448c17.673 0 32 14.327 32 32v64c0 17.673-14.327 32-32 32zm-48-88c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm-64 0c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm112 248H32c-17.673 0-32-14.327-32-32v-64c0-17.673 14.327-32 32-32h448c17.673 0 32 14.327 32 32v64c0 17.673-14.327 32-32 32zm-48-88c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm-64 0c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24z"
-                                />
-                              </svg>
-                            </ServerIcon>
+                                <FindRefWrapper
+                                  onFoundRef={[Function]}
+                                >
+                                  <ServerIcon
+                                    aria-describedby="pf-tooltip-5"
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  >
+                                    <svg
+                                      aria-describedby="pf-tooltip-5"
+                                      aria-hidden={true}
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 512 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M480 160H32c-17.673 0-32-14.327-32-32V64c0-17.673 14.327-32 32-32h448c17.673 0 32 14.327 32 32v64c0 17.673-14.327 32-32 32zm-48-88c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm-64 0c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm112 248H32c-17.673 0-32-14.327-32-32v-64c0-17.673 14.327-32 32-32h448c17.673 0 32 14.327 32 32v64c0 17.673-14.327 32-32 32zm-48-88c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm-64 0c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm112 248H32c-17.673 0-32-14.327-32-32v-64c0-17.673 14.327-32 32-32h448c17.673 0 32 14.327 32 32v64c0 17.673-14.327 32-32 32zm-48-88c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm-64 0c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24z"
+                                      />
+                                    </svg>
+                                  </ServerIcon>
+                                </FindRefWrapper>
+                              </Popper>
+                            </Tooltip>
                           </div>
                           <div
                             className="system-name"
@@ -2035,38 +2472,133 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                             className="system-updated-and-reference"
                           >
                             <ReferenceSelector
-                              id="9c79efcc-8f9a-47c7-b0f2-142ff52e89e9"
                               isReference={false}
+                              item={
+                                Object {
+                                  "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
+                                  "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+                                  "last_updated": "2019-01-15T14:53:15.886891Z",
+                                  "type": "system",
+                                }
+                              }
                               updateReferenceId={[Function]}
                             >
-                              <OutlinedStarIcon
-                                className="reference-selector pointer"
-                                color="currentColor"
-                                noVerticalAlign={false}
-                                onClick={[Function]}
-                                size="sm"
+                              <Tooltip
+                                content={
+                                  <div>
+                                    Use this 
+                                    system
+                                     as a reference to compare.
+                                  </div>
+                                }
+                                position="top"
                               >
-                                <svg
-                                  aria-hidden={true}
-                                  aria-labelledby={null}
-                                  className="reference-selector pointer"
-                                  fill="currentColor"
-                                  height="1em"
-                                  onClick={[Function]}
-                                  role="img"
-                                  style={
+                                <Popper
+                                  appendTo={[Function]}
+                                  distance={15}
+                                  enableFlip={true}
+                                  flipBehavior={
+                                    Array [
+                                      "top",
+                                      "right",
+                                      "bottom",
+                                      "left",
+                                      "top",
+                                      "right",
+                                      "bottom",
+                                    ]
+                                  }
+                                  isVisible={false}
+                                  onBlur={[Function]}
+                                  onDocumentClick={false}
+                                  onDocumentKeyDown={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  onTriggerEnter={[Function]}
+                                  placement="top"
+                                  popper={
+                                    <div
+                                      className="pf-c-tooltip"
+                                      id="pf-tooltip-6"
+                                      role="tooltip"
+                                      style={
+                                        Object {
+                                          "maxWidth": null,
+                                          "opacity": 0,
+                                          "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
+                                        }
+                                      }
+                                    >
+                                      <TooltipArrow />
+                                      <TooltipContent
+                                        isLeftAligned={false}
+                                      >
+                                        <div>
+                                          Use this 
+                                          system
+                                           as a reference to compare.
+                                        </div>
+                                      </TooltipContent>
+                                    </div>
+                                  }
+                                  popperMatchesTriggerWidth={false}
+                                  positionModifiers={
                                     Object {
-                                      "verticalAlign": "-0.125em",
+                                      "bottom": "pf-m-bottom",
+                                      "left": "pf-m-left",
+                                      "right": "pf-m-right",
+                                      "top": "pf-m-top",
                                     }
                                   }
-                                  viewBox="0 0 576 512"
-                                  width="1em"
+                                  trigger={
+                                    <OutlinedStarIcon
+                                      aria-describedby="pf-tooltip-6"
+                                      className="reference-selector pointer"
+                                      color="currentColor"
+                                      noVerticalAlign={false}
+                                      onClick={[Function]}
+                                      size="sm"
+                                    />
+                                  }
+                                  zIndex={9999}
                                 >
-                                  <path
-                                    d="M528.1 171.5L382 150.2 316.7 17.8c-11.7-23.6-45.6-23.9-57.4 0L194 150.2 47.9 171.5c-26.2 3.8-36.7 36.1-17.7 54.6l105.7 103-25 145.5c-4.5 26.3 23.2 46 46.4 33.7L288 439.6l130.7 68.7c23.2 12.2 50.9-7.4 46.4-33.7l-25-145.5 105.7-103c19-18.5 8.5-50.8-17.7-54.6zM388.6 312.3l23.7 138.4L288 385.4l-124.3 65.3 23.7-138.4-100.6-98 139-20.2 62.2-126 62.2 126 139 20.2-100.6 98z"
-                                  />
-                                </svg>
-                              </OutlinedStarIcon>
+                                  <FindRefWrapper
+                                    onFoundRef={[Function]}
+                                  >
+                                    <OutlinedStarIcon
+                                      aria-describedby="pf-tooltip-6"
+                                      className="reference-selector pointer"
+                                      color="currentColor"
+                                      noVerticalAlign={false}
+                                      onClick={[Function]}
+                                      size="sm"
+                                    >
+                                      <svg
+                                        aria-describedby="pf-tooltip-6"
+                                        aria-hidden={true}
+                                        aria-labelledby={null}
+                                        className="reference-selector pointer"
+                                        fill="currentColor"
+                                        height="1em"
+                                        onClick={[Function]}
+                                        role="img"
+                                        style={
+                                          Object {
+                                            "verticalAlign": "-0.125em",
+                                          }
+                                        }
+                                        viewBox="0 0 576 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M528.1 171.5L382 150.2 316.7 17.8c-11.7-23.6-45.6-23.9-57.4 0L194 150.2 47.9 171.5c-26.2 3.8-36.7 36.1-17.7 54.6l105.7 103-25 145.5c-4.5 26.3 23.2 46 46.4 33.7L288 439.6l130.7 68.7c23.2 12.2 50.9-7.4 46.4-33.7l-25-145.5 105.7-103c19-18.5 8.5-50.8-17.7-54.6zM388.6 312.3l23.7 138.4L288 385.4l-124.3 65.3 23.7-138.4-100.6-98 139-20.2 62.2-126 62.2 126 139 20.2-100.6 98z"
+                                        />
+                                      </svg>
+                                    </OutlinedStarIcon>
+                                  </FindRefWrapper>
+                                </Popper>
+                              </Tooltip>
                             </ReferenceSelector>
                             15 Jan 2019, 14:53 UTC
                             <withRouter(Connect(HistoricalProfilesDropdown))
@@ -2487,30 +3019,112 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                           <div
                             className="drift-header-icon"
                           >
-                            <ClockIcon
-                              color="currentColor"
-                              noVerticalAlign={false}
-                              size="sm"
+                            <Tooltip
+                              content={
+                                <div>
+                                  Historical system
+                                </div>
+                              }
+                              position="top"
                             >
-                              <svg
-                                aria-hidden={true}
-                                aria-labelledby={null}
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                style={
+                              <Popper
+                                appendTo={[Function]}
+                                distance={15}
+                                enableFlip={true}
+                                flipBehavior={
+                                  Array [
+                                    "top",
+                                    "right",
+                                    "bottom",
+                                    "left",
+                                    "top",
+                                    "right",
+                                    "bottom",
+                                  ]
+                                }
+                                isVisible={false}
+                                onBlur={[Function]}
+                                onDocumentClick={false}
+                                onDocumentKeyDown={[Function]}
+                                onFocus={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                onTriggerEnter={[Function]}
+                                placement="top"
+                                popper={
+                                  <div
+                                    className="pf-c-tooltip"
+                                    id="pf-tooltip-7"
+                                    role="tooltip"
+                                    style={
+                                      Object {
+                                        "maxWidth": null,
+                                        "opacity": 0,
+                                        "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
+                                      }
+                                    }
+                                  >
+                                    <TooltipArrow />
+                                    <TooltipContent
+                                      isLeftAligned={false}
+                                    >
+                                      <div>
+                                        Historical system
+                                      </div>
+                                    </TooltipContent>
+                                  </div>
+                                }
+                                popperMatchesTriggerWidth={false}
+                                positionModifiers={
                                   Object {
-                                    "verticalAlign": "-0.125em",
+                                    "bottom": "pf-m-bottom",
+                                    "left": "pf-m-left",
+                                    "right": "pf-m-right",
+                                    "top": "pf-m-top",
                                   }
                                 }
-                                viewBox="0 0 512 512"
-                                width="1em"
+                                trigger={
+                                  <ClockIcon
+                                    aria-describedby="pf-tooltip-7"
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  />
+                                }
+                                zIndex={9999}
                               >
-                                <path
-                                  d="M256,8C119,8,8,119,8,256S119,504,256,504,504,393,504,256,393,8,256,8Zm92.49,313h0l-20,25a16,16,0,0,1-22.49,2.5h0l-67-49.72a40,40,0,0,1-15-31.23V112a16,16,0,0,1,16-16h32a16,16,0,0,1,16,16V256l58,42.5A16,16,0,0,1,348.49,321Z"
-                                />
-                              </svg>
-                            </ClockIcon>
+                                <FindRefWrapper
+                                  onFoundRef={[Function]}
+                                >
+                                  <ClockIcon
+                                    aria-describedby="pf-tooltip-7"
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  >
+                                    <svg
+                                      aria-describedby="pf-tooltip-7"
+                                      aria-hidden={true}
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 512 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M256,8C119,8,8,119,8,256S119,504,256,504,504,393,504,256,393,8,256,8Zm92.49,313h0l-20,25a16,16,0,0,1-22.49,2.5h0l-67-49.72a40,40,0,0,1-15-31.23V112a16,16,0,0,1,16-16h32a16,16,0,0,1,16,16V256l58,42.5A16,16,0,0,1,348.49,321Z"
+                                      />
+                                    </svg>
+                                  </ClockIcon>
+                                </FindRefWrapper>
+                              </Popper>
+                            </Tooltip>
                           </div>
                           <div
                             className="system-name"
@@ -2521,38 +3135,134 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                             className="system-updated-and-reference"
                           >
                             <ReferenceSelector
-                              id="9bbbefcc-8f23-4d97-07f2-142asdl234e8"
                               isReference={false}
+                              item={
+                                Object {
+                                  "display_name": "system1",
+                                  "id": "9bbbefcc-8f23-4d97-07f2-142asdl234e8",
+                                  "last_updated": "2019-01-15T14:53:15.886891Z",
+                                  "system_id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+                                  "type": "historical-system-profile",
+                                }
+                              }
                               updateReferenceId={[Function]}
                             >
-                              <OutlinedStarIcon
-                                className="reference-selector pointer"
-                                color="currentColor"
-                                noVerticalAlign={false}
-                                onClick={[Function]}
-                                size="sm"
+                              <Tooltip
+                                content={
+                                  <div>
+                                    Use this 
+                                    historical system
+                                     as a reference to compare.
+                                  </div>
+                                }
+                                position="top"
                               >
-                                <svg
-                                  aria-hidden={true}
-                                  aria-labelledby={null}
-                                  className="reference-selector pointer"
-                                  fill="currentColor"
-                                  height="1em"
-                                  onClick={[Function]}
-                                  role="img"
-                                  style={
+                                <Popper
+                                  appendTo={[Function]}
+                                  distance={15}
+                                  enableFlip={true}
+                                  flipBehavior={
+                                    Array [
+                                      "top",
+                                      "right",
+                                      "bottom",
+                                      "left",
+                                      "top",
+                                      "right",
+                                      "bottom",
+                                    ]
+                                  }
+                                  isVisible={false}
+                                  onBlur={[Function]}
+                                  onDocumentClick={false}
+                                  onDocumentKeyDown={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  onTriggerEnter={[Function]}
+                                  placement="top"
+                                  popper={
+                                    <div
+                                      className="pf-c-tooltip"
+                                      id="pf-tooltip-8"
+                                      role="tooltip"
+                                      style={
+                                        Object {
+                                          "maxWidth": null,
+                                          "opacity": 0,
+                                          "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
+                                        }
+                                      }
+                                    >
+                                      <TooltipArrow />
+                                      <TooltipContent
+                                        isLeftAligned={false}
+                                      >
+                                        <div>
+                                          Use this 
+                                          historical system
+                                           as a reference to compare.
+                                        </div>
+                                      </TooltipContent>
+                                    </div>
+                                  }
+                                  popperMatchesTriggerWidth={false}
+                                  positionModifiers={
                                     Object {
-                                      "verticalAlign": "-0.125em",
+                                      "bottom": "pf-m-bottom",
+                                      "left": "pf-m-left",
+                                      "right": "pf-m-right",
+                                      "top": "pf-m-top",
                                     }
                                   }
-                                  viewBox="0 0 576 512"
-                                  width="1em"
+                                  trigger={
+                                    <OutlinedStarIcon
+                                      aria-describedby="pf-tooltip-8"
+                                      className="reference-selector pointer"
+                                      color="currentColor"
+                                      noVerticalAlign={false}
+                                      onClick={[Function]}
+                                      size="sm"
+                                    />
+                                  }
+                                  zIndex={9999}
                                 >
-                                  <path
-                                    d="M528.1 171.5L382 150.2 316.7 17.8c-11.7-23.6-45.6-23.9-57.4 0L194 150.2 47.9 171.5c-26.2 3.8-36.7 36.1-17.7 54.6l105.7 103-25 145.5c-4.5 26.3 23.2 46 46.4 33.7L288 439.6l130.7 68.7c23.2 12.2 50.9-7.4 46.4-33.7l-25-145.5 105.7-103c19-18.5 8.5-50.8-17.7-54.6zM388.6 312.3l23.7 138.4L288 385.4l-124.3 65.3 23.7-138.4-100.6-98 139-20.2 62.2-126 62.2 126 139 20.2-100.6 98z"
-                                  />
-                                </svg>
-                              </OutlinedStarIcon>
+                                  <FindRefWrapper
+                                    onFoundRef={[Function]}
+                                  >
+                                    <OutlinedStarIcon
+                                      aria-describedby="pf-tooltip-8"
+                                      className="reference-selector pointer"
+                                      color="currentColor"
+                                      noVerticalAlign={false}
+                                      onClick={[Function]}
+                                      size="sm"
+                                    >
+                                      <svg
+                                        aria-describedby="pf-tooltip-8"
+                                        aria-hidden={true}
+                                        aria-labelledby={null}
+                                        className="reference-selector pointer"
+                                        fill="currentColor"
+                                        height="1em"
+                                        onClick={[Function]}
+                                        role="img"
+                                        style={
+                                          Object {
+                                            "verticalAlign": "-0.125em",
+                                          }
+                                        }
+                                        viewBox="0 0 576 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M528.1 171.5L382 150.2 316.7 17.8c-11.7-23.6-45.6-23.9-57.4 0L194 150.2 47.9 171.5c-26.2 3.8-36.7 36.1-17.7 54.6l105.7 103-25 145.5c-4.5 26.3 23.2 46 46.4 33.7L288 439.6l130.7 68.7c23.2 12.2 50.9-7.4 46.4-33.7l-25-145.5 105.7-103c19-18.5 8.5-50.8-17.7-54.6zM388.6 312.3l23.7 138.4L288 385.4l-124.3 65.3 23.7-138.4-100.6-98 139-20.2 62.2-126 62.2 126 139 20.2-100.6 98z"
+                                        />
+                                      </svg>
+                                    </OutlinedStarIcon>
+                                  </FindRefWrapper>
+                                </Popper>
+                              </Tooltip>
                             </ReferenceSelector>
                             15 Jan 2019, 14:53 UTC
                             <withRouter(Connect(HistoricalProfilesDropdown))
@@ -2976,30 +3686,112 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                           <div
                             className="drift-header-icon"
                           >
-                            <ClockIcon
-                              color="currentColor"
-                              noVerticalAlign={false}
-                              size="sm"
+                            <Tooltip
+                              content={
+                                <div>
+                                  Historical system
+                                </div>
+                              }
+                              position="top"
                             >
-                              <svg
-                                aria-hidden={true}
-                                aria-labelledby={null}
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                style={
+                              <Popper
+                                appendTo={[Function]}
+                                distance={15}
+                                enableFlip={true}
+                                flipBehavior={
+                                  Array [
+                                    "top",
+                                    "right",
+                                    "bottom",
+                                    "left",
+                                    "top",
+                                    "right",
+                                    "bottom",
+                                  ]
+                                }
+                                isVisible={false}
+                                onBlur={[Function]}
+                                onDocumentClick={false}
+                                onDocumentKeyDown={[Function]}
+                                onFocus={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                onTriggerEnter={[Function]}
+                                placement="top"
+                                popper={
+                                  <div
+                                    className="pf-c-tooltip"
+                                    id="pf-tooltip-9"
+                                    role="tooltip"
+                                    style={
+                                      Object {
+                                        "maxWidth": null,
+                                        "opacity": 0,
+                                        "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
+                                      }
+                                    }
+                                  >
+                                    <TooltipArrow />
+                                    <TooltipContent
+                                      isLeftAligned={false}
+                                    >
+                                      <div>
+                                        Historical system
+                                      </div>
+                                    </TooltipContent>
+                                  </div>
+                                }
+                                popperMatchesTriggerWidth={false}
+                                positionModifiers={
                                   Object {
-                                    "verticalAlign": "-0.125em",
+                                    "bottom": "pf-m-bottom",
+                                    "left": "pf-m-left",
+                                    "right": "pf-m-right",
+                                    "top": "pf-m-top",
                                   }
                                 }
-                                viewBox="0 0 512 512"
-                                width="1em"
+                                trigger={
+                                  <ClockIcon
+                                    aria-describedby="pf-tooltip-9"
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  />
+                                }
+                                zIndex={9999}
                               >
-                                <path
-                                  d="M256,8C119,8,8,119,8,256S119,504,256,504,504,393,504,256,393,8,256,8Zm92.49,313h0l-20,25a16,16,0,0,1-22.49,2.5h0l-67-49.72a40,40,0,0,1-15-31.23V112a16,16,0,0,1,16-16h32a16,16,0,0,1,16,16V256l58,42.5A16,16,0,0,1,348.49,321Z"
-                                />
-                              </svg>
-                            </ClockIcon>
+                                <FindRefWrapper
+                                  onFoundRef={[Function]}
+                                >
+                                  <ClockIcon
+                                    aria-describedby="pf-tooltip-9"
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  >
+                                    <svg
+                                      aria-describedby="pf-tooltip-9"
+                                      aria-hidden={true}
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 512 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M256,8C119,8,8,119,8,256S119,504,256,504,504,393,504,256,393,8,256,8Zm92.49,313h0l-20,25a16,16,0,0,1-22.49,2.5h0l-67-49.72a40,40,0,0,1-15-31.23V112a16,16,0,0,1,16-16h32a16,16,0,0,1,16,16V256l58,42.5A16,16,0,0,1,348.49,321Z"
+                                      />
+                                    </svg>
+                                  </ClockIcon>
+                                </FindRefWrapper>
+                              </Popper>
+                            </Tooltip>
                           </div>
                           <div
                             className="system-name"
@@ -3010,38 +3802,134 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                             className="system-updated-and-reference"
                           >
                             <ReferenceSelector
-                              id="edmk59dj-fn42-dfjk-alv3-bmn2854mnn27"
                               isReference={false}
+                              item={
+                                Object {
+                                  "display_name": "system1",
+                                  "id": "edmk59dj-fn42-dfjk-alv3-bmn2854mnn27",
+                                  "last_updated": "2019-01-15T15:25:16.304899Z",
+                                  "system_id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+                                  "type": "historical-system-profile",
+                                }
+                              }
                               updateReferenceId={[Function]}
                             >
-                              <OutlinedStarIcon
-                                className="reference-selector pointer"
-                                color="currentColor"
-                                noVerticalAlign={false}
-                                onClick={[Function]}
-                                size="sm"
+                              <Tooltip
+                                content={
+                                  <div>
+                                    Use this 
+                                    historical system
+                                     as a reference to compare.
+                                  </div>
+                                }
+                                position="top"
                               >
-                                <svg
-                                  aria-hidden={true}
-                                  aria-labelledby={null}
-                                  className="reference-selector pointer"
-                                  fill="currentColor"
-                                  height="1em"
-                                  onClick={[Function]}
-                                  role="img"
-                                  style={
+                                <Popper
+                                  appendTo={[Function]}
+                                  distance={15}
+                                  enableFlip={true}
+                                  flipBehavior={
+                                    Array [
+                                      "top",
+                                      "right",
+                                      "bottom",
+                                      "left",
+                                      "top",
+                                      "right",
+                                      "bottom",
+                                    ]
+                                  }
+                                  isVisible={false}
+                                  onBlur={[Function]}
+                                  onDocumentClick={false}
+                                  onDocumentKeyDown={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  onTriggerEnter={[Function]}
+                                  placement="top"
+                                  popper={
+                                    <div
+                                      className="pf-c-tooltip"
+                                      id="pf-tooltip-10"
+                                      role="tooltip"
+                                      style={
+                                        Object {
+                                          "maxWidth": null,
+                                          "opacity": 0,
+                                          "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
+                                        }
+                                      }
+                                    >
+                                      <TooltipArrow />
+                                      <TooltipContent
+                                        isLeftAligned={false}
+                                      >
+                                        <div>
+                                          Use this 
+                                          historical system
+                                           as a reference to compare.
+                                        </div>
+                                      </TooltipContent>
+                                    </div>
+                                  }
+                                  popperMatchesTriggerWidth={false}
+                                  positionModifiers={
                                     Object {
-                                      "verticalAlign": "-0.125em",
+                                      "bottom": "pf-m-bottom",
+                                      "left": "pf-m-left",
+                                      "right": "pf-m-right",
+                                      "top": "pf-m-top",
                                     }
                                   }
-                                  viewBox="0 0 576 512"
-                                  width="1em"
+                                  trigger={
+                                    <OutlinedStarIcon
+                                      aria-describedby="pf-tooltip-10"
+                                      className="reference-selector pointer"
+                                      color="currentColor"
+                                      noVerticalAlign={false}
+                                      onClick={[Function]}
+                                      size="sm"
+                                    />
+                                  }
+                                  zIndex={9999}
                                 >
-                                  <path
-                                    d="M528.1 171.5L382 150.2 316.7 17.8c-11.7-23.6-45.6-23.9-57.4 0L194 150.2 47.9 171.5c-26.2 3.8-36.7 36.1-17.7 54.6l105.7 103-25 145.5c-4.5 26.3 23.2 46 46.4 33.7L288 439.6l130.7 68.7c23.2 12.2 50.9-7.4 46.4-33.7l-25-145.5 105.7-103c19-18.5 8.5-50.8-17.7-54.6zM388.6 312.3l23.7 138.4L288 385.4l-124.3 65.3 23.7-138.4-100.6-98 139-20.2 62.2-126 62.2 126 139 20.2-100.6 98z"
-                                  />
-                                </svg>
-                              </OutlinedStarIcon>
+                                  <FindRefWrapper
+                                    onFoundRef={[Function]}
+                                  >
+                                    <OutlinedStarIcon
+                                      aria-describedby="pf-tooltip-10"
+                                      className="reference-selector pointer"
+                                      color="currentColor"
+                                      noVerticalAlign={false}
+                                      onClick={[Function]}
+                                      size="sm"
+                                    >
+                                      <svg
+                                        aria-describedby="pf-tooltip-10"
+                                        aria-hidden={true}
+                                        aria-labelledby={null}
+                                        className="reference-selector pointer"
+                                        fill="currentColor"
+                                        height="1em"
+                                        onClick={[Function]}
+                                        role="img"
+                                        style={
+                                          Object {
+                                            "verticalAlign": "-0.125em",
+                                          }
+                                        }
+                                        viewBox="0 0 576 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M528.1 171.5L382 150.2 316.7 17.8c-11.7-23.6-45.6-23.9-57.4 0L194 150.2 47.9 171.5c-26.2 3.8-36.7 36.1-17.7 54.6l105.7 103-25 145.5c-4.5 26.3 23.2 46 46.4 33.7L288 439.6l130.7 68.7c23.2 12.2 50.9-7.4 46.4-33.7l-25-145.5 105.7-103c19-18.5 8.5-50.8-17.7-54.6zM388.6 312.3l23.7 138.4L288 385.4l-124.3 65.3 23.7-138.4-100.6-98 139-20.2 62.2-126 62.2 126 139 20.2-100.6 98z"
+                                        />
+                                      </svg>
+                                    </OutlinedStarIcon>
+                                  </FindRefWrapper>
+                                </Popper>
+                              </Tooltip>
                             </ReferenceSelector>
                             15 Jan 2019, 15:25 UTC
                             <withRouter(Connect(HistoricalProfilesDropdown))
@@ -3465,30 +4353,112 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                           <div
                             className="drift-header-icon"
                           >
-                            <ServerIcon
-                              color="currentColor"
-                              noVerticalAlign={false}
-                              size="sm"
+                            <Tooltip
+                              content={
+                                <div>
+                                  System
+                                </div>
+                              }
+                              position="top"
                             >
-                              <svg
-                                aria-hidden={true}
-                                aria-labelledby={null}
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                style={
+                              <Popper
+                                appendTo={[Function]}
+                                distance={15}
+                                enableFlip={true}
+                                flipBehavior={
+                                  Array [
+                                    "top",
+                                    "right",
+                                    "bottom",
+                                    "left",
+                                    "top",
+                                    "right",
+                                    "bottom",
+                                  ]
+                                }
+                                isVisible={false}
+                                onBlur={[Function]}
+                                onDocumentClick={false}
+                                onDocumentKeyDown={[Function]}
+                                onFocus={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                onTriggerEnter={[Function]}
+                                placement="top"
+                                popper={
+                                  <div
+                                    className="pf-c-tooltip"
+                                    id="pf-tooltip-11"
+                                    role="tooltip"
+                                    style={
+                                      Object {
+                                        "maxWidth": null,
+                                        "opacity": 0,
+                                        "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
+                                      }
+                                    }
+                                  >
+                                    <TooltipArrow />
+                                    <TooltipContent
+                                      isLeftAligned={false}
+                                    >
+                                      <div>
+                                        System
+                                      </div>
+                                    </TooltipContent>
+                                  </div>
+                                }
+                                popperMatchesTriggerWidth={false}
+                                positionModifiers={
                                   Object {
-                                    "verticalAlign": "-0.125em",
+                                    "bottom": "pf-m-bottom",
+                                    "left": "pf-m-left",
+                                    "right": "pf-m-right",
+                                    "top": "pf-m-top",
                                   }
                                 }
-                                viewBox="0 0 512 512"
-                                width="1em"
+                                trigger={
+                                  <ServerIcon
+                                    aria-describedby="pf-tooltip-11"
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  />
+                                }
+                                zIndex={9999}
                               >
-                                <path
-                                  d="M480 160H32c-17.673 0-32-14.327-32-32V64c0-17.673 14.327-32 32-32h448c17.673 0 32 14.327 32 32v64c0 17.673-14.327 32-32 32zm-48-88c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm-64 0c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm112 248H32c-17.673 0-32-14.327-32-32v-64c0-17.673 14.327-32 32-32h448c17.673 0 32 14.327 32 32v64c0 17.673-14.327 32-32 32zm-48-88c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm-64 0c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm112 248H32c-17.673 0-32-14.327-32-32v-64c0-17.673 14.327-32 32-32h448c17.673 0 32 14.327 32 32v64c0 17.673-14.327 32-32 32zm-48-88c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm-64 0c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24z"
-                                />
-                              </svg>
-                            </ServerIcon>
+                                <FindRefWrapper
+                                  onFoundRef={[Function]}
+                                >
+                                  <ServerIcon
+                                    aria-describedby="pf-tooltip-11"
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  >
+                                    <svg
+                                      aria-describedby="pf-tooltip-11"
+                                      aria-hidden={true}
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 512 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M480 160H32c-17.673 0-32-14.327-32-32V64c0-17.673 14.327-32 32-32h448c17.673 0 32 14.327 32 32v64c0 17.673-14.327 32-32 32zm-48-88c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm-64 0c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm112 248H32c-17.673 0-32-14.327-32-32v-64c0-17.673 14.327-32 32-32h448c17.673 0 32 14.327 32 32v64c0 17.673-14.327 32-32 32zm-48-88c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm-64 0c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm112 248H32c-17.673 0-32-14.327-32-32v-64c0-17.673 14.327-32 32-32h448c17.673 0 32 14.327 32 32v64c0 17.673-14.327 32-32 32zm-48-88c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm-64 0c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24z"
+                                      />
+                                    </svg>
+                                  </ServerIcon>
+                                </FindRefWrapper>
+                              </Popper>
+                            </Tooltip>
                           </div>
                           <div
                             className="system-name"
@@ -3499,38 +4469,133 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                             className="system-updated-and-reference"
                           >
                             <ReferenceSelector
-                              id="f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2"
                               isReference={false}
+                              item={
+                                Object {
+                                  "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
+                                  "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
+                                  "last_updated": "2019-01-15T15:25:16.304899Z",
+                                  "type": "system",
+                                }
+                              }
                               updateReferenceId={[Function]}
                             >
-                              <OutlinedStarIcon
-                                className="reference-selector pointer"
-                                color="currentColor"
-                                noVerticalAlign={false}
-                                onClick={[Function]}
-                                size="sm"
+                              <Tooltip
+                                content={
+                                  <div>
+                                    Use this 
+                                    system
+                                     as a reference to compare.
+                                  </div>
+                                }
+                                position="top"
                               >
-                                <svg
-                                  aria-hidden={true}
-                                  aria-labelledby={null}
-                                  className="reference-selector pointer"
-                                  fill="currentColor"
-                                  height="1em"
-                                  onClick={[Function]}
-                                  role="img"
-                                  style={
+                                <Popper
+                                  appendTo={[Function]}
+                                  distance={15}
+                                  enableFlip={true}
+                                  flipBehavior={
+                                    Array [
+                                      "top",
+                                      "right",
+                                      "bottom",
+                                      "left",
+                                      "top",
+                                      "right",
+                                      "bottom",
+                                    ]
+                                  }
+                                  isVisible={false}
+                                  onBlur={[Function]}
+                                  onDocumentClick={false}
+                                  onDocumentKeyDown={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  onTriggerEnter={[Function]}
+                                  placement="top"
+                                  popper={
+                                    <div
+                                      className="pf-c-tooltip"
+                                      id="pf-tooltip-12"
+                                      role="tooltip"
+                                      style={
+                                        Object {
+                                          "maxWidth": null,
+                                          "opacity": 0,
+                                          "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
+                                        }
+                                      }
+                                    >
+                                      <TooltipArrow />
+                                      <TooltipContent
+                                        isLeftAligned={false}
+                                      >
+                                        <div>
+                                          Use this 
+                                          system
+                                           as a reference to compare.
+                                        </div>
+                                      </TooltipContent>
+                                    </div>
+                                  }
+                                  popperMatchesTriggerWidth={false}
+                                  positionModifiers={
                                     Object {
-                                      "verticalAlign": "-0.125em",
+                                      "bottom": "pf-m-bottom",
+                                      "left": "pf-m-left",
+                                      "right": "pf-m-right",
+                                      "top": "pf-m-top",
                                     }
                                   }
-                                  viewBox="0 0 576 512"
-                                  width="1em"
+                                  trigger={
+                                    <OutlinedStarIcon
+                                      aria-describedby="pf-tooltip-12"
+                                      className="reference-selector pointer"
+                                      color="currentColor"
+                                      noVerticalAlign={false}
+                                      onClick={[Function]}
+                                      size="sm"
+                                    />
+                                  }
+                                  zIndex={9999}
                                 >
-                                  <path
-                                    d="M528.1 171.5L382 150.2 316.7 17.8c-11.7-23.6-45.6-23.9-57.4 0L194 150.2 47.9 171.5c-26.2 3.8-36.7 36.1-17.7 54.6l105.7 103-25 145.5c-4.5 26.3 23.2 46 46.4 33.7L288 439.6l130.7 68.7c23.2 12.2 50.9-7.4 46.4-33.7l-25-145.5 105.7-103c19-18.5 8.5-50.8-17.7-54.6zM388.6 312.3l23.7 138.4L288 385.4l-124.3 65.3 23.7-138.4-100.6-98 139-20.2 62.2-126 62.2 126 139 20.2-100.6 98z"
-                                  />
-                                </svg>
-                              </OutlinedStarIcon>
+                                  <FindRefWrapper
+                                    onFoundRef={[Function]}
+                                  >
+                                    <OutlinedStarIcon
+                                      aria-describedby="pf-tooltip-12"
+                                      className="reference-selector pointer"
+                                      color="currentColor"
+                                      noVerticalAlign={false}
+                                      onClick={[Function]}
+                                      size="sm"
+                                    >
+                                      <svg
+                                        aria-describedby="pf-tooltip-12"
+                                        aria-hidden={true}
+                                        aria-labelledby={null}
+                                        className="reference-selector pointer"
+                                        fill="currentColor"
+                                        height="1em"
+                                        onClick={[Function]}
+                                        role="img"
+                                        style={
+                                          Object {
+                                            "verticalAlign": "-0.125em",
+                                          }
+                                        }
+                                        viewBox="0 0 576 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M528.1 171.5L382 150.2 316.7 17.8c-11.7-23.6-45.6-23.9-57.4 0L194 150.2 47.9 171.5c-26.2 3.8-36.7 36.1-17.7 54.6l105.7 103-25 145.5c-4.5 26.3 23.2 46 46.4 33.7L288 439.6l130.7 68.7c23.2 12.2 50.9-7.4 46.4-33.7l-25-145.5 105.7-103c19-18.5 8.5-50.8-17.7-54.6zM388.6 312.3l23.7 138.4L288 385.4l-124.3 65.3 23.7-138.4-100.6-98 139-20.2 62.2-126 62.2 126 139 20.2-100.6 98z"
+                                        />
+                                      </svg>
+                                    </OutlinedStarIcon>
+                                  </FindRefWrapper>
+                                </Popper>
+                              </Tooltip>
                             </ReferenceSelector>
                             15 Jan 2019, 15:25 UTC
                             <withRouter(Connect(HistoricalProfilesDropdown))

--- a/src/SmartComponents/StateIcon/StateIcon.js
+++ b/src/SmartComponents/StateIcon/StateIcon.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { CheckCircleIcon, QuestionCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
+import { Tooltip } from '@patternfly/react-core';
 
 class StateIcon extends Component {
     constructor(props) {
@@ -10,9 +11,9 @@ class StateIcon extends Component {
     icon() {
         let iconClass = '';
 
-        if (this.props.factState === 'SAME') {
+        if (this.props.fact.state === 'SAME') {
             iconClass = <CheckCircleIcon color='#3E8635' height='16px' width='16px'/>;
-        } else if (this.props.factState === 'DIFFERENT') {
+        } else if (this.props.fact.state === 'DIFFERENT') {
             iconClass = <ExclamationCircleIcon color='#C9190B' height='16px' width='16px'/>;
         } else {
             iconClass = <QuestionCircleIcon color='#151515' height='16px' width='16px'/>;
@@ -23,13 +24,20 @@ class StateIcon extends Component {
 
     render() {
         return (
-            this.icon()
+            <Tooltip
+                position="top"
+                content={
+                    <div>{ this.props.fact.tooltip }</div>
+                }
+            >
+                { this.icon() }
+            </Tooltip>
         );
     }
 }
 
 StateIcon.propTypes = {
-    factState: PropTypes.string
+    fact: PropTypes.object
 };
 
 export default StateIcon;

--- a/src/SmartComponents/modules/__tests__/reducer-test.js
+++ b/src/SmartComponents/modules/__tests__/reducer-test.js
@@ -6,6 +6,7 @@ import { compareReducerPayload, compareReducerState, sortedDesc,
     paginatedStatePageOne, paginatedStatePageTwo } from './reducer.fixtures';
 import { factFilteredStateOne, factFilteredStateTwo } from './reducer.fact-filter-fixtures';
 import stateFilteredFixtures from './reducer.state-filter-fixtures';
+import stateFilters from './state-filter.fixtures';
 
 describe('compare reducer', () => {
     it('should return initial state', () => {
@@ -14,11 +15,7 @@ describe('compare reducer', () => {
                 fullCompareData: [],
                 sortedFilteredFacts: [],
                 factFilter: '',
-                stateFilters: [
-                    { filter: 'SAME', display: 'Same', selected: true },
-                    { filter: 'DIFFERENT', display: 'Different', selected: true },
-                    { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: true }
-                ],
+                stateFilters: stateFilters.allStatesTrue,
                 factSort: ASC,
                 stateSort: DESC,
                 filteredCompareData: [],
@@ -32,7 +29,8 @@ describe('compare reducer', () => {
                 loading: false,
                 expandedRows: [],
                 error: {},
-                emptyState: true
+                emptyState: true,
+                referenceId: undefined
             }
         );
     });
@@ -48,11 +46,7 @@ describe('compare reducer', () => {
                 perPage: 10,
                 factSort: DESC,
                 stateSort: ASC,
-                stateFilters: [
-                    { filter: 'SAME', display: 'Same', selected: false },
-                    { filter: 'DIFFERENT', display: 'Different', selected: true },
-                    { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: false }
-                ],
+                stateFilters: stateFilters.diffStateTrue,
                 factFilter: 'dog',
                 expandedRows: [ 'something', 'something-else' ]}, {
                 type: `${types.CLEAR_COMPARISON}` })
@@ -62,11 +56,7 @@ describe('compare reducer', () => {
             sortedFilteredFacts: [],
             referenceId: undefined,
             factFilter: 'dog',
-            stateFilters: [
-                { filter: 'SAME', display: 'Same', selected: false },
-                { filter: 'DIFFERENT', display: 'Different', selected: true },
-                { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: false }
-            ],
+            stateFilters: stateFilters.diffStateTrue,
             factSort: DESC,
             stateSort: ASC,
             filteredCompareData: [],
@@ -99,24 +89,16 @@ describe('compare reducer', () => {
                 perPage: 10,
                 factSort: DESC,
                 stateSort: ASC,
-                stateFilters: [
-                    { filter: 'SAME', display: 'Same', selected: false },
-                    { filter: 'DIFFERENT', display: 'Different', selected: true },
-                    { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: false }
-                ],
+                stateFilters: stateFilters.diffStateTrue,
                 factFilter: 'dog' }, {
                 type: `${types.CLEAR_COMPARISON_FILTERS}` })
         ).toEqual({
             baselines: [],
-            fullCompareData: compareReducerState.facts,
+            fullCompareData: compareReducerPayload.facts,
             sortedFilteredFacts: [],
             referenceId: '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9',
             factFilter: '',
-            stateFilters: [
-                { filter: 'SAME', display: 'Same', selected: false },
-                { filter: 'DIFFERENT', display: 'Different', selected: false },
-                { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: false }
-            ],
+            stateFilters: stateFilters.allStatesFalse,
             factSort: DESC,
             stateSort: ASC,
             filteredCompareData: [],
@@ -238,11 +220,7 @@ describe('compare reducer', () => {
             compareReducer({
                 perPage: 50,
                 page: 1,
-                stateFilters: [
-                    { filter: 'SAME', display: 'Same', selected: true },
-                    { filter: 'DIFFERENT', display: 'Different', selected: true },
-                    { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: true }
-                ],
+                stateFilters: stateFilters.allStatesTrue,
                 factFilter: '' },
             {
                 payload: compareReducerPayload,
@@ -259,11 +237,7 @@ describe('compare reducer', () => {
             systems: compareReducerState.systems,
             page: 1,
             perPage: 50,
-            stateFilters: [
-                { filter: 'SAME', display: 'Same', selected: true },
-                { filter: 'DIFFERENT', display: 'Different', selected: true },
-                { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: true }
-            ],
+            stateFilters: stateFilters.allStatesTrue,
             totalFacts: 3,
             emptyState: false
         });
@@ -274,11 +248,7 @@ describe('compare reducer', () => {
             compareReducer({
                 perPage: 50,
                 page: 1,
-                stateFilters: [
-                    { filter: 'SAME', display: 'Same', selected: true },
-                    { filter: 'DIFFERENT', display: 'Different', selected: true },
-                    { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: true }
-                ],
+                stateFilters: stateFilters.allStatesTrue,
                 factFilter: '' },
             {
                 payload: { facts: [], systems: []},
@@ -295,11 +265,7 @@ describe('compare reducer', () => {
             systems: [],
             page: 1,
             perPage: 50,
-            stateFilters: [
-                { filter: 'SAME', display: 'Same', selected: true },
-                { filter: 'DIFFERENT', display: 'Different', selected: true },
-                { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: true }
-            ],
+            stateFilters: stateFilters.allStatesTrue,
             totalFacts: 0,
             emptyState: false
         });
@@ -339,11 +305,7 @@ describe('compare reducer', () => {
                 fullCompareData: compareReducerPayload.facts,
                 systems: compareReducerPayload.systems,
                 factFilter: '',
-                stateFilters: [
-                    { filter: 'SAME', display: 'Same', selected: true },
-                    { filter: 'DIFFERENT', display: 'Different', selected: true },
-                    { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: true }
-                ]},
+                stateFilters: stateFilters.allStatesTrue },
             {
                 payload: { perPage: 2, page: 1 },
                 type: `${types.UPDATE_DRIFT_PAGINATION}`
@@ -356,11 +318,7 @@ describe('compare reducer', () => {
             systems: paginatedStatePageOne.systems,
             page: 1,
             perPage: 2,
-            stateFilters: [
-                { filter: 'SAME', display: 'Same', selected: true },
-                { filter: 'DIFFERENT', display: 'Different', selected: true },
-                { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: true }
-            ],
+            stateFilters: stateFilters.allStatesTrue,
             totalFacts: 3
         });
     });
@@ -373,11 +331,7 @@ describe('compare reducer', () => {
                 fullCompareData: compareReducerPayload.facts,
                 systems: compareReducerPayload.systems,
                 factFilter: '',
-                stateFilters: [
-                    { filter: 'SAME', display: 'Same', selected: true },
-                    { filter: 'DIFFERENT', display: 'Different', selected: true },
-                    { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: true }
-                ]},
+                stateFilters: stateFilters.allStatesTrue },
             {
                 payload: { perPage: 2, page: 2 },
                 type: `${types.UPDATE_DRIFT_PAGINATION}`
@@ -390,11 +344,7 @@ describe('compare reducer', () => {
             systems: paginatedStatePageTwo.systems,
             page: 2,
             perPage: 2,
-            stateFilters: [
-                { filter: 'SAME', display: 'Same', selected: true },
-                { filter: 'DIFFERENT', display: 'Different', selected: true },
-                { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: true }
-            ],
+            stateFilters: stateFilters.allStatesTrue,
             totalFacts: 3
         });
     });
@@ -407,11 +357,7 @@ describe('compare reducer', () => {
                 fullCompareData: compareReducerPayload.facts,
                 systems: compareReducerPayload.systems,
                 factFilter: '',
-                stateFilters: [
-                    { filter: 'SAME', display: 'Same', selected: true },
-                    { filter: 'DIFFERENT', display: 'Different', selected: true },
-                    { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: true }
-                ]},
+                stateFilters: stateFilters.allStatesTrue },
             {
                 payload: { perPage: 2, page: 3 },
                 type: `${types.UPDATE_DRIFT_PAGINATION}`
@@ -424,11 +370,7 @@ describe('compare reducer', () => {
             systems: paginatedStatePageTwo.systems,
             page: 3,
             perPage: 2,
-            stateFilters: [
-                { filter: 'SAME', display: 'Same', selected: true },
-                { filter: 'DIFFERENT', display: 'Different', selected: true },
-                { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: true }
-            ],
+            stateFilters: stateFilters.allStatesTrue,
             totalFacts: 3
         });
     });
@@ -441,13 +383,13 @@ describe('compare reducer', () => {
                 fullCompareData: stateFilteredFixtures.stateFilteredStateAll.facts,
                 systems: stateFilteredFixtures.stateFilteredStateAll.systems,
                 factFilter: '',
-                stateFilters: [
-                    { filter: 'SAME', display: 'Same', selected: false },
-                    { filter: 'DIFFERENT', display: 'Different', selected: false },
-                    { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: false }
-                ]},
+                stateFilters: stateFilters.allStatesFalse },
             {
-                payload: { filter: 'SAME', display: 'Same', selected: true },
+                payload: {
+                    filter: 'SAME',
+                    display: 'Same',
+                    selected: true
+                },
                 type: `${types.ADD_STATE_FILTER}`
             })
         ).toEqual({
@@ -458,11 +400,7 @@ describe('compare reducer', () => {
             systems: stateFilteredFixtures.stateFilteredStateAll.systems,
             page: 1,
             perPage: 50,
-            stateFilters: [
-                { filter: 'SAME', display: 'Same', selected: true },
-                { filter: 'DIFFERENT', display: 'Different', selected: false },
-                { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: false }
-            ],
+            stateFilters: stateFilters.sameStateTrue,
             totalFacts: 1
         });
     });
@@ -475,13 +413,13 @@ describe('compare reducer', () => {
                 fullCompareData: stateFilteredFixtures.stateFilteredStateAll.facts,
                 systems: stateFilteredFixtures.stateFilteredStateAll.systems,
                 factFilter: '',
-                stateFilters: [
-                    { filter: 'SAME', display: 'Same', selected: false },
-                    { filter: 'DIFFERENT', display: 'Different', selected: false },
-                    { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: false }
-                ]},
+                stateFilters: stateFilters.allStatesFalse },
             {
-                payload: { filter: 'DIFFERENT', display: 'Different', selected: true },
+                payload: {
+                    filter: 'DIFFERENT',
+                    display: 'Different',
+                    selected: true
+                },
                 type: `${types.ADD_STATE_FILTER}`
             })
         ).toEqual({
@@ -493,9 +431,21 @@ describe('compare reducer', () => {
             page: 1,
             perPage: 50,
             stateFilters: [
-                { filter: 'SAME', display: 'Same', selected: false },
-                { filter: 'DIFFERENT', display: 'Different', selected: true },
-                { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: false }
+                {
+                    filter: 'SAME',
+                    display: 'Same',
+                    selected: false
+                },
+                {
+                    filter: 'DIFFERENT',
+                    display: 'Different',
+                    selected: true
+                },
+                {
+                    filter: 'INCOMPLETE_DATA',
+                    display: 'Incomplete data',
+                    selected: false
+                }
             ],
             totalFacts: 1
         });
@@ -509,13 +459,13 @@ describe('compare reducer', () => {
                 fullCompareData: stateFilteredFixtures.stateFilteredStateAll.facts,
                 systems: stateFilteredFixtures.stateFilteredStateAll.systems,
                 factFilter: '',
-                stateFilters: [
-                    { filter: 'SAME', display: 'Same', selected: false },
-                    { filter: 'DIFFERENT', display: 'Different', selected: false },
-                    { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: false }
-                ]},
+                stateFilters: stateFilters.allStatesFalse },
             {
-                payload: { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: true },
+                payload: {
+                    filter: 'INCOMPLETE_DATA',
+                    display: 'Incomplete data',
+                    selected: true
+                },
                 type: `${types.ADD_STATE_FILTER}`
             })
         ).toEqual({
@@ -526,11 +476,7 @@ describe('compare reducer', () => {
             systems: stateFilteredFixtures.stateFilteredStateAll.systems,
             page: 1,
             perPage: 50,
-            stateFilters: [
-                { filter: 'SAME', display: 'Same', selected: false },
-                { filter: 'DIFFERENT', display: 'Different', selected: false },
-                { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: true }
-            ],
+            stateFilters: stateFilters.incompleteStateTrue,
             totalFacts: 1
         });
     });
@@ -543,13 +489,13 @@ describe('compare reducer', () => {
                 fullCompareData: stateFilteredFixtures.stateFilteredStateAll.facts,
                 systems: stateFilteredFixtures.stateFilteredStateAll.systems,
                 factFilter: '',
-                stateFilters: [
-                    { filter: 'SAME', display: 'Same', selected: true },
-                    { filter: 'DIFFERENT', display: 'Different', selected: false },
-                    { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: false }
-                ]},
+                stateFilters: stateFilters.sameStateTrue },
             {
-                payload: { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: true },
+                payload: {
+                    filter: 'INCOMPLETE_DATA',
+                    display: 'Incomplete data',
+                    selected: true
+                },
                 type: `${types.ADD_STATE_FILTER}`
             })
         ).toEqual({
@@ -560,11 +506,7 @@ describe('compare reducer', () => {
             systems: stateFilteredFixtures.stateFilteredStateAll.systems,
             page: 1,
             perPage: 50,
-            stateFilters: [
-                { filter: 'SAME', display: 'Same', selected: true },
-                { filter: 'DIFFERENT', display: 'Different', selected: false },
-                { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: true }
-            ],
+            stateFilters: stateFilters.diffStateFalse,
             totalFacts: 2
         });
     });
@@ -577,13 +519,13 @@ describe('compare reducer', () => {
                 fullCompareData: stateFilteredFixtures.stateFilteredStateAll.facts,
                 systems: stateFilteredFixtures.stateFilteredStateAll.systems,
                 factFilter: '',
-                stateFilters: [
-                    { filter: 'SAME', display: 'Same', selected: true },
-                    { filter: 'DIFFERENT', display: 'Different', selected: false },
-                    { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: false }
-                ]},
+                stateFilters: stateFilters.sameStateTrue },
             {
-                payload: { filter: 'DIFFERENT', display: 'Different', selected: true },
+                payload: {
+                    filter: 'DIFFERENT',
+                    display: 'Different',
+                    selected: true
+                },
                 type: `${types.ADD_STATE_FILTER}`
             })
         ).toEqual({
@@ -594,11 +536,7 @@ describe('compare reducer', () => {
             systems: stateFilteredFixtures.stateFilteredStateAll.systems,
             page: 1,
             perPage: 50,
-            stateFilters: [
-                { filter: 'SAME', display: 'Same', selected: true },
-                { filter: 'DIFFERENT', display: 'Different', selected: true },
-                { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: false }
-            ],
+            stateFilters: stateFilters.incompleteStateFalse,
             totalFacts: 2
         });
     });
@@ -611,13 +549,13 @@ describe('compare reducer', () => {
                 fullCompareData: stateFilteredFixtures.stateFilteredStateAll.facts,
                 systems: stateFilteredFixtures.stateFilteredStateAll.systems,
                 factFilter: '',
-                stateFilters: [
-                    { filter: 'SAME', display: 'Same', selected: false },
-                    { filter: 'DIFFERENT', display: 'Different', selected: false },
-                    { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: true }
-                ]},
+                stateFilters: stateFilters.incompleteStateTrue },
             {
-                payload: { filter: 'DIFFERENT', display: 'Different', selected: true },
+                payload: {
+                    filter: 'DIFFERENT',
+                    display: 'Different',
+                    selected: true
+                },
                 type: `${types.ADD_STATE_FILTER}`
             })
         ).toEqual({
@@ -628,11 +566,7 @@ describe('compare reducer', () => {
             systems: stateFilteredFixtures.stateFilteredStateAll.systems,
             page: 1,
             perPage: 50,
-            stateFilters: [
-                { filter: 'SAME', display: 'Same', selected: false },
-                { filter: 'DIFFERENT', display: 'Different', selected: true },
-                { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: true }
-            ],
+            stateFilters: stateFilters.sameStateFalse,
             totalFacts: 2
         });
     });
@@ -645,13 +579,13 @@ describe('compare reducer', () => {
                 fullCompareData: stateFilteredFixtures.stateFilteredStateAll.facts,
                 systems: stateFilteredFixtures.stateFilteredStateAll.systems,
                 factFilter: '',
-                stateFilters: [
-                    { filter: 'SAME', display: 'Same', selected: false },
-                    { filter: 'DIFFERENT', display: 'Different', selected: true },
-                    { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: false }
-                ]},
+                stateFilters: stateFilters.diffStateTrue },
             {
-                payload: { filter: 'DIFFERENT', display: 'Different', selected: false },
+                payload: {
+                    filter: 'DIFFERENT',
+                    display: 'Different',
+                    selected: false
+                },
                 type: `${types.ADD_STATE_FILTER}`
             })
         ).toEqual({
@@ -662,11 +596,7 @@ describe('compare reducer', () => {
             systems: stateFilteredFixtures.stateFilteredStateAll.systems,
             page: 1,
             perPage: 50,
-            stateFilters: [
-                { filter: 'SAME', display: 'Same', selected: false },
-                { filter: 'DIFFERENT', display: 'Different', selected: false },
-                { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: false }
-            ],
+            stateFilters: stateFilters.allStatesFalse,
             totalFacts: 0
         });
     });
@@ -679,11 +609,7 @@ describe('compare reducer', () => {
                 fullCompareData: compareReducerPayload.facts,
                 systems: compareReducerPayload.systems,
                 factFilter: '',
-                stateFilters: [
-                    { filter: 'SAME', display: 'Same', selected: true },
-                    { filter: 'DIFFERENT', display: 'Different', selected: true },
-                    { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: true }
-                ]},
+                stateFilters: stateFilters.allStatesTrue },
             {
                 payload: 'i',
                 type: `${types.FILTER_BY_FACT}`
@@ -696,11 +622,7 @@ describe('compare reducer', () => {
             systems: factFilteredStateOne.systems,
             page: 1,
             perPage: 50,
-            stateFilters: [
-                { filter: 'SAME', display: 'Same', selected: true },
-                { filter: 'DIFFERENT', display: 'Different', selected: true },
-                { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: true }
-            ],
+            stateFilters: stateFilters.allStatesTrue,
             totalFacts: 2
         });
     });
@@ -713,11 +635,7 @@ describe('compare reducer', () => {
                 fullCompareData: compareReducerPayload.facts,
                 systems: compareReducerPayload.systems,
                 factFilter: 'i',
-                stateFilters: [
-                    { filter: 'SAME', display: 'Same', selected: true },
-                    { filter: 'DIFFERENT', display: 'Different', selected: true },
-                    { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: true }
-                ]},
+                stateFilters: stateFilters.allStatesTrue },
             {
                 payload: 'io',
                 type: `${types.FILTER_BY_FACT}`
@@ -730,11 +648,7 @@ describe('compare reducer', () => {
             systems: factFilteredStateTwo.systems,
             page: 1,
             perPage: 50,
-            stateFilters: [
-                { filter: 'SAME', display: 'Same', selected: true },
-                { filter: 'DIFFERENT', display: 'Different', selected: true },
-                { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: true }
-            ],
+            stateFilters: stateFilters.allStatesTrue,
             totalFacts: 1
         });
     });
@@ -747,11 +661,7 @@ describe('compare reducer', () => {
                 fullCompareData: compareReducerPayload.facts,
                 systems: compareReducerPayload.systems,
                 factFilter: 'io',
-                stateFilters: [
-                    { filter: 'SAME', display: 'Same', selected: true },
-                    { filter: 'DIFFERENT', display: 'Different', selected: true },
-                    { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: true }
-                ]},
+                stateFilters: stateFilters.allStatesTrue },
             {
                 payload: 'iou',
                 type: `${types.FILTER_BY_FACT}`
@@ -764,11 +674,7 @@ describe('compare reducer', () => {
             systems: compareReducerState.systems,
             page: 1,
             perPage: 50,
-            stateFilters: [
-                { filter: 'SAME', display: 'Same', selected: true },
-                { filter: 'DIFFERENT', display: 'Different', selected: true },
-                { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: true }
-            ],
+            stateFilters: stateFilters.allStatesTrue,
             totalFacts: 0
         });
     });
@@ -781,11 +687,7 @@ describe('compare reducer', () => {
                 fullCompareData: compareReducerPayload.facts,
                 systems: compareReducerPayload.systems,
                 factFilter: '',
-                stateFilters: [
-                    { filter: 'SAME', display: 'Same', selected: true },
-                    { filter: 'DIFFERENT', display: 'Different', selected: false },
-                    { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: false }
-                ]},
+                stateFilters: stateFilters.sameStateTrue },
             {
                 payload: 'io',
                 type: `${types.FILTER_BY_FACT}`
@@ -798,11 +700,7 @@ describe('compare reducer', () => {
             systems: factFilteredStateTwo.systems,
             page: 1,
             perPage: 50,
-            stateFilters: [
-                { filter: 'SAME', display: 'Same', selected: true },
-                { filter: 'DIFFERENT', display: 'Different', selected: false },
-                { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: false }
-            ],
+            stateFilters: stateFilters.sameStateTrue,
             totalFacts: 1
         });
     });
@@ -815,11 +713,7 @@ describe('compare reducer', () => {
                 fullCompareData: compareReducerPayload.facts,
                 systems: compareReducerPayload.systems,
                 factFilter: '',
-                stateFilters: [
-                    { filter: 'SAME', display: 'Same', selected: false },
-                    { filter: 'DIFFERENT', display: 'Different', selected: true },
-                    { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: false }
-                ]},
+                stateFilters: stateFilters.diffStateTrue },
             {
                 payload: 'io',
                 type: `${types.FILTER_BY_FACT}`
@@ -832,11 +726,7 @@ describe('compare reducer', () => {
             systems: compareReducerState.systems,
             page: 1,
             perPage: 50,
-            stateFilters: [
-                { filter: 'SAME', display: 'Same', selected: false },
-                { filter: 'DIFFERENT', display: 'Different', selected: true },
-                { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: false }
-            ],
+            stateFilters: stateFilters.diffStateTrue,
             totalFacts: 0
         });
     });
@@ -850,11 +740,7 @@ describe('compare reducer', () => {
                 systems: compareReducerPayload.systems,
                 factFilter: '',
                 factSort: ASC,
-                stateFilters: [
-                    { filter: 'SAME', display: 'Same', selected: false },
-                    { filter: 'DIFFERENT', display: 'Different', selected: false },
-                    { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: false }
-                ]},
+                stateFilters: stateFilters.allStatesFalse },
             {
                 payload: DESC,
                 type: `${types.TOGGLE_FACT_SORT}`
@@ -866,11 +752,7 @@ describe('compare reducer', () => {
             systems: compareReducerState.systems,
             page: 1,
             perPage: 50,
-            stateFilters: [
-                { filter: 'SAME', display: 'Same', selected: false },
-                { filter: 'DIFFERENT', display: 'Different', selected: false },
-                { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: false }
-            ],
+            stateFilters: stateFilters.allStatesFalse,
             totalFacts: 0,
             factFilter: '',
             factSort: DESC
@@ -886,11 +768,7 @@ describe('compare reducer', () => {
                 systems: compareReducerPayload.systems,
                 factFilter: '',
                 factSort: DESC,
-                stateFilters: [
-                    { filter: 'SAME', display: 'Same', selected: false },
-                    { filter: 'DIFFERENT', display: 'Different', selected: false },
-                    { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: false }
-                ]},
+                stateFilters: stateFilters.allStatesFalse },
             {
                 payload: ASC,
                 type: `${types.TOGGLE_FACT_SORT}`
@@ -902,11 +780,7 @@ describe('compare reducer', () => {
             systems: compareReducerState.systems,
             page: 1,
             perPage: 50,
-            stateFilters: [
-                { filter: 'SAME', display: 'Same', selected: false },
-                { filter: 'DIFFERENT', display: 'Different', selected: false },
-                { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: false }
-            ],
+            stateFilters: stateFilters.allStatesFalse,
             totalFacts: 0,
             factFilter: '',
             factSort: ASC
@@ -922,11 +796,7 @@ describe('compare reducer', () => {
                 systems: compareReducerPayload.systems,
                 factFilter: '',
                 stateSort: DESC,
-                stateFilters: [
-                    { filter: 'SAME', display: 'Same', selected: false },
-                    { filter: 'DIFFERENT', display: 'Different', selected: false },
-                    { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: false }
-                ]},
+                stateFilters: stateFilters.allStatesFalse },
             {
                 payload: ASC,
                 type: `${types.TOGGLE_STATE_SORT}`
@@ -938,11 +808,7 @@ describe('compare reducer', () => {
             systems: compareReducerState.systems,
             page: 1,
             perPage: 50,
-            stateFilters: [
-                { filter: 'SAME', display: 'Same', selected: false },
-                { filter: 'DIFFERENT', display: 'Different', selected: false },
-                { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: false }
-            ],
+            stateFilters: stateFilters.allStatesFalse,
             totalFacts: 0,
             factFilter: '',
             stateSort: ASC
@@ -958,11 +824,7 @@ describe('compare reducer', () => {
                 systems: compareReducerPayload.systems,
                 factFilter: '',
                 stateSort: ASC,
-                stateFilters: [
-                    { filter: 'SAME', display: 'Same', selected: false },
-                    { filter: 'DIFFERENT', display: 'Different', selected: false },
-                    { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: false }
-                ]},
+                stateFilters: stateFilters.allStatesFalse },
             {
                 payload: '',
                 type: `${types.TOGGLE_STATE_SORT}`
@@ -974,11 +836,7 @@ describe('compare reducer', () => {
             systems: compareReducerState.systems,
             page: 1,
             perPage: 50,
-            stateFilters: [
-                { filter: 'SAME', display: 'Same', selected: false },
-                { filter: 'DIFFERENT', display: 'Different', selected: false },
-                { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: false }
-            ],
+            stateFilters: stateFilters.allStatesFalse,
             totalFacts: 0,
             factFilter: '',
             stateSort: ''
@@ -994,11 +852,7 @@ describe('compare reducer', () => {
                 systems: compareReducerPayload.systems,
                 factFilter: '',
                 stateSort: '',
-                stateFilters: [
-                    { filter: 'SAME', display: 'Same', selected: false },
-                    { filter: 'DIFFERENT', display: 'Different', selected: false },
-                    { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: false }
-                ]},
+                stateFilters: stateFilters.allStatesFalse },
             {
                 payload: ASC,
                 type: `${types.TOGGLE_STATE_SORT}`
@@ -1010,11 +864,7 @@ describe('compare reducer', () => {
             systems: compareReducerState.systems,
             page: 1,
             perPage: 50,
-            stateFilters: [
-                { filter: 'SAME', display: 'Same', selected: false },
-                { filter: 'DIFFERENT', display: 'Different', selected: false },
-                { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: false }
-            ],
+            stateFilters: stateFilters.allStatesFalse,
             totalFacts: 0,
             factFilter: '',
             stateSort: ASC
@@ -1030,11 +880,7 @@ describe('compare reducer', () => {
                 systems: compareReducerPayload.systems,
                 factFilter: '',
                 expandedRows: [],
-                stateFilters: [
-                    { filter: 'SAME', display: 'Same', selected: false },
-                    { filter: 'DIFFERENT', display: 'Different', selected: false },
-                    { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: false }
-                ]},
+                stateFilters: stateFilters.allStatesFalse },
             {
                 payload: 'bios_uuid',
                 type: `${types.EXPAND_ROW}`
@@ -1047,17 +893,13 @@ describe('compare reducer', () => {
             factFilter: '',
             page: 1,
             perPage: 50,
-            stateFilters: [
-                { filter: 'SAME', display: 'Same', selected: false },
-                { filter: 'DIFFERENT', display: 'Different', selected: false },
-                { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: false }
-            ],
+            stateFilters: stateFilters.allStatesFalse,
             expandedRows: [ 'bios_uuid' ],
             totalFacts: 0
         });
     });
 
-    it('should handle EXPAND_ROW to remove fact', () => {
+    it('should handle EXPAND_ROW to collapse fact', () => {
         expect(
             compareReducer({
                 page: 1,
@@ -1066,11 +908,7 @@ describe('compare reducer', () => {
                 systems: compareReducerPayload.systems,
                 factFilter: '',
                 expandedRows: [ 'bios_uuid', 'display_name' ],
-                stateFilters: [
-                    { filter: 'SAME', display: 'Same', selected: false },
-                    { filter: 'DIFFERENT', display: 'Different', selected: false },
-                    { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: false }
-                ]},
+                stateFilters: stateFilters.allStatesFalse },
             {
                 payload: 'bios_uuid',
                 type: `${types.EXPAND_ROW}`
@@ -1083,11 +921,7 @@ describe('compare reducer', () => {
             factFilter: '',
             page: 1,
             perPage: 50,
-            stateFilters: [
-                { filter: 'SAME', display: 'Same', selected: false },
-                { filter: 'DIFFERENT', display: 'Different', selected: false },
-                { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: false }
-            ],
+            stateFilters: stateFilters.allStatesFalse,
             expandedRows: [ 'display_name' ],
             totalFacts: 0
         });
@@ -1102,11 +936,7 @@ describe('compare reducer', () => {
                 fullCompareData: [],
                 sortedFilteredFacts: [],
                 factFilter: '',
-                stateFilters: [
-                    { filter: 'SAME', display: 'Same', selected: true },
-                    { filter: 'DIFFERENT', display: 'Different', selected: true },
-                    { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: true }
-                ],
+                stateFilters: stateFilters.allStatesTrue,
                 factSort: ASC,
                 stateSort: DESC,
                 filteredCompareData: [],
@@ -1120,6 +950,21 @@ describe('compare reducer', () => {
                 expandedRows: [],
                 error: {},
                 emptyState: true
+            }
+        );
+    });
+
+    it('should handle UPDATE_REFERENCE_ID', () => {
+        expect(
+            compareReducer({
+                referenceId: undefined },
+            {
+                payload: 'abcd-1234-efgh-5678',
+                type: `${types.UPDATE_REFERENCE_ID}`
+            })
+        ).toEqual(
+            {
+                referenceId: 'abcd-1234-efgh-5678'
             }
         );
     });

--- a/src/SmartComponents/modules/__tests__/reducer.fact-filter-fixtures.js
+++ b/src/SmartComponents/modules/__tests__/reducer.fact-filter-fixtures.js
@@ -10,7 +10,8 @@ export const factFilteredStateOne = ({
                 {
                     id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2', value: 'FAKE-BIOS'
                 }
-            ]
+            ],
+            tooltip: 'Same - All system facts in this row are the same.'
         },
         {
             name: 'display_name',
@@ -22,7 +23,8 @@ export const factFilteredStateOne = ({
                 {
                     id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2', value: 'PC-NAME'
                 }
-            ]
+            ],
+            tooltip: 'Same - All system facts in this row are the same.'
         }
     ],
     /* eslint-disable camelcase */
@@ -53,7 +55,8 @@ export const factFilteredStateTwo = ({
                 {
                     id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2', value: 'FAKE-BIOS'
                 }
-            ]
+            ],
+            tooltip: 'Same - All system facts in this row are the same.'
         }
     ],
     /* eslint-disable camelcase */

--- a/src/SmartComponents/modules/__tests__/reducer.fixtures.js
+++ b/src/SmartComponents/modules/__tests__/reducer.fixtures.js
@@ -11,7 +11,8 @@ export const compareReducerPayload = ({
                 {
                     id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2', value: '3'
                 }
-            ]
+            ],
+            tooltip: 'Different - At least one system fact value in this row differs.'
         },
         {
             name: 'bios_uuid',
@@ -64,7 +65,8 @@ export const compareReducerState = ({
                 {
                     id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2', value: '3'
                 }
-            ]
+            ],
+            tooltip: 'Different - At least one system fact value in this row differs.'
         },
         {
             name: 'bios_uuid',
@@ -76,7 +78,8 @@ export const compareReducerState = ({
                 {
                     id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2', value: 'FAKE-BIOS'
                 }
-            ]
+            ],
+            tooltip: 'Same - All system facts in this row are the same.'
         },
         {
             name: 'display_name',
@@ -88,7 +91,8 @@ export const compareReducerState = ({
                 {
                     id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2', value: 'PC-NAME'
                 }
-            ]
+            ],
+            tooltip: 'Same - All system facts in this row are the same.'
         }
     ],
     systems: [
@@ -117,7 +121,8 @@ export const sortedDesc = ({
                 {
                     id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2', value: 'FAKE-BIOS'
                 }
-            ]
+            ],
+            tooltip: 'Same - All system facts in this row are the same.'
         },
         {
             name: 'cpus',
@@ -129,7 +134,8 @@ export const sortedDesc = ({
                 {
                     id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2', value: '3'
                 }
-            ]
+            ],
+            tooltip: 'Different - At least one system fact value in this row differs.'
         },
         {
             name: 'display_name',
@@ -141,7 +147,8 @@ export const sortedDesc = ({
                 {
                     id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2', value: 'PC-NAME'
                 }
-            ]
+            ],
+            tooltip: 'Same - All system facts in this row are the same.'
         }
     ],
     systems: [
@@ -170,7 +177,8 @@ export const paginatedStatePageOne = ({
                 {
                     id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2', value: '3'
                 }
-            ]
+            ],
+            tooltip: 'Different - At least one system fact value in this row differs.'
         },
         {
             name: 'bios_uuid',
@@ -182,7 +190,8 @@ export const paginatedStatePageOne = ({
                 {
                     id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2', value: 'FAKE-BIOS'
                 }
-            ]
+            ],
+            tooltip: 'Same - All system facts in this row are the same.'
         }
     ],
     systems: [
@@ -211,7 +220,8 @@ export const paginatedStatePageTwo = ({
                 {
                     id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2', value: 'PC-NAME'
                 }
-            ]
+            ],
+            tooltip: 'Same - All system facts in this row are the same.'
         }
     ],
     systems: [

--- a/src/SmartComponents/modules/__tests__/reducer.state-filter-fixtures.js
+++ b/src/SmartComponents/modules/__tests__/reducer.state-filter-fixtures.js
@@ -10,7 +10,8 @@ export const stateFilteredStateAll = ({
                 {
                     id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2', value: 'FAKE-BIOS'
                 }
-            ]
+            ],
+            tooltip: 'Same - All system facts in this row are the same.'
         },
         {
             name: 'display_name',
@@ -22,7 +23,8 @@ export const stateFilteredStateAll = ({
                 {
                     id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2', value: 'PC-NAME'
                 }
-            ]
+            ],
+            tooltip: 'Different - At least one system fact value in this row differs.'
         },
         {
             name: 'cpus',
@@ -34,7 +36,8 @@ export const stateFilteredStateAll = ({
                 {
                     id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2', value: '3'
                 }
-            ]
+            ],
+            tooltip: 'Incomplete data - At least one system fact value in this row is missing.'
         }
 
     ],
@@ -65,7 +68,8 @@ const stateFilteredStateSame = ([
             {
                 id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2', value: 'FAKE-BIOS'
             }
-        ]
+        ],
+        tooltip: 'Same - All system facts in this row are the same.'
     }
 ]);
 
@@ -80,7 +84,8 @@ const stateFilteredStateDifferent = ([
             {
                 id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2', value: 'PC-NAME'
             }
-        ]
+        ],
+        tooltip: 'Different - At least one system fact value in this row differs.'
     }
 ]);
 
@@ -95,7 +100,8 @@ const stateFilteredStateIncomplete = ([
             {
                 id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2', value: '3'
             }
-        ]
+        ],
+        tooltip: 'Incomplete data - At least one system fact value in this row is missing.'
     }
 ]);
 
@@ -110,7 +116,8 @@ const stateFilteredStateSameDiff = ([
             {
                 id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2', value: 'FAKE-BIOS'
             }
-        ]
+        ],
+        tooltip: 'Same - All system facts in this row are the same.'
     },
     {
         name: 'display_name',
@@ -122,7 +129,8 @@ const stateFilteredStateSameDiff = ([
             {
                 id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2', value: 'PC-NAME'
             }
-        ]
+        ],
+        tooltip: 'Different - At least one system fact value in this row differs.'
     }
 ]);
 
@@ -137,7 +145,8 @@ const stateFilteredStateSameIncomplete = ([
             {
                 id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2', value: 'FAKE-BIOS'
             }
-        ]
+        ],
+        tooltip: 'Same - All system facts in this row are the same.'
     },
     {
         name: 'cpus',
@@ -149,7 +158,8 @@ const stateFilteredStateSameIncomplete = ([
             {
                 id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2', value: '3'
             }
-        ]
+        ],
+        tooltip: 'Incomplete data - At least one system fact value in this row is missing.'
     }
 ]);
 
@@ -164,7 +174,8 @@ const stateFilteredStateDiffIncomplete = ([
             {
                 id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2', value: 'PC-NAME'
             }
-        ]
+        ],
+        tooltip: 'Different - At least one system fact value in this row differs.'
     },
     {
         name: 'cpus',
@@ -176,7 +187,8 @@ const stateFilteredStateDiffIncomplete = ([
             {
                 id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2', value: '3'
             }
-        ]
+        ],
+        tooltip: 'Incomplete data - At least one system fact value in this row is missing.'
     }
 ]);
 

--- a/src/SmartComponents/modules/__tests__/state-filter.fixtures.js
+++ b/src/SmartComponents/modules/__tests__/state-filter.fixtures.js
@@ -1,16 +1,154 @@
 const allStatesTrue = [
-    { filter: 'SAME', display: 'Same', selected: true },
-    { filter: 'DIFFERENT', display: 'Different', selected: true },
-    { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: true }
+    {
+        filter: 'SAME',
+        display: 'Same',
+        selected: true
+    },
+    {
+        filter: 'DIFFERENT',
+        display: 'Different',
+        selected: true
+    },
+    {
+        filter: 'INCOMPLETE_DATA',
+        display: 'Incomplete data',
+        selected: true
+    }
 ];
 
+const allStatesFalse = [
+    {
+        filter: 'SAME',
+        display: 'Same',
+        selected: false
+    },
+    {
+        filter: 'DIFFERENT',
+        display: 'Different',
+        selected: false
+    },
+    {
+        filter: 'INCOMPLETE_DATA',
+        display: 'Incomplete data',
+        selected: false
+    }
+];
+
+const sameStateTrue = ([
+    {
+        filter: 'SAME',
+        display: 'Same',
+        selected: true
+    },
+    {
+        filter: 'DIFFERENT',
+        display: 'Different',
+        selected: false
+    },
+    {
+        filter: 'INCOMPLETE_DATA',
+        display: 'Incomplete data',
+        selected: false
+    }
+]);
+
+const diffStateTrue = ([
+    {
+        filter: 'SAME',
+        display: 'Same',
+        selected: false
+    },
+    {
+        filter: 'DIFFERENT',
+        display: 'Different',
+        selected: true
+    },
+    {
+        filter: 'INCOMPLETE_DATA',
+        display: 'Incomplete data',
+        selected: false
+    }
+]);
+
+const incompleteStateTrue = ([
+    {
+        filter: 'SAME',
+        display: 'Same',
+        selected: false
+    },
+    {
+        filter: 'DIFFERENT',
+        display: 'Different',
+        selected: false
+    },
+    {
+        filter: 'INCOMPLETE_DATA',
+        display: 'Incomplete data',
+        selected: true
+    }
+]);
+
 const sameStateFalse = ([
-    { filter: 'SAME', display: 'Same', selected: false },
-    { filter: 'DIFFERENT', display: 'Different', selected: true },
-    { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: true }
+    {
+        filter: 'SAME',
+        display: 'Same',
+        selected: false
+    },
+    {
+        filter: 'DIFFERENT',
+        display: 'Different',
+        selected: true
+    },
+    {
+        filter: 'INCOMPLETE_DATA',
+        display: 'Incomplete data',
+        selected: true
+    }
+]);
+
+const diffStateFalse = ([
+    {
+        filter: 'SAME',
+        display: 'Same',
+        selected: true
+    },
+    {
+        filter: 'DIFFERENT',
+        display: 'Different',
+        selected: false
+    },
+    {
+        filter: 'INCOMPLETE_DATA',
+        display: 'Incomplete data',
+        selected: true
+    }
+]);
+
+const incompleteStateFalse = ([
+    {
+        filter: 'SAME',
+        display: 'Same',
+        selected: true
+    },
+    {
+        filter: 'DIFFERENT',
+        display: 'Different',
+        selected: true
+    },
+    {
+        filter: 'INCOMPLETE_DATA',
+        display: 'Incomplete data',
+        selected: false
+    }
 ]);
 
 export default {
     allStatesTrue,
-    sameStateFalse
+    allStatesFalse,
+    sameStateTrue,
+    diffStateTrue,
+    incompleteStateTrue,
+    sameStateFalse,
+    diffStateFalse,
+    incompleteStateFalse
 };

--- a/src/SmartComponents/modules/helpers.js
+++ b/src/SmartComponents/modules/helpers.js
@@ -29,7 +29,43 @@ function getStateSelected(state, stateFilters) {
     return isStateSelected;
 }
 
-function filterCompareData(data, stateFilters, factFilter) {
+function getState(state, stateFilters) {
+    let isStateSelected;
+
+    isStateSelected = stateFilters.find(function(stateFilter) {
+        if (stateFilter.filter === state) {
+            return stateFilter;
+        }
+    });
+
+    return isStateSelected;
+}
+
+function setTooltip (data, stateFilter, referenceId) {
+    let type = data.comparisons ? 'category' : 'row';
+
+    if (stateFilter.filter === 'SAME') {
+        data.tooltip = stateFilter.display +
+        ' - ' +
+        'All system facts in this ' + type + ' are the same.';
+    } else if (stateFilter.filter === 'INCOMPLETE_DATA') {
+        data.tooltip = stateFilter.display +
+        ' - ' +
+        'At least one system fact value in this ' + type + ' is missing.';
+    } else {
+        if (referenceId) {
+            data.tooltip = stateFilter.display +
+            ' - ' +
+            'At least one system fact value in this ' + type + ' differs from the reference.';
+        } else {
+            data.tooltip = stateFilter.display +
+            ' - ' +
+            'At least one system fact value in this ' + type + ' differs.';
+        }
+    }
+}
+
+function filterCompareData(data, stateFilters, factFilter, referenceId) {
     let filteredFacts = [];
     let filteredComparisons = [];
     let isStateSelected;
@@ -43,8 +79,14 @@ function filterCompareData(data, stateFilters, factFilter) {
 
         if (data[i].comparisons) {
             if (data[i].name === factFilter) {
-                filteredComparisons = filterComparisons(data[i].comparisons, stateFilters, '');
-                filteredFacts.push({ name: data[i].name, state: data[i].state, comparisons: filteredComparisons });
+                setTooltip(data[i], getState(data[i].state, stateFilters), referenceId);
+                filteredComparisons = filterComparisons(data[i].comparisons, stateFilters, '', referenceId);
+                filteredFacts.push({
+                    name: data[i].name,
+                    state: data[i].state,
+                    comparisons: filteredComparisons,
+                    tooltip: data[i].tooltip
+                });
 
                 break;
             }
@@ -52,11 +94,18 @@ function filterCompareData(data, stateFilters, factFilter) {
             filteredComparisons = filterComparisons(data[i].comparisons, stateFilters, factFilter);
 
             if (filteredComparisons.length) {
-                filteredFacts.push({ name: data[i].name, state: data[i].state, comparisons: filteredComparisons });
+                setTooltip(data[i], isStateSelected, referenceId);
+                filteredFacts.push({
+                    name: data[i].name,
+                    state: data[i].state,
+                    comparisons: filteredComparisons,
+                    tooltip: data[i].tooltip
+                });
             }
         } else {
             if (data[i].name.includes(factFilter)) {
                 if (isStateSelected) {
+                    setTooltip(data[i], isStateSelected, referenceId);
                     filteredFacts.push(data[i]);
                 }
             }
@@ -66,7 +115,7 @@ function filterCompareData(data, stateFilters, factFilter) {
     return filteredFacts;
 }
 
-function filterComparisons(comparisons, stateFilters, factFilter) {
+function filterComparisons(comparisons, stateFilters, factFilter, referenceId) {
     let filteredComparisons = [];
     let isStateSelected;
 
@@ -75,6 +124,7 @@ function filterComparisons(comparisons, stateFilters, factFilter) {
 
         if (comparisons[i].name.includes(factFilter)) {
             if (isStateSelected) {
+                setTooltip(comparisons[i], isStateSelected, referenceId);
                 filteredComparisons.push(comparisons[i]);
             }
         }

--- a/src/SmartComponents/modules/reducers.js
+++ b/src/SmartComponents/modules/reducers.js
@@ -13,9 +13,21 @@ const initialState = {
     historicalProfiles: [],
     previousStateSystems: [],
     stateFilters: [
-        { filter: 'SAME', display: 'Same', selected: true },
-        { filter: 'DIFFERENT', display: 'Different', selected: true },
-        { filter: 'INCOMPLETE_DATA', display: 'Incomplete data', selected: true }
+        {
+            filter: 'SAME',
+            display: 'Same',
+            selected: true
+        },
+        {
+            filter: 'DIFFERENT',
+            display: 'Different',
+            selected: true
+        },
+        {
+            filter: 'INCOMPLETE_DATA',
+            display: 'Incomplete data',
+            selected: true
+        }
     ],
     factFilter: '',
     totalFacts: 0,
@@ -54,7 +66,7 @@ export function compareReducer(state = initialState, action) {
         case types.CLEAR_COMPARISON_FILTERS:
             newStateFilters = [ ...state.stateFilters ];
             newStateFilters.forEach(function(stateFilter) { stateFilter.selected = false; });
-            filteredFacts = reducerHelpers.filterCompareData(state.fullCompareData, newStateFilters, initialState.factFilter);
+            filteredFacts = reducerHelpers.filterCompareData(state.fullCompareData, newStateFilters, initialState.factFilter, state.referenceId);
             sortedFacts = reducerHelpers.sortData(filteredFacts, state.factSort, state.stateSort);
             return {
                 ...state,
@@ -83,7 +95,7 @@ export function compareReducer(state = initialState, action) {
                 emptyState: false
             };
         case `${types.FETCH_COMPARE}_FULFILLED`:
-            filteredFacts = reducerHelpers.filterCompareData(action.payload.facts, state.stateFilters, state.factFilter);
+            filteredFacts = reducerHelpers.filterCompareData(action.payload.facts, state.stateFilters, state.factFilter, state.referenceId);
             sortedFacts = reducerHelpers.sortData(filteredFacts, state.factSort, state.stateSort);
             paginatedFacts = reducerHelpers.paginateData(sortedFacts, 1, state.perPage);
 
@@ -117,7 +129,7 @@ export function compareReducer(state = initialState, action) {
                 emptyState: true
             };
         case `${types.UPDATE_DRIFT_PAGINATION}`:
-            filteredFacts = reducerHelpers.filterCompareData(state.fullCompareData, state.stateFilters, state.factFilter);
+            filteredFacts = reducerHelpers.filterCompareData(state.fullCompareData, state.stateFilters, state.factFilter, state.referenceId);
             sortedFacts = reducerHelpers.sortData(filteredFacts, state.factSort, state.stateSort);
             paginatedFacts = reducerHelpers.paginateData(sortedFacts, action.payload.page, action.payload.perPage);
             return {
@@ -130,7 +142,7 @@ export function compareReducer(state = initialState, action) {
             };
         case `${types.ADD_STATE_FILTER}`:
             updatedStateFilters = reducerHelpers.updateStateFilters(state.stateFilters, action.payload);
-            filteredFacts = reducerHelpers.filterCompareData(state.fullCompareData, updatedStateFilters, state.factFilter);
+            filteredFacts = reducerHelpers.filterCompareData(state.fullCompareData, updatedStateFilters, state.factFilter, state.referenceId);
             sortedFacts = reducerHelpers.sortData(filteredFacts, state.factSort, state.stateSort);
             paginatedFacts = reducerHelpers.paginateData(sortedFacts, 1, state.perPage);
             return {
@@ -142,7 +154,7 @@ export function compareReducer(state = initialState, action) {
                 totalFacts: filteredFacts.length
             };
         case `${types.FILTER_BY_FACT}`:
-            filteredFacts = reducerHelpers.filterCompareData(state.fullCompareData, state.stateFilters, action.payload);
+            filteredFacts = reducerHelpers.filterCompareData(state.fullCompareData, state.stateFilters, action.payload, state.referenceId);
             sortedFacts = reducerHelpers.sortData(filteredFacts, state.factSort, state.stateSort);
             paginatedFacts = reducerHelpers.paginateData(sortedFacts, 1, state.perPage);
             return {
@@ -154,7 +166,7 @@ export function compareReducer(state = initialState, action) {
                 totalFacts: filteredFacts.length
             };
         case `${types.TOGGLE_FACT_SORT}`:
-            filteredFacts = reducerHelpers.filterCompareData(state.fullCompareData, state.stateFilters, state.factFilter);
+            filteredFacts = reducerHelpers.filterCompareData(state.fullCompareData, state.stateFilters, state.factFilter, state.referenceId);
             sortedFacts = reducerHelpers.sortData(filteredFacts, action.payload, state.stateSort);
             paginatedFacts = reducerHelpers.paginateData(sortedFacts, 1, state.perPage);
             return {
@@ -166,7 +178,7 @@ export function compareReducer(state = initialState, action) {
                 totalFacts: filteredFacts.length
             };
         case `${types.TOGGLE_STATE_SORT}`:
-            filteredFacts = reducerHelpers.filterCompareData(state.fullCompareData, state.stateFilters, state.factFilter);
+            filteredFacts = reducerHelpers.filterCompareData(state.fullCompareData, state.stateFilters, state.factFilter, state.referenceId);
             sortedFacts = reducerHelpers.sortData(filteredFacts, state.factSort, action.payload);
             paginatedFacts = reducerHelpers.paginateData(sortedFacts, 1, state.perPage);
             return {
@@ -184,7 +196,7 @@ export function compareReducer(state = initialState, action) {
             };
         case `${types.EXPAND_ROW}`:
             newExpandedRows = reducerHelpers.toggleExpandedRow(state.expandedRows, action.payload);
-            filteredFacts = reducerHelpers.filterCompareData(state.fullCompareData, state.stateFilters, state.factFilter);
+            filteredFacts = reducerHelpers.filterCompareData(state.fullCompareData, state.stateFilters, state.factFilter, state.referenceId);
             sortedFacts = reducerHelpers.sortData(filteredFacts, state.factSort, state.stateSort);
             paginatedFacts = reducerHelpers.paginateData(sortedFacts, state.page, state.perPage);
             return {


### PR DESCRIPTION
Tooltips should be on the following:
- State icons
    - Tooltips should read differently for same, different and incomplete data
    - Different tooltips should be different if a reference is set (Same and incomplete remain unchanged)
    - Tooltips should reference category vs. row if it is a category
- Icons next to baseline/system/hsp name
- Reference selector
    - Tooltip should read differently on set reference vs. unset reference