### PR TITLE
[DRFT-159] Fix workloads: undefined in global filter alert

### DIFF
--- a/src/SmartComponents/GlobalFilterAlert/GlobalFilterAlert.js
+++ b/src/SmartComponents/GlobalFilterAlert/GlobalFilterAlert.js
@@ -21,7 +21,10 @@ export class GlobalFilterAlert extends Component {
 
     buildBody = () => {
         const { sidsFilter, tagsFilter, workloadsFilter } = this.props.globalFilterState;
-        let filters = 'Workloads: ' + Object.keys(workloadsFilter)[0] + '. ';
+
+        let filters = Object.keys(workloadsFilter).length
+            ? 'Workloads: ' + Object.keys(workloadsFilter)[0] + '. '
+            : '';
 
         if (sidsFilter.length) {
             filters += 'SAP ID (SID): ';


### PR DESCRIPTION
To reproduce:
- Spin up fresh drift page with no pre-selected global filters
- Choose a SAP ID (SID) from the global filters, but do not choose a workload
- Click the `Add to comparison` button to view the modal

You should see `Workloads: undefined`

With this fix, the workloads won't show up if you haven't filtered by a workload