### PR TITLE
Adds config for spandx to run local frontend alongside drift-dev-setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,24 @@ And run the follwing command in another terminal:
 `npm run start`
 
 
+# how to run with [drift-dev-setup](https://github.com/RedHatInsights/drift-dev-setup)
+
+In terminal
+```
+cd drift-frontend
+SPANDX_PORT=1338 SPANDX_CONFIG=profiles/local-drift-dev-setup.js bash ../insights-proxy/scripts/run.sh
+```
+Note that `SPANDX_PORT` should be different from the port used for [drift-dev-setup](https://github.com/RedHatInsights/drift-dev-setup) which is `1337` by default.
+
+In another terminal
+```
+cd drift-frontend
+npm run start -- --port 8001 # value set in profiles/local-drift-dev-setup.js
+```
+
+This way we can have running both frontend from container via [drift-dev-setup](https://github.com/RedHatInsights/drift-dev-setup) and one from local source each running on different port.
+
+
 # troubleshooting
 
 If you are updating the drift-frontend app after a long period of time away, your node_modules folder may not be up to date with the packages outlined in the `package.json` file. The easiest way to update this quickly and efficiently is to fun the following commands in a terminal window.

--- a/profiles/local-drift-dev-setup.js
+++ b/profiles/local-drift-dev-setup.js
@@ -1,0 +1,24 @@
+/*global module*/
+
+const SECTION = 'insights';
+const APP_ID = 'drift';
+const FRONTEND_PORT = 8001;
+const routes = {};
+
+// backend
+routes[`/api/inventory`] = { host: `http://localhost:8082` };
+routes[`/api/system-baseline`] = { host: `http://localhost:8083` };
+routes[`/api/drift`] = { host: `http://localhost:8084` };
+routes[`/api/historical-system-profiles`] = { host: `http://localhost:8085` };
+
+// frontend
+routes[`/beta/${SECTION}/${APP_ID}`] = { host: `http://localhost:${FRONTEND_PORT}` };
+routes[`/${SECTION}/${APP_ID}`]      = { host: `http://localhost:${FRONTEND_PORT}` };
+routes[`/beta/apps/${APP_ID}`]       = { host: `http://localhost:${FRONTEND_PORT}` };
+routes[`/apps/${APP_ID}`]            = { host: `http://localhost:${FRONTEND_PORT}` };
+
+
+module.exports = { routes };
+
+
+


### PR DESCRIPTION
This can help developers with running frontend from local source alongside the one from https://github.com/RedHatInsights/drift-dev-setup at the same time.