### PR TITLE
Fix missing styles in prod build.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1896,9 +1896,9 @@
       }
     },
     "@redhat-cloud-services/frontend-components-config": {
-      "version": "3.0.0-beta17",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-3.0.0-beta17.tgz",
-      "integrity": "sha512-oYyaC2MQXFyIigWpa0o5Z9eCCS6In3EcW2jURVvvV+JCXMLw+2F8mTYdTUqfv+5WHrzByH+7KjSJjz2KMcnUNg==",
+      "version": "3.0.0-beta19",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-3.0.0-beta19.tgz",
+      "integrity": "sha512-ZML8BO1dcGBolAjuhxbwwU0OYamF7ThPQ54pVJ4UJYMT+UnHd1rU8KTaPsjqCOj6mvyw4P4BTeztDxSun0Zzjw==",
       "dev": true,
       "requires": {
         "assert": "^2.0.0",
@@ -11886,9 +11886,9 @@
               "dev": true
             },
             "entities": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-              "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+              "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
               "dev": true
             }
           }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@babel/preset-env": "^7.11.0",
     "@babel/preset-flow": "^7.10.4",
     "@babel/preset-react": "^7.10.4",
-    "@redhat-cloud-services/frontend-components-config": "3.0.0-beta17",
+    "@redhat-cloud-services/frontend-components-config": "3.0.0-beta19",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^25.5.1",


### PR DESCRIPTION
The CSS scope was not properly assigned to minified CSS. Therefore the default PF styling was overriding the scoped CSS thus causing visual bugs.

You can reproduce this locally when running the app locally via `npm run prod`

we should no longer need: https://github.com/RedHatInsights/drift-frontend/pull/426
### Before
![Screenshot from 2021-01-26 10-57-36](https://user-images.githubusercontent.com/22619452/105830762-2f7fcc80-5fc6-11eb-9191-9b6fd9e235d3.png)


### After
![Screenshot from 2021-01-26 11-00-33](https://user-images.githubusercontent.com/22619452/105830781-33135380-5fc6-11eb-974a-f97a12b26a79.png)

@johnsonm325 