### PR TITLE
DRFT-112 Fix multi-filter broken with category filter

### DIFF
--- a/src/SmartComponents/modules/helpers.js
+++ b/src/SmartComponents/modules/helpers.js
@@ -89,7 +89,7 @@ function filterCompareData(data, stateFilters, factFilter, referenceId, activeFa
                     tooltip: data[i].tooltip
                 });
 
-                break;
+                continue;
             }
 
             filteredComparisons = filterComparisons(data[i].comparisons, stateFilters, factFilter, referenceId, activeFactFilters);


### PR DESCRIPTION
To reproduce:
1. Create a comparison
2. Add a filter for category (include full category name to filter out all but the full category. installed_packages is a good example) and press Enter
3. Begin typing in a new filter for a regular fact that is alphabetically after your category (if your category is installed_packages, type in something like os_release)

The comparison will not show the os_release in the filtered facts. I replaced a `break` with a `continue` because I was matching the category and then breaking out of the entire loop, ignoring every fact and category that came after it. Choosing to `continue` just jumps to the next iteration rather than breaking out of the entire loop.