### PR TITLE
Add active global filters

### DIFF
--- a/src/SmartComponents/AddSystemModal/AddSystemModal.js
+++ b/src/SmartComponents/AddSystemModal/AddSystemModal.js
@@ -6,6 +6,7 @@ import { sortable, cellWidth } from '@patternfly/react-table';
 
 import SystemsTable from '../SystemsTable/SystemsTable';
 import BaselinesTable from '../BaselinesTable/BaselinesTable';
+import GlobalFilterAlert from '../GlobalFilterAlert/GlobalFilterAlert';
 import { addSystemModalActions } from './redux';
 import { baselinesTableActions } from '../BaselinesTable/redux';
 
@@ -87,9 +88,9 @@ export class AddSystemModal extends Component {
     }
 
     render() {
-        const { activeTab, addSystemModalOpened, baselineTableData, hasBaselinesReadPermissions, hasBaselinesWritePermissions,
-            hasInventoryReadPermissions, historicalProfiles, loading, entities, selectedBaselineIds, selectedHSPIds,
-            totalBaselines } = this.props;
+        const { activeTab, addSystemModalOpened, baselineTableData, globalFilterState, hasBaselinesReadPermissions,
+            hasBaselinesWritePermissions, hasInventoryReadPermissions, historicalProfiles, loading, entities, selectedBaselineIds,
+            selectedHSPIds, totalBaselines } = this.props;
         const { columns } = this.state;
 
         return (
@@ -121,6 +122,8 @@ export class AddSystemModal extends Component {
                         </Button>
                     ] }
                 >
+
+                    <GlobalFilterAlert globalFilterState={ globalFilterState } />
                     <Tabs
                         activeKey={ activeTab }
                         onSelect={ this.changeActiveTab }
@@ -188,7 +191,8 @@ AddSystemModal.propTypes = {
     totalBaselines: PropTypes.number,
     hasInventoryReadPermissions: PropTypes.bool,
     hasBaselinesReadPermissions: PropTypes.bool,
-    hasBaselinesWritePermissions: PropTypes.bool
+    hasBaselinesWritePermissions: PropTypes.bool,
+    globalFilterState: PropTypes.object
 };
 
 function mapStateToProps(state) {
@@ -203,7 +207,8 @@ function mapStateToProps(state) {
         loading: state.baselinesTableState.checkboxTable.loading,
         baselineTableData: state.baselinesTableState.checkboxTable.baselineTableData,
         historicalProfiles: state.compareState.historicalProfiles,
-        totalBaselines: state.baselinesTableState.checkboxTable.totalBaselines
+        totalBaselines: state.baselinesTableState.checkboxTable.totalBaselines,
+        globalFilterState: state.globalFilterState
     };
 }
 

--- a/src/SmartComponents/AddSystemModal/__tests__/AddSystemModal.tests.js
+++ b/src/SmartComponents/AddSystemModal/__tests__/AddSystemModal.tests.js
@@ -86,6 +86,11 @@ describe('ConnectedAddSystemModal', () => {
             },
             addSystemModalActions: {
                 toggleAddSystemModal: jest.fn()
+            },
+            globalFilterState: {
+                sidsFilter: [],
+                tagsFilter: [],
+                workloadsFilter: {}
             }
         };
 
@@ -166,6 +171,39 @@ describe('ConnectedAddSystemModal', () => {
         );
 
         expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('should render GlobalFilterAlert', () => {
+        initialState.globalFilterState.workloadsFilter = {
+            SAP: {
+                group: {
+                    name: 'Workloads'
+                },
+                item: {
+                    value: 'SAP'
+                }
+            }
+        };
+
+        initialState.globalFilterState.sidsFilter = [ 'AB1', 'XY1' ];
+        initialState.globalFilterState.tagsFilter = [
+            'patch/rest=patchman-engine', 'patch/dev=patchman-engine', 'insights-client/group=XmygroupX'
+        ];
+        const store = mockStore(initialState);
+
+        const wrapper = mount(
+            <PermissionContext.Provider value={ value }>
+                <MemoryRouter keyLength={ 0 }>
+                    <Provider store={ store }>
+                        <ConnectedAddSystemModal { ...props } />
+                    </Provider>
+                </MemoryRouter>
+            </PermissionContext.Provider>
+        );
+
+        expect(wrapper.find('.pf-c-alert__description').text()).toBe(
+            'Workloads: SAP. SAP ID (SID): AB1, XY1. Tags: patch: rest=patchman-engine, dev=patchman-engine. insights-client: group=XmygroupX. '
+        );
     });
 
     it.skip('should confirm modal with one system selected', () => {

--- a/src/SmartComponents/AddSystemModal/__tests__/__snapshots__/AddSystemModal.tests.js.snap
+++ b/src/SmartComponents/AddSystemModal/__tests__/__snapshots__/AddSystemModal.tests.js.snap
@@ -36,6 +36,7 @@ exports[`AddSystemModal should render correctly 1`] = `
     variant="default"
     width="950px"
   >
+    <GlobalFilterAlert />
     <Tabs
       activeKey={0}
       component="div"
@@ -9326,6 +9327,13 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
               "selectedSystemIds": Array [],
             }
           }
+          globalFilterState={
+            Object {
+              "sidsFilter": Array [],
+              "tagsFilter": Array [],
+              "workloadsFilter": Object {},
+            }
+          }
           hasInventoryReadPermissions={true}
           historicalProfiles={Array []}
           loading={false}
@@ -10423,6 +10431,15 @@ Try changing your filter settings.
                                 className="pf-c-modal-box__body"
                                 id="pf-modal-part-8"
                               >
+                                <GlobalFilterAlert
+                                  globalFilterState={
+                                    Object {
+                                      "sidsFilter": Array [],
+                                      "tagsFilter": Array [],
+                                      "workloadsFilter": Object {},
+                                    }
+                                  }
+                                />
                                 <Tabs
                                   activeKey={1}
                                   component="div"
@@ -14758,6 +14775,13 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
               "selectedSystemIds": Array [],
             }
           }
+          globalFilterState={
+            Object {
+              "sidsFilter": Array [],
+              "tagsFilter": Array [],
+              "workloadsFilter": Object {},
+            }
+          }
           hasInventoryReadPermissions={true}
           historicalProfiles={Array []}
           loading={false}
@@ -15855,6 +15879,15 @@ Try changing your filter settings.
                                 className="pf-c-modal-box__body"
                                 id="pf-modal-part-2"
                               >
+                                <GlobalFilterAlert
+                                  globalFilterState={
+                                    Object {
+                                      "sidsFilter": Array [],
+                                      "tagsFilter": Array [],
+                                      "workloadsFilter": Object {},
+                                    }
+                                  }
+                                />
                                 <Tabs
                                   activeKey={0}
                                   component="div"
@@ -20190,6 +20223,13 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
               "selectedSystemIds": Array [],
             }
           }
+          globalFilterState={
+            Object {
+              "sidsFilter": Array [],
+              "tagsFilter": Array [],
+              "workloadsFilter": Object {},
+            }
+          }
           hasInventoryReadPermissions={false}
           historicalProfiles={Array []}
           loading={false}
@@ -21305,6 +21345,15 @@ Try changing your filter settings.
                                 className="pf-c-modal-box__body"
                                 id="pf-modal-part-4"
                               >
+                                <GlobalFilterAlert
+                                  globalFilterState={
+                                    Object {
+                                      "sidsFilter": Array [],
+                                      "tagsFilter": Array [],
+                                      "workloadsFilter": Object {},
+                                    }
+                                  }
+                                />
                                 <Tabs
                                   activeKey={0}
                                   component="div"

--- a/src/SmartComponents/BaselinesPage/CreateBaselineModal/CreateBaselineModal.js
+++ b/src/SmartComponents/BaselinesPage/CreateBaselineModal/CreateBaselineModal.js
@@ -7,6 +7,7 @@ import { sortable, cellWidth } from '@patternfly/react-table';
 
 import SystemsTable from '../../SystemsTable/SystemsTable';
 import BaselinesTable from '../../BaselinesTable/BaselinesTable';
+import GlobalFilterAlert from '../../GlobalFilterAlert/GlobalFilterAlert';
 import { createBaselineModalActions } from './redux';
 import { baselinesTableActions } from '../../BaselinesTable/redux';
 
@@ -263,7 +264,8 @@ export class CreateBaselineModal extends Component {
     }
 
     render() {
-        const { createBaselineError, createBaselineModalOpened } = this.props;
+        const { createBaselineError, createBaselineModalOpened, globalFilterState } = this.props;
+        const { copySystemChecked } = this.state;
 
         return (
             <Modal
@@ -273,6 +275,10 @@ export class CreateBaselineModal extends Component {
                 onClose={ this.cancelModal }
                 actions={ this.renderActions() }
             >
+                { copySystemChecked
+                    ? <GlobalFilterAlert globalFilterState={ globalFilterState }/>
+                    : null
+                }
                 { createBaselineError.status
                     ? <Alert
                         variant='danger'
@@ -310,7 +316,8 @@ CreateBaselineModal.propTypes = {
     selectedHSPIds: PropTypes.array,
     hasInventoryReadPermissions: PropTypes.bool,
     hasReadPermissions: PropTypes.bool,
-    hasWritePermissions: PropTypes.bool
+    hasWritePermissions: PropTypes.bool,
+    globalFilterState: PropTypes.object
 };
 
 function mapStateToProps(state) {
@@ -325,7 +332,8 @@ function mapStateToProps(state) {
         baselineTableData: state.baselinesTableState.radioTable.baselineTableData,
         totalBaselines: state.baselinesTableState.radioTable.totalBaselines,
         historicalProfiles: state.compareState.historicalProfiles,
-        selectedHSPIds: state.historicProfilesState.selectedHSPIds
+        selectedHSPIds: state.historicProfilesState.selectedHSPIds,
+        globalFilterState: state.globalFilterState
     };
 }
 

--- a/src/SmartComponents/BaselinesPage/CreateBaselineModal/__tests__/CreateBaselineModal.tests.js
+++ b/src/SmartComponents/BaselinesPage/CreateBaselineModal/__tests__/CreateBaselineModal.tests.js
@@ -98,6 +98,23 @@ describe('CreateBaselineModal', () => {
             wrapper.find('.pf-c-button').at(1).simulate('click');
             expect(createBaseline).toHaveBeenCalledTimes(1);
         });
+
+        it('should render global filter alert', () => {
+            const event = { currentTarget: { value: 'copySystemChecked' }};
+            props.createBaselineModalOpened = true;
+            const wrapper = shallow(
+                <CreateBaselineModal { ...props }/>
+            );
+
+            expect(wrapper.find('GlobalFilterAlert')).toHaveLength(0);
+
+            /*eslint-disable no-undef*/
+            event.currentTarget.value = 'copySystemChecked';
+            wrapper.find('[id="copy system"]').simulate('change', _, event);
+            /*eslint-enable no-undef*/
+
+            expect(wrapper.find('GlobalFilterAlert')).toHaveLength(1);
+        });
     });
 
     it('should cancelModal', () => {

--- a/src/SmartComponents/GlobalFilterAlert/GlobalFilterAlert.js
+++ b/src/SmartComponents/GlobalFilterAlert/GlobalFilterAlert.js
@@ -1,0 +1,99 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Alert, AlertActionCloseButton } from '@patternfly/react-core';
+
+export class GlobalFilterAlert extends Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            isOpen: true
+        };
+
+        this.toggleIsOpen = () => {
+            const { isOpen } = this.state;
+
+            this.setState({
+                isOpen: !isOpen
+            });
+        };
+    }
+
+    buildBody = () => {
+        const { sidsFilter, tagsFilter, workloadsFilter } = this.props.globalFilterState;
+        let filters = 'Workloads: ' + Object.keys(workloadsFilter)[0] + '. ';
+
+        if (sidsFilter.length) {
+            filters += 'SAP ID (SID): ';
+            for (let i = 0; i < sidsFilter.length; i++) {
+                filters += sidsFilter[i];
+                if (i + 1 === sidsFilter.length) {
+                    filters += '. ';
+                } else {
+                    filters += ', ';
+                }
+            }
+        }
+
+        if (tagsFilter.length) {
+            let tags = [];
+            let tagsList = {};
+            filters += 'Tags: ';
+
+            tagsFilter.forEach(function(tag) {
+                tags.push(tag.split('/'));
+            });
+
+            tags.forEach(function(tag) {
+                if (!(tag[0] in tagsList)) {
+                    tagsList[tag[0]] = [ tag[1] ];
+                } else {
+                    tagsList[tag[0]].push(tag[1]);
+                }
+            });
+
+            for (const [ key, value ] of Object.entries(tagsList)) {
+                filters += key + ': ';
+                for (let i = 0; i < value.length; i++) {
+                    filters += value[i];
+                    if (i + 1 === value.length) {
+                        filters += '. ';
+                    } else {
+                        filters += ', ';
+                    }
+                }
+            }
+        }
+
+        return filters;
+    }
+
+    render() {
+        const { sidsFilter, tagsFilter, workloadsFilter } = this.props.globalFilterState;
+        const { isOpen } = this.state;
+
+        return (
+            <React.Fragment>
+                { isOpen && (workloadsFilter.SAP || sidsFilter.length > 0 || tagsFilter.length > 0)
+                    ? <Alert
+                        variant='info'
+                        title='Your systems are pre-filtered by the global context selector.'
+                        isInline
+                        actionClose={ <AlertActionCloseButton onClose={ () => this.toggleIsOpen() } /> }
+                    >
+                        <p>
+                            { this.buildBody() }
+                        </p>
+                    </Alert>
+                    : null
+                }
+            </React.Fragment>
+        );
+    }
+}
+
+GlobalFilterAlert.propTypes = {
+    globalFilterState: PropTypes.object
+};
+
+export default GlobalFilterAlert;

--- a/src/SmartComponents/GlobalFilterAlert/__tests__/GlobalFilterAlert.tests.js
+++ b/src/SmartComponents/GlobalFilterAlert/__tests__/GlobalFilterAlert.tests.js
@@ -1,0 +1,107 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import toJson from 'enzyme-to-json';
+
+import { GlobalFilterAlert } from '../GlobalFilterAlert';
+
+describe('GlobalFilterAlert', () => {
+    let props;
+
+    beforeEach(() => {
+        props = {
+            globalFilterState: {
+                sidsFilter: [],
+                tagsFilter: [],
+                workloadsFilter: {}
+            }
+        };
+    });
+
+    it('should not render when empty', () => {
+        const wrapper = shallow(
+            <GlobalFilterAlert
+                { ...props }
+            />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('should not render with all workloads', () => {
+        props.globalFilterState.workloadsFilter = {
+            'All Workloads': {
+                group: {
+                    name: 'Workloads'
+                }
+            }
+        };
+
+        const wrapper = shallow(
+            <GlobalFilterAlert
+                { ...props }
+            />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('should render with SAP', () => {
+        props.globalFilterState.workloadsFilter = {
+            SAP: {
+                group: {
+                    name: 'Workloads'
+                },
+                item: {
+                    value: 'SAP'
+                }
+            }
+        };
+
+        const wrapper = shallow(
+            <GlobalFilterAlert
+                { ...props }
+            />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('should render with SAP and filters', () => {
+        props.globalFilterState.workloadsFilter = {
+            SAP: {
+                group: {
+                    name: 'Workloads'
+                },
+                item: {
+                    value: 'SAP'
+                }
+            }
+        };
+
+        props.globalFilterState.sidsFilter = [ 'AB1', 'XY1' ];
+        props.globalFilterState.tagsFilter = [ 'patch/rest=patchman-engine', 'patch/dev=patchman-engine', 'insights-client/group=XmygroupX' ];
+
+        const wrapper = shallow(
+            <GlobalFilterAlert
+                { ...props }
+            />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('should close alert', () => {
+        props.globalFilterState.workloadsFilter = {
+            SAP: {}
+        };
+
+        const wrapper = mount(
+            <GlobalFilterAlert
+                { ...props }
+            />
+        );
+
+        wrapper.find('AlertActionCloseButton').simulate('click');
+        expect(wrapper.state('isOpen')).toBe(false);
+    });
+});

--- a/src/SmartComponents/GlobalFilterAlert/__tests__/__snapshots__/GlobalFilterAlert.tests.js.snap
+++ b/src/SmartComponents/GlobalFilterAlert/__tests__/__snapshots__/GlobalFilterAlert.tests.js.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GlobalFilterAlert should not render when empty 1`] = `<Fragment />`;
+
+exports[`GlobalFilterAlert should not render with all workloads 1`] = `<Fragment />`;
+
+exports[`GlobalFilterAlert should render with SAP 1`] = `
+<Fragment>
+  <Alert
+    actionClose={
+      <AlertActionCloseButton
+        onClose={[Function]}
+      />
+    }
+    isInline={true}
+    title="Your systems are pre-filtered by the global context selector."
+    variant="info"
+  >
+    <p>
+      Workloads: SAP. 
+    </p>
+  </Alert>
+</Fragment>
+`;
+
+exports[`GlobalFilterAlert should render with SAP and filters 1`] = `
+<Fragment>
+  <Alert
+    actionClose={
+      <AlertActionCloseButton
+        onClose={[Function]}
+      />
+    }
+    isInline={true}
+    title="Your systems are pre-filtered by the global context selector."
+    variant="info"
+  >
+    <p>
+      Workloads: SAP. SAP ID (SID): AB1, XY1. Tags: patch: rest=patchman-engine, dev=patchman-engine. insights-client: group=XmygroupX. 
+    </p>
+  </Alert>
+</Fragment>
+`;


### PR DESCRIPTION
This PR adds an alert to the top of the add system and create baseline modals that shows any active global filters. The filter will only show up if you choose a filter. If you only select 'All Workloads' but don't select any tags or SAP IDs, then you won't see the alert.

You should be able to close this alert by clicking the 'X'. If you back out of the modal and go back in, the alert should reappear.