### PR TITLE
Fix break on 'Clear all filters' drift table

### DIFF
--- a/src/SmartComponents/modules/__tests__/helpers-tests.js
+++ b/src/SmartComponents/modules/__tests__/helpers-tests.js
@@ -1,0 +1,36 @@
+import helpers from '../helpers';
+import stateFiltersFixtures from './state-filter.fixtures';
+
+describe('helpers', () => {
+    it('it should return SAME filter selected true getStateSelected', () => {
+        const state = 'SAME';
+        const stateFilters = stateFiltersFixtures.sameStateTrue;
+        expect(helpers.getStateSelected(state, stateFilters)).toEqual(stateFiltersFixtures.sameStateTrue[0]);
+    });
+
+    it('it should return undefined when state is not selected', () => {
+        const state = 'SAME';
+        const stateFilters = stateFiltersFixtures.allStatesFalse;
+        expect(helpers.getStateSelected(state, stateFilters)).toEqual(undefined);
+    });
+
+    it('it should return SAME filter true getState', () => {
+        const state = 'SAME';
+        const stateFilters = stateFiltersFixtures.sameStateTrue;
+        expect(helpers.getState(state, stateFilters)).toEqual(stateFiltersFixtures.sameStateTrue[0]);
+    });
+
+    it('it should return SAME filter false getState', () => {
+        const state = 'SAME';
+        const stateFilters = stateFiltersFixtures.sameStateFalse;
+        expect(helpers.getState(state, stateFilters)).toEqual(stateFiltersFixtures.sameStateFalse[0]);
+    });
+
+    it('it should set tooltip when reference set', () => {
+        const data = { name: 'system1', state: 'DIFFERENT' };
+        const referenceId = 'abcd-1234-efgh-5678';
+        helpers.setTooltip(data, stateFiltersFixtures.allStatesTrue, referenceId);
+        expect(data.tooltip).toEqual('Different - At least one system fact value in this row differs from the reference.');
+    });
+});
+/*eslint-enable camelcase*/

--- a/src/SmartComponents/modules/helpers.js
+++ b/src/SmartComponents/modules/helpers.js
@@ -41,24 +41,25 @@ function getState(state, stateFilters) {
     return isStateSelected;
 }
 
-function setTooltip (data, stateFilter, referenceId) {
+function setTooltip (data, stateFilters, referenceId) {
     let type = data.comparisons ? 'category' : 'row';
+    let state = getState(data.state, stateFilters);
 
-    if (stateFilter.filter === 'SAME') {
-        data.tooltip = stateFilter.display +
+    if (data.state === 'SAME') {
+        data.tooltip = state.display +
         ' - ' +
         'All system facts in this ' + type + ' are the same.';
-    } else if (stateFilter.filter === 'INCOMPLETE_DATA') {
-        data.tooltip = stateFilter.display +
+    } else if (data.state === 'INCOMPLETE_DATA') {
+        data.tooltip = state.display +
         ' - ' +
         'At least one system fact value in this ' + type + ' is missing.';
     } else {
         if (referenceId) {
-            data.tooltip = stateFilter.display +
+            data.tooltip = state.display +
             ' - ' +
             'At least one system fact value in this ' + type + ' differs from the reference.';
         } else {
-            data.tooltip = stateFilter.display +
+            data.tooltip = state.display +
             ' - ' +
             'At least one system fact value in this ' + type + ' differs.';
         }
@@ -79,7 +80,7 @@ function filterCompareData(data, stateFilters, factFilter, referenceId) {
 
         if (data[i].comparisons) {
             if (data[i].name === factFilter) {
-                setTooltip(data[i], getState(data[i].state, stateFilters), referenceId);
+                setTooltip(data[i], stateFilters, referenceId);
                 filteredComparisons = filterComparisons(data[i].comparisons, stateFilters, '', referenceId);
                 filteredFacts.push({
                     name: data[i].name,
@@ -91,10 +92,10 @@ function filterCompareData(data, stateFilters, factFilter, referenceId) {
                 break;
             }
 
-            filteredComparisons = filterComparisons(data[i].comparisons, stateFilters, factFilter);
+            filteredComparisons = filterComparisons(data[i].comparisons, stateFilters, factFilter, referenceId);
 
             if (filteredComparisons.length) {
-                setTooltip(data[i], isStateSelected, referenceId);
+                setTooltip(data[i], stateFilters, referenceId);
                 filteredFacts.push({
                     name: data[i].name,
                     state: data[i].state,
@@ -105,7 +106,7 @@ function filterCompareData(data, stateFilters, factFilter, referenceId) {
         } else {
             if (data[i].name.includes(factFilter)) {
                 if (isStateSelected) {
-                    setTooltip(data[i], isStateSelected, referenceId);
+                    setTooltip(data[i], stateFilters, referenceId);
                     filteredFacts.push(data[i]);
                 }
             }
@@ -124,7 +125,7 @@ function filterComparisons(comparisons, stateFilters, factFilter, referenceId) {
 
         if (comparisons[i].name.includes(factFilter)) {
             if (isStateSelected) {
-                setTooltip(comparisons[i], isStateSelected, referenceId);
+                setTooltip(comparisons[i], stateFilters, referenceId);
                 filteredComparisons.push(comparisons[i]);
             }
         }
@@ -361,6 +362,9 @@ function updateStateFilters(stateFilters, updatedStateFilter) {
 
 export default {
     paginateData,
+    getStateSelected,
+    getState,
+    setTooltip,
     filterCompareData,
     sortData,
     downloadCSV,


### PR DESCRIPTION
To reproduce:
1. Add a system to a comparison that contains a category with state SAME and at least 1 INCOMPLETE_DATA. The state on the category will be DIFFERENT in this case.
2. Click 'Clear all filters' link next to the chips.

This should cause an error. You may not see it, but the Incomplete data chip should remain in the chips, which is not what we expect. We expect to see all chips cleared out.

This PR fixes the error and properly removes all chips.