### PR TITLE
Check if SAP is selected

### DIFF
--- a/src/SmartComponents/GlobalFilterAlert/GlobalFilterAlert.js
+++ b/src/SmartComponents/GlobalFilterAlert/GlobalFilterAlert.js
@@ -74,7 +74,7 @@ export class GlobalFilterAlert extends Component {
 
         return (
             <React.Fragment>
-                { isOpen && (workloadsFilter.SAP || sidsFilter.length > 0 || tagsFilter.length > 0)
+                { isOpen && (workloadsFilter.SAP?.isSelected || sidsFilter.length > 0 || tagsFilter.length > 0)
                     ? <Alert
                         variant='info'
                         title='Your systems are pre-filtered by the global context selector.'

--- a/src/SmartComponents/GlobalFilterAlert/__tests__/GlobalFilterAlert.tests.js
+++ b/src/SmartComponents/GlobalFilterAlert/__tests__/GlobalFilterAlert.tests.js
@@ -53,7 +53,30 @@ describe('GlobalFilterAlert', () => {
                 },
                 item: {
                     value: 'SAP'
-                }
+                },
+                isSelected: true
+            }
+        };
+
+        const wrapper = shallow(
+            <GlobalFilterAlert
+                { ...props }
+            />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('should NOT render with not selected SAP', () => {
+        props.globalFilterState.workloadsFilter = {
+            SAP: {
+                group: {
+                    name: 'Workloads'
+                },
+                item: {
+                    value: 'SAP'
+                },
+                isSelected: false
             }
         };
 
@@ -74,7 +97,8 @@ describe('GlobalFilterAlert', () => {
                 },
                 item: {
                     value: 'SAP'
-                }
+                },
+                isSelected: true
             }
         };
 
@@ -92,7 +116,9 @@ describe('GlobalFilterAlert', () => {
 
     it('should close alert', () => {
         props.globalFilterState.workloadsFilter = {
-            SAP: {}
+            SAP: {
+                isSelected: true
+            }
         };
 
         const wrapper = mount(

--- a/src/SmartComponents/GlobalFilterAlert/__tests__/__snapshots__/GlobalFilterAlert.tests.js.snap
+++ b/src/SmartComponents/GlobalFilterAlert/__tests__/__snapshots__/GlobalFilterAlert.tests.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`GlobalFilterAlert should NOT render with not selected SAP 1`] = `<Fragment />`;
+
 exports[`GlobalFilterAlert should not render when empty 1`] = `<Fragment />`;
 
 exports[`GlobalFilterAlert should not render with all workloads 1`] = `<Fragment />`;


### PR DESCRIPTION
### Check if workloads filter has SAP selected

Because workloads has been changed and now it is checkbox we have to check if SAP is really selected and if so show the global filter, otherwise no need to show it at all.