### PR TITLE
DRFT-113 Fix persistent activeFactFilter on new fetch

### DIFF
--- a/src/SmartComponents/modules/__tests__/reducer-test.js
+++ b/src/SmartComponents/modules/__tests__/reducer-test.js
@@ -248,6 +248,36 @@ describe('compare reducer', () => {
         });
     });
 
+    it('should keep activeFactFilters FETCH_COMPARE_FULFILLED', () => {
+        expect(
+            compareReducer({
+                perPage: 50,
+                page: 1,
+                stateFilters: stateFilters.allStatesTrue,
+                factFilter: '',
+                activeFactFilters: [ 'bios' ]},
+            {
+                payload: compareReducerPayload,
+                type: `${types.FETCH_COMPARE}_FULFILLED`
+            })
+        ).toEqual({
+            baselines: [],
+            historicalProfiles: [],
+            fullCompareData: compareReducerState.facts,
+            loading: false,
+            factFilter: '',
+            activeFactFilters: [ 'bios' ],
+            filteredCompareData: factFilteredStateTwo.facts,
+            sortedFilteredFacts: factFilteredStateTwo.facts,
+            systems: factFilteredStateTwo.systems,
+            page: 1,
+            perPage: 50,
+            stateFilters: stateFilters.allStatesTrue,
+            totalFacts: 1,
+            emptyState: false
+        });
+    });
+
     it('should handle fullCompareData undefined', () => {
         expect(
             compareReducer({

--- a/src/SmartComponents/modules/reducers.js
+++ b/src/SmartComponents/modules/reducers.js
@@ -103,7 +103,7 @@ export function compareReducer(state = initialState, action) {
             };
         case `${types.FETCH_COMPARE}_FULFILLED`:
             filteredFacts = reducerHelpers.filterCompareData(
-                action.payload.facts, state.stateFilters, state.factFilter, state.referenceId, state.newActiveFactFilters
+                action.payload.facts, state.stateFilters, state.factFilter, state.referenceId, state.activeFactFilters
             );
             sortedFacts = reducerHelpers.sortData(filteredFacts, state.factSort, state.stateSort);
             paginatedFacts = reducerHelpers.paginateData(sortedFacts, 1, state.perPage);


### PR DESCRIPTION
To reproduce:
1. Add a system for comparison
2. Filter by fact.  Works correctly.
3. Add another system.

The facts are no longer filtered, although the filter chip is still there.

This PR fixes the bug where an empty array was being added to the a filter function in the reducer on FETCH_COMPARE_FULFILLED instead of passing the activeFactFilter in the state.