### PR TITLE
Fix stable build by using new version of config and passing custom deployment

### DIFF
--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -3,7 +3,9 @@ const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPl
 const config = require('@redhat-cloud-services/frontend-components-config');
 const { config: webpackConfig, plugins } = config({
     rootFolder: resolve(__dirname, '../'),
-    https: false
+    https: false,
+    debug: true,
+    ...process.env.BUILD_STABLE && { deployment: 'apps' }
 });
 
 plugins.push(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1896,9 +1896,9 @@
       }
     },
     "@redhat-cloud-services/frontend-components-config": {
-      "version": "3.0.0-beta19",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-3.0.0-beta19.tgz",
-      "integrity": "sha512-ZML8BO1dcGBolAjuhxbwwU0OYamF7ThPQ54pVJ4UJYMT+UnHd1rU8KTaPsjqCOj6mvyw4P4BTeztDxSun0Zzjw==",
+      "version": "3.0.0-beta22",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-3.0.0-beta22.tgz",
+      "integrity": "sha512-bTVitPcJL9M9QXZwWHHTg0UEQ3vcg0FEFTD6mjDGLW/TuubWcNwALaqlk6RNF9oG+pFS1bkp5x2Qd2nflrToqg==",
       "dev": true,
       "requires": {
         "assert": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@babel/preset-env": "^7.11.0",
     "@babel/preset-flow": "^7.10.4",
     "@babel/preset-react": "^7.10.4",
-    "@redhat-cloud-services/frontend-components-config": "3.0.0-beta19",
+    "@redhat-cloud-services/frontend-components-config": "3.0.0-beta22",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^25.5.1",


### PR DESCRIPTION
### Fix stable deployments

Since drift is using custom release that releases stable builds from master branch we have to pass in `deployment` config variable to shared config. This has been enabled in most recent version.