### PR TITLE
Change 'Fact name' to 'Baseline name' on baseline table chip

### DIFF
--- a/src/SmartComponents/AddSystemModal/__tests__/__snapshots__/AddSystemModal.tests.js.snap
+++ b/src/SmartComponents/AddSystemModal/__tests__/__snapshots__/AddSystemModal.tests.js.snap
@@ -11264,7 +11264,7 @@ Try changing your filter settings.
                                                                 className="pf-c-toolbar__group pf-m-filter-group"
                                                               >
                                                                 <ToolbarFilter
-                                                                  categoryName="Fact name"
+                                                                  categoryName="Baseline name"
                                                                   chips={Array []}
                                                                   deleteChip={[Function]}
                                                                   showToolbarItem={true}
@@ -16548,7 +16548,7 @@ Try changing your filter settings.
                                                                 className="pf-c-toolbar__group pf-m-filter-group"
                                                               >
                                                                 <ToolbarFilter
-                                                                  categoryName="Fact name"
+                                                                  categoryName="Baseline name"
                                                                   chips={Array []}
                                                                   deleteChip={[Function]}
                                                                   showToolbarItem={true}
@@ -21905,7 +21905,7 @@ Try changing your filter settings.
                                                                 className="pf-c-toolbar__group pf-m-filter-group"
                                                               >
                                                                 <ToolbarFilter
-                                                                  categoryName="Fact name"
+                                                                  categoryName="Baseline name"
                                                                   chips={Array []}
                                                                   deleteChip={[Function]}
                                                                   showToolbarItem={true}

--- a/src/SmartComponents/BaselinesPage/__tests__/__snapshots__/BaselinesPage.tests.js.snap
+++ b/src/SmartComponents/BaselinesPage/__tests__/__snapshots__/BaselinesPage.tests.js.snap
@@ -983,7 +983,7 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                                                     className="pf-c-toolbar__group pf-m-filter-group"
                                                   >
                                                     <ToolbarFilter
-                                                      categoryName="Fact name"
+                                                      categoryName="Baseline name"
                                                       chips={Array []}
                                                       deleteChip={[Function]}
                                                       showToolbarItem={true}

--- a/src/SmartComponents/BaselinesTable/BaselinesToolbar/BaselinesToolbar.js
+++ b/src/SmartComponents/BaselinesTable/BaselinesToolbar/BaselinesToolbar.js
@@ -138,7 +138,7 @@ export class BaselinesToolbar extends Component {
                             <ToolbarFilter
                                 chips={ nameSearch !== '' ? [ nameSearch ] : [] }
                                 deleteChip={ this.clearFilters }
-                                categoryName="Fact name"
+                                categoryName="Baseline name"
                             >
                                 <ConditionalFilter
                                     placeholder="Filter by name"

--- a/src/SmartComponents/BaselinesTable/BaselinesToolbar/__test__/__snapshots__/BaselinesToolbar.test.js.snap
+++ b/src/SmartComponents/BaselinesTable/BaselinesToolbar/__test__/__snapshots__/BaselinesToolbar.test.js.snap
@@ -46,7 +46,7 @@ exports[`jest-tests BaselinesToolbar should render correctly 1`] = `
         variant="filter-group"
       >
         <ToolbarFilter
-          categoryName="Fact name"
+          categoryName="Baseline name"
           chips={Array []}
           deleteChip={[Function]}
           showToolbarItem={true}
@@ -668,7 +668,7 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
                           className="pf-c-toolbar__group pf-m-filter-group"
                         >
                           <ToolbarFilter
-                            categoryName="Fact name"
+                            categoryName="Baseline name"
                             chips={Array []}
                             deleteChip={[Function]}
                             showToolbarItem={true}

--- a/src/SmartComponents/BaselinesTable/__tests__/__snapshots__/BaselinesTable.tests.js.snap
+++ b/src/SmartComponents/BaselinesTable/__tests__/__snapshots__/BaselinesTable.tests.js.snap
@@ -700,7 +700,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                               className="pf-c-toolbar__group pf-m-filter-group"
                             >
                               <ToolbarFilter
-                                categoryName="Fact name"
+                                categoryName="Baseline name"
                                 chips={Array []}
                                 deleteChip={[Function]}
                                 showToolbarItem={true}
@@ -6927,7 +6927,7 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                               className="pf-c-toolbar__group pf-m-filter-group"
                             >
                               <ToolbarFilter
-                                categoryName="Fact name"
+                                categoryName="Baseline name"
                                 chips={Array []}
                                 deleteChip={[Function]}
                                 showToolbarItem={true}
@@ -18047,7 +18047,7 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
                               className="pf-c-toolbar__group pf-m-filter-group"
                             >
                               <ToolbarFilter
-                                categoryName="Fact name"
+                                categoryName="Baseline name"
                                 chips={Array []}
                                 deleteChip={[Function]}
                                 showToolbarItem={true}
@@ -29531,7 +29531,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                               className="pf-c-toolbar__group pf-m-filter-group"
                             >
                               <ToolbarFilter
-                                categoryName="Fact name"
+                                categoryName="Baseline name"
                                 chips={Array []}
                                 deleteChip={[Function]}
                                 showToolbarItem={true}
@@ -35714,7 +35714,7 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                               className="pf-c-toolbar__group pf-m-filter-group"
                             >
                               <ToolbarFilter
-                                categoryName="Fact name"
+                                categoryName="Baseline name"
                                 chips={Array []}
                                 deleteChip={[Function]}
                                 showToolbarItem={true}
@@ -40505,7 +40505,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                               className="pf-c-toolbar__group pf-m-filter-group"
                             >
                               <ToolbarFilter
-                                categoryName="Fact name"
+                                categoryName="Baseline name"
                                 chips={Array []}
                                 deleteChip={[Function]}
                                 showToolbarItem={true}


### PR DESCRIPTION
If you filter the baselines by name, the chip group that appears in the toolbar will read "Fact name". With this fix, it should read "Baseline name".