### PR TITLE
[DRFT-165] Fix version import in constants.js

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,4 @@
-import { version } from './../package.json';
+import version from './../package.json';
 export const DRIFT_API_ROOT = '/api/drift/v1';
 export const BASELINE_API_ROOT = '/api/system-baseline/v1';
 export const HISTORICAL_PROFILES_API_ROOT = '/api/historical-system-profiles/v1';


### PR DESCRIPTION
We were importing as `{ version }` when the import of the file is an object. We simply had to import `version` from the returned object.

To reproduce:
1. run `npm run start` on master and see the compiler warning.

This fix will cause the compiler to compile successfully every time instead of with warnings.