### PR TITLE
Add additional app data to DOM to improve Pendo

### DIFF
--- a/src/SmartComponents/BaselinesPage/BaselinesPage.js
+++ b/src/SmartComponents/BaselinesPage/BaselinesPage.js
@@ -40,6 +40,7 @@ export class BaselinesPage extends Component {
 
     async componentDidMount() {
         await window.insights.chrome.auth.getUser();
+        await window.insights?.chrome?.appAction?.('baseline-list');
     }
 
     fetchBaseline = (baselineId) => {

--- a/src/SmartComponents/BaselinesPage/EditBaseline/EditBaseline.js
+++ b/src/SmartComponents/BaselinesPage/EditBaseline/EditBaseline.js
@@ -54,7 +54,11 @@ export class EditBaseline extends Component {
     }
 
     async componentDidMount() {
+        const { match: { params }} = this.props;
+
         await window.insights.chrome.auth.getUser();
+        await window.insights?.chrome?.appAction?.('baseline-view');
+        await window.insights?.chrome?.appObjectId(params.id);
     }
 
     componentDidUpdate() {

--- a/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
+++ b/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
@@ -44,6 +44,12 @@ export class DriftTable extends Component {
         }
     }
 
+    async shouldComponentUpdate(nextProps) {
+        if (!nextProps.emptyState) {
+            await window.insights?.chrome?.appAction?.('comparison-view');
+        }
+    }
+
     shiftReferenceToFront = (masterList) => {
         let index;
         let systemToMove;

--- a/src/SmartComponents/EmptyStateDisplay/EmptyStateDisplay.js
+++ b/src/SmartComponents/EmptyStateDisplay/EmptyStateDisplay.js
@@ -8,6 +8,10 @@ export class EmptyStateDisplay extends Component {
         super(props);
     }
 
+    async componentDidMount() {
+        await window.insights?.chrome?.appAction?.('comparison-list');
+    }
+
     render() {
         const { button, color, error, icon, isSmall, text, title } = this.props;
 


### PR DESCRIPTION
To test:
1. Go to comparison landing page
2. Open developer tools with F12 (or function + F12)
3. Click the `Elements` tab at the top of the dev tools window
4. Press `Ctrl` + `F` to find a string in the html

The following should be found as the `data-ouia-page-type` when you search on the corresponding pages:

- Comparison landing page (no comparison) - `comparison-list`
- Comparison (at least one system/baseline/hsp compared) - `comparison-view`
    - It should change back to `comparison-list` if you clear all comparisons.
- Baselines page - `baseline-list`
- Edit baseline - `baseline-view`
    - Here, you should also find the id of the baseline you selected by searching for `data-ouia-page-object-id`