### PR TITLE
Fix broken tooltips on state sort

### DIFF
--- a/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
+++ b/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
@@ -278,21 +278,22 @@ export class DriftTable extends Component {
     }
 
     renderRow(fact) {
+        const { expandedRows, stateSort } = this.props;
         let row = [];
         let rows = [];
 
         if (fact.comparisons) {
             row.push(
                 <td className={
-                    this.props.expandedRows.includes(fact.name) ?
+                    expandedRows.includes(fact.name) ?
                         'nested-fact sticky-column fixed-column-1' :
                         'sticky-column fixed-column-1' }>
-                    { this.renderExpandableRowButton(this.props.expandedRows, fact.name) } { fact.name }
+                    { this.renderExpandableRowButton(expandedRows, fact.name) } { fact.name }
                 </td>
             );
             row.push(
                 <td className="fact-state sticky-column fixed-column-2">
-                    <StateIcon fact={ fact }/>
+                    <StateIcon fact={ fact } stateSort={ stateSort }/>
                 </td>
             );
 
@@ -302,7 +303,7 @@ export class DriftTable extends Component {
 
             rows.push(<tr>{ row }</tr>);
 
-            if (this.props.expandedRows.includes(fact.name)) {
+            if (expandedRows.includes(fact.name)) {
                 fact.comparisons.forEach(comparison => {
                     row = this.renderRowChild(comparison);
                     rows.push(<tr className={ comparison.state === 'DIFFERENT' ? 'unexpected-row' : '' }>{ row }</tr>);
@@ -312,7 +313,7 @@ export class DriftTable extends Component {
             row.push(<td className="sticky-column fixed-column-1">{ fact.name }</td>);
             row.push(
                 <td className="fact-state sticky-column fixed-column-2">
-                    <StateIcon fact={ fact }/>
+                    <StateIcon fact={ fact } stateSort={ stateSort }/>
                 </td>
             );
 

--- a/src/SmartComponents/StateIcon/StateIcon.js
+++ b/src/SmartComponents/StateIcon/StateIcon.js
@@ -23,11 +23,14 @@ class StateIcon extends Component {
     };
 
     render() {
+        const { fact, stateSort } = this.props;
+
         return (
             <Tooltip
+                key={ fact.name + '-' + stateSort }
                 position="top"
                 content={
-                    <div>{ this.props.fact.tooltip }</div>
+                    <div>{ fact.tooltip }</div>
                 }
             >
                 { this.icon() }
@@ -37,7 +40,8 @@ class StateIcon extends Component {
 }
 
 StateIcon.propTypes = {
-    fact: PropTypes.object
+    fact: PropTypes.object,
+    stateSort: PropTypes.string
 };
 
 export default StateIcon;


### PR DESCRIPTION
Steps to reproduce:
1. Create a comparison
2. See that tooltips appear
3. Sort by state and see that some tooltips don't appear

This PR fixes this issue and all tooltips appear on state sort.