### PR TITLE
DRFT-121 Fix clear all comparisons for activeFactFilters

### DIFF
--- a/src/SmartComponents/modules/__tests__/reducer-test.js
+++ b/src/SmartComponents/modules/__tests__/reducer-test.js
@@ -50,6 +50,7 @@ describe('compare reducer', () => {
                 stateSort: ASC,
                 stateFilters: stateFilters.diffStateTrue,
                 factFilter: 'dog',
+                activeFactFilters: [ 'cat', 'mouse' ],
                 expandedRows: [ 'something', 'something-else' ]}, {
                 type: `${types.CLEAR_COMPARISON}` })
         ).toEqual({
@@ -58,7 +59,7 @@ describe('compare reducer', () => {
             sortedFilteredFacts: [],
             referenceId: undefined,
             factFilter: 'dog',
-            activeFactFilters: [],
+            activeFactFilters: [ 'cat', 'mouse' ],
             stateFilters: stateFilters.diffStateTrue,
             factSort: DESC,
             stateSort: ASC,

--- a/src/SmartComponents/modules/reducers.js
+++ b/src/SmartComponents/modules/reducers.js
@@ -61,6 +61,7 @@ export function compareReducer(state = initialState, action) {
                 ...initialState,
                 stateFilters: state.stateFilters,
                 factFilter: state.factFilter,
+                activeFactFilters: state.activeFactFilters,
                 factSort: state.factSort,
                 stateSort: state.stateSort,
                 perPage: state.perPage,


### PR DESCRIPTION
To repro:
Add two systems
Apply filter by name, press enter
Apply another name filter, don't press enter
Clear all comparisons
Add a system

Only one of the name filters remains applied. This PR keeps all filters on clear all comparisons.