### PR TITLE
[DRFT-144] Add filters and sorting to url

### DIFF
--- a/src/SmartComponents/AddSystemModal/AddSystemModal.js
+++ b/src/SmartComponents/AddSystemModal/AddSystemModal.js
@@ -63,11 +63,7 @@ export class AddSystemModal extends Component {
     }
 
     selectedSystemIds() {
-        let ids = this.props.systems.map(function (system) {
-            return system.id;
-        });
-
-        return ids ? ids : [];
+        return this.props.systems?.map(({ id }) => id) || [];
     }
 
     changeActiveTab(event, tabIndex) {

--- a/src/SmartComponents/DriftPage/DriftPage.js
+++ b/src/SmartComponents/DriftPage/DriftPage.js
@@ -37,6 +37,19 @@ export class DriftPage extends Component {
         await window.insights.chrome.auth.getUser();
     }
 
+    setHistory = () => {
+        const { activeFactFilters, baselines, factFilter, factSort, historicalProfiles, history, referenceId, stateFilters,
+            stateSort, systems } = this.props;
+
+        let systemIds = systems.map(system => system.id);
+        let baselineIds = baselines.map(baseline => baseline.id);
+        let HSPIds = historicalProfiles.map(hsp => hsp.id);
+
+        setHistory(
+            history, systemIds, baselineIds, HSPIds, referenceId, activeFactFilters, factFilter, stateFilters, factSort, stateSort
+        );
+    }
+
     setIsFirstReference = (value) => {
         this.setState({
             isFirstReference: value
@@ -75,9 +88,9 @@ export class DriftPage extends Component {
     }
 
     render() {
-        const { activeFactFilters, addStateFilter, clearAllFactFilters, clearComparison, clearComparisonFilters, clearSelectedBaselines,
-            emptyState, error, exportToCSV, factFilter, filterByFact, handleFactFilter, history, loading, page, perPage, stateFilters,
-            totalFacts, updatePagination, updateReferenceId } = this.props;
+        const { activeFactFilters, addStateFilter, baselines, clearAllFactFilters, clearComparison, clearComparisonFilters, clearSelectedBaselines,
+            emptyState, error, exportToCSV, factFilter, factSort, filterByFact, handleFactFilter, historicalProfiles, history, loading, page, perPage,
+            referenceId, stateFilters, stateSort, systems, totalFacts, updatePagination, updateReferenceId } = this.props;
         const { isFirstReference } = this.state;
 
         return (
@@ -128,6 +141,7 @@ export class DriftPage extends Component {
                                                         activeFactFilters={ activeFactFilters }
                                                         handleFactFilter={ handleFactFilter }
                                                         clearAllFactFilters={ clearAllFactFilters }
+                                                        setHistory={ this.setHistory }
                                                     />
                                                     : null
                                                 }
@@ -140,6 +154,18 @@ export class DriftPage extends Component {
                                                     hasBaselinesReadPermissions={ value.permissions.baselinesRead }
                                                     hasBaselinesWritePermissions={ value.permissions.baselinesWrite }
                                                     hasInventoryReadPermissions={ value.permissions.inventoryRead }
+                                                    handleFactFilter={ handleFactFilter }
+                                                    addStateFilter={ addStateFilter }
+                                                    stateFilters={ stateFilters }
+                                                    activeFactFilters={ activeFactFilters }
+                                                    factFilter={ factFilter }
+                                                    setHistory={ this.setHistory }
+                                                    factSort={ factSort }
+                                                    stateSort={ stateSort }
+                                                    referenceId={ referenceId }
+                                                    systems={ systems }
+                                                    baselines={ baselines }
+                                                    historicalProfiles={ historicalProfiles }
                                                 />
                                                 { !emptyState && !loading ?
                                                     <Toolbar className="drift-toolbar">
@@ -185,6 +211,7 @@ DriftPage.propTypes = {
     clearComparison: PropTypes.func,
     clearComparisonFilters: PropTypes.func,
     history: PropTypes.object,
+    location: PropTypes.object,
     selectHistoricProfiles: PropTypes.func,
     selectedHSPIds: PropTypes.array,
     revertCompareData: PropTypes.func,
@@ -196,7 +223,13 @@ DriftPage.propTypes = {
     filterByFact: PropTypes.func,
     stateFilters: PropTypes.array,
     addStateFilter: PropTypes.func,
-    clearAllFactFilters: PropTypes.func
+    clearAllFactFilters: PropTypes.func,
+    factSort: PropTypes.string,
+    stateSort: PropTypes.string,
+    referenceId: PropTypes.number,
+    systems: PropTypes.array,
+    baselines: PropTypes.array,
+    historicalProfiles: PropTypes.array
 };
 
 function mapDispatchToProps(dispatch) {
@@ -228,7 +261,13 @@ function mapStateToProps(state) {
         previousStateSystems: state.compareState.previousStateSystems,
         factFilter: state.compareState.factFilter,
         stateFilters: state.compareState.stateFilters,
-        activeFactFilters: state.compareState.activeFactFilters
+        activeFactFilters: state.compareState.activeFactFilters,
+        factSort: state.compareState.factSort,
+        stateSort: state.compareState.stateSort,
+        referenceId: state.compareState.referenceId,
+        systems: state.compareState.systems,
+        baselines: state.compareState.baselines,
+        historicalProfiles: state.compareState.historicalProfiles
     };
 }
 

--- a/src/SmartComponents/DriftPage/DriftTable/ComparisonHeader/ComparisonHeader.js
+++ b/src/SmartComponents/DriftPage/DriftTable/ComparisonHeader/ComparisonHeader.js
@@ -35,14 +35,16 @@ class ComparisonHeader extends Component {
         return sortIcon;
     }
 
-    toggleSort(sortType, sort) {
-        const { toggleFactSort, toggleStateSort } = this.props;
+    async toggleSort(sortType, sort) {
+        const { setHistory, toggleFactSort, toggleStateSort } = this.props;
 
         if (sortType === 'fact') {
-            toggleFactSort(sort);
+            await toggleFactSort(sort);
         } else {
-            toggleStateSort(sort);
+            await toggleStateSort(sort);
         }
+
+        setHistory();
     }
 
     renderSystemHeaders() {
@@ -187,7 +189,8 @@ ComparisonHeader.propTypes = {
     systemIds: PropTypes.array,
     toggleFactSort: PropTypes.func,
     toggleStateSort: PropTypes.func,
-    updateReferenceId: PropTypes.func
+    updateReferenceId: PropTypes.func,
+    setHistory: PropTypes.func
 };
 
 export default ComparisonHeader;

--- a/src/SmartComponents/DriftPage/DriftTable/ComparisonHeader/__tests__/ComparisonHeader.tests.js
+++ b/src/SmartComponents/DriftPage/DriftTable/ComparisonHeader/__tests__/ComparisonHeader.tests.js
@@ -19,7 +19,8 @@ describe('ComparisonHeader', () => {
             systemIds: [],
             toggleFactSort: jest.fn(),
             toggleStateSort: jest.fn(),
-            updateReferenceId: jest.fn()
+            updateReferenceId: jest.fn(),
+            setHistory: jest.fn()
         };
     });
 
@@ -73,7 +74,7 @@ describe('ComparisonHeader', () => {
         );
 
         wrapper.find('th').first().simulate('click');
-        expect(wrapper.find('LongArrowAltUpIcon').length).toEqual(1);
+        expect(props.toggleFactSort).toHaveBeenCalledWith('asc');
     });
 
     it('should render fact sort asc on click', () => {
@@ -83,7 +84,7 @@ describe('ComparisonHeader', () => {
         );
 
         wrapper.find('th').first().simulate('click');
-        expect(wrapper.find('LongArrowAltDownIcon').length).toEqual(1);
+        expect(props.toggleFactSort).toHaveBeenCalledWith('desc');
     });
 
     it('should render state sort none on click', () => {
@@ -93,7 +94,27 @@ describe('ComparisonHeader', () => {
         );
 
         wrapper.find('th').at(1).simulate('click');
-        expect(wrapper.find('ArrowsAltVIcon').length).toEqual(1);
+        expect(props.toggleStateSort).toHaveBeenCalledWith('desc');
+    });
+
+    it('should render state sort asc on click', () => {
+        props.stateSort = '';
+        const wrapper = shallow(
+            <ComparisonHeader { ...props }/>
+        );
+
+        wrapper.find('th').at(1).simulate('click');
+        expect(props.toggleStateSort).toHaveBeenCalledWith('');
+    });
+
+    it('should render state sort desc on click', () => {
+        props.stateSort = 'asc';
+        const wrapper = shallow(
+            <ComparisonHeader { ...props }/>
+        );
+
+        wrapper.find('th').at(1).simulate('click');
+        expect(props.toggleStateSort).toHaveBeenCalledWith('asc');
     });
 
     it('should remove a system', () => {
@@ -114,5 +135,25 @@ describe('ComparisonHeader', () => {
 
         wrapper.find('a').simulate('click');
         expect(props.removeSystem).toHaveBeenCalled();
+    });
+
+    it('should call setHistory on toggleFactSort', async () => {
+        props.factSort = 'desc';
+        const wrapper = shallow(
+            <ComparisonHeader { ...props }/>
+        );
+
+        await wrapper.instance().toggleSort('fact', 'desc');
+        expect(props.setHistory).toHaveBeenCalled();
+    });
+
+    it('should call setHistory on toggleStateSort', async () => {
+        props.stateSort = 'desc';
+        const wrapper = shallow(
+            <ComparisonHeader { ...props }/>
+        );
+
+        await wrapper.instance().toggleSort('state', 'desc');
+        expect(props.setHistory).toHaveBeenCalled();
     });
 });

--- a/src/SmartComponents/DriftPage/DriftTable/__tests__/DriftTable.tests.js
+++ b/src/SmartComponents/DriftPage/DriftTable/__tests__/DriftTable.tests.js
@@ -11,7 +11,9 @@ import { Skeleton } from '@redhat-cloud-services/frontend-components';
 import ConnectedDriftTable, { DriftTable } from '../DriftTable';
 import { compareReducerPayload, compareReducerPayloadWithMultiFact, baselinesPayload,
     historicalProfilesPayload } from '../../../modules/__tests__/reducer.fixtures';
+import stateFilterFixtures from '../../../modules/__tests__/state-filter.fixtures';
 import ReferenceSelector from '../ReferenceSelector/ReferenceSelector';
+import { ASC, DESC } from '../../../../constants';
 
 describe('DriftTable', () => {
     let props;
@@ -26,10 +28,11 @@ describe('DriftTable', () => {
             systems: [],
             baselines: [],
             historicalProfiles: [],
-            factSort: '',
-            stateSort: '',
+            factSort: ASC,
+            stateSort: DESC,
             loading: false,
             isFirstReference: true,
+            stateFilters: stateFilterFixtures.allStatesTrue,
             toggleFactSort: jest.fn(),
             toggleStateSort: jest.fn(),
             expandRow: jest.fn(),
@@ -38,7 +41,10 @@ describe('DriftTable', () => {
             selectHistoricProfiles: jest.fn(),
             updateReferenceId: jest.fn(),
             setIsFirstReference: jest.fn(),
-            clearComparison: jest.fn()
+            clearComparison: jest.fn(),
+            setHistory: jest.fn(),
+            handleFactFilter: jest.fn(),
+            addStateFilter: jest.fn()
         };
     });
 
@@ -62,21 +68,21 @@ describe('DriftTable', () => {
         expect(props.clearComparison).toHaveBeenCalled();
     });
 
-    it('should set first reference on baselineId', () => {
+    it('should set first reference on baselineId', async () => {
         const wrapper = shallow(
             <DriftTable { ...props } />
         );
 
-        wrapper.instance().fetchCompare([], [ 'abcd1234' ], [], undefined);
+        await wrapper.instance().fetchCompare([], [ 'abcd1234' ], [], undefined);
         expect(props.setIsFirstReference).toHaveBeenCalledWith(false);
     });
 
-    it('should set first reference on referenceId', () => {
+    it('should set first reference on referenceId', async () => {
         const wrapper = shallow(
             <DriftTable { ...props } />
         );
 
-        wrapper.instance().fetchCompare([ 'abcd1234' ], [], [], 'abcd1234');
+        await wrapper.instance().fetchCompare([ 'abcd1234' ], [], [], 'abcd1234');
         expect(props.setIsFirstReference).toHaveBeenCalledWith(false);
     });
 
@@ -93,21 +99,73 @@ describe('DriftTable', () => {
         });
         expect(props.setIsFirstReference).toHaveBeenCalledWith(true);
     });
+
+    it('should set fact filter', () => {
+        props.location.search = 'filter[name]=abc,123';
+        const wrapper = shallow(
+            <DriftTable { ...props } />
+        );
+
+        wrapper.instance().setFilters();
+        expect(props.handleFactFilter).toHaveBeenCalledWith('abc');
+        expect(props.handleFactFilter).toHaveBeenCalledWith('123');
+    });
+
+    it('should set state filter', () => {
+        props.location.search = 'filter[state]=same,incomplete_data';
+        const wrapper = shallow(
+            <DriftTable { ...props } />
+        );
+
+        wrapper.instance().setFilters();
+        expect(props.addStateFilter).toHaveBeenCalledWith(stateFilterFixtures.allStatesFalse[0]);
+        expect(props.addStateFilter).toHaveBeenCalledWith(stateFilterFixtures.allStatesFalse[2]);
+    });
+
+    it('should set sort asc', () => {
+        props.location.search = 'sort=fact,state';
+        const wrapper = shallow(
+            <DriftTable { ...props } />
+        );
+
+        wrapper.instance().setSort();
+        expect(props.toggleFactSort).toHaveBeenCalledWith(DESC);
+        expect(props.toggleStateSort).toHaveBeenCalledWith('');
+    });
+
+    it('should set sort desc', () => {
+        props.location.search = 'sort=-fact,-state';
+        const wrapper = shallow(
+            <DriftTable { ...props } />
+        );
+
+        wrapper.instance().setSort();
+        expect(props.toggleFactSort).toHaveBeenCalledWith(ASC);
+        expect(props.toggleStateSort).toHaveBeenCalledWith(ASC);
+    });
+
+    it('should set state sort, no sort', () => {
+        props.location.search = 'sort=fact';
+        const wrapper = shallow(
+            <DriftTable { ...props } />
+        );
+
+        wrapper.instance().setSort();
+        expect(props.toggleFactSort).toHaveBeenCalledWith(DESC);
+        expect(props.toggleStateSort).toHaveBeenCalledWith(DESC);
+    });
 });
 
 describe('ConnectedDriftTable', () => {
     let initialState;
+    let props;
     let mockStore;
-    let updateReferenceId;
 
     beforeEach(() => {
         mockStore = configureStore();
         initialState = {
             compareState: {
                 loading: false,
-                systems: [],
-                baselines: [],
-                historicalProfiles: [],
                 fullCompareData: [],
                 stateFilters: [
                     { filter: 'SAME', display: 'Same', selected: true },
@@ -123,7 +181,13 @@ describe('ConnectedDriftTable', () => {
             }},
             historicProfilesState: { selectedHSPIds: []}
         };
-        updateReferenceId = jest.fn();
+
+        props = {
+            systems: [],
+            baselines: [],
+            historicalProfiles: [],
+            updateReferenceId: jest.fn()
+        };
     });
 
     it('should render correctly', () => {
@@ -134,7 +198,7 @@ describe('ConnectedDriftTable', () => {
             <MemoryRouter keyLength={ 0 }>
                 <Provider store={ store }>
                     <ConnectedDriftTable
-                        updateReferenceId={ updateReferenceId }
+                        { ...props }
                         error={ error }
                     />
                 </Provider>
@@ -147,17 +211,17 @@ describe('ConnectedDriftTable', () => {
     it('should render systems, baselines and historicalProfiles', () => {
         initialState.compareState.fullCompareData = compareReducerPayload.facts;
         initialState.compareState.filteredCompareData = compareReducerPayload.facts;
-        initialState.compareState.systems = compareReducerPayload.systems;
-        initialState.compareState.baselines = baselinesPayload;
-        initialState.compareState.historicalProfiles = historicalProfilesPayload;
         initialState.compareState.loading = false;
+        props.systems = compareReducerPayload.systems;
+        props.baselines = baselinesPayload;
+        props.historicalProfiles = historicalProfilesPayload;
 
         const store = mockStore(initialState);
 
         const wrapper = mount(
             <MemoryRouter keyLength={ 0 }>
                 <Provider store={ store }>
-                    <ConnectedDriftTable updateReferenceId={ updateReferenceId } />
+                    <ConnectedDriftTable { ...props } />
                 </Provider>
             </MemoryRouter>
         );
@@ -171,18 +235,18 @@ describe('ConnectedDriftTable', () => {
     it('should render multi fact values', () => {
         initialState.compareState.fullCompareData = compareReducerPayloadWithMultiFact.facts;
         initialState.compareState.filteredCompareData = compareReducerPayloadWithMultiFact.facts;
-        initialState.compareState.systems = compareReducerPayloadWithMultiFact.systems;
-        initialState.compareState.baselines = baselinesPayload;
-        initialState.compareState.historicalProfiles = historicalProfilesPayload;
         initialState.compareState.loading = false;
         initialState.compareState.expandedRows = [ 'cpu_flags', 'abc' ];
+        props.systems = compareReducerPayloadWithMultiFact.systems;
+        props.baselines = baselinesPayload;
+        props.historicalProfiles = historicalProfilesPayload;
 
         const store = mockStore(initialState);
 
         const wrapper = mount(
             <MemoryRouter keyLength={ 0 }>
                 <Provider store={ store }>
-                    <ConnectedDriftTable updateReferenceId={ updateReferenceId } />
+                    <ConnectedDriftTable { ...props } />
                 </Provider>
             </MemoryRouter>
         );
@@ -202,7 +266,7 @@ describe('ConnectedDriftTable', () => {
             <MemoryRouter keyLength={ 0 }>
                 <Provider store={ store }>
                     <ConnectedDriftTable
-                        updateReferenceId={ updateReferenceId }
+                        { ...props }
                         error={ error }
                     />
                 </Provider>
@@ -217,13 +281,13 @@ describe('ConnectedDriftTable', () => {
 
     it('should call updateReferenceId with new reference id', () => {
         initialState.compareState.fullCompareData = compareReducerPayload.facts;
-        initialState.compareState.systems = compareReducerPayload.systems;
-        initialState.compareState.baselines = baselinesPayload;
-        initialState.compareState.historicalProfiles = historicalProfilesPayload;
         initialState.compareState.loading = false;
         initialState.historicProfilesState.selectedHSPIds = [
             '9bbbefcc-8f23-4d97-07f2-142asdl234e8', 'edmk59dj-fn42-dfjk-alv3-bmn2854mnn27'
         ];
+        props.systems = compareReducerPayload.systems;
+        props.baselines = baselinesPayload;
+        props.historicalProfiles = historicalProfilesPayload;
         let setIsFirstReference = jest.fn();
 
         const store = mockStore(initialState);
@@ -232,7 +296,7 @@ describe('ConnectedDriftTable', () => {
             <MemoryRouter keyLength={ 0 }>
                 <Provider store={ store }>
                     <ConnectedDriftTable
-                        updateReferenceId={ updateReferenceId }
+                        { ...props }
                         setIsFirstReference={ setIsFirstReference }
                     />
                 </Provider>
@@ -240,8 +304,8 @@ describe('ConnectedDriftTable', () => {
         );
 
         wrapper.find(ReferenceSelector).first().simulate('click');
-        expect(updateReferenceId).toHaveBeenCalledWith('9bbbefcc-8f23-4d97-07f2-142asdl234e9');
+        expect(props.updateReferenceId).toHaveBeenCalledWith('9bbbefcc-8f23-4d97-07f2-142asdl234e9');
         wrapper.find(ReferenceSelector).first().simulate('click');
-        expect(updateReferenceId).toHaveBeenCalledWith(undefined);
+        expect(props.updateReferenceId).toHaveBeenCalledWith(undefined);
     });
 });

--- a/src/SmartComponents/DriftPage/DriftTable/__tests__/__snapshots__/DriftTable.tests.js.snap
+++ b/src/SmartComponents/DriftPage/DriftTable/__tests__/__snapshots__/DriftTable.tests.js.snap
@@ -49,7 +49,10 @@ exports[`ConnectedDriftTable should render correctly 1`] = `
       }
     >
       <withRouter(Connect(DriftTable))
+        baselines={Array []}
         error={Object {}}
+        historicalProfiles={Array []}
+        systems={Array []}
         updateReferenceId={
           [MockFunction] {
             "calls": Array [
@@ -67,7 +70,9 @@ exports[`ConnectedDriftTable should render correctly 1`] = `
         }
       >
         <Connect(DriftTable)
+          baselines={Array []}
           error={Object {}}
+          historicalProfiles={Array []}
           history={
             Object {
               "action": "POP",
@@ -114,6 +119,7 @@ exports[`ConnectedDriftTable should render correctly 1`] = `
               "url": "/",
             }
           }
+          systems={Array []}
           updateReferenceId={
             [MockFunction] {
               "calls": Array [
@@ -214,15 +220,12 @@ exports[`ConnectedDriftTable should render correctly 1`] = `
             >
               <AddSystemModal
                 addSystemModalOpened={false}
-                baselines={Array []}
                 confirmModal={[Function]}
-                historicalProfiles={Array []}
                 selectActiveTab={[Function]}
                 selectBaseline={[Function]}
                 selectedBaselineIds={Array []}
                 selectedHSPIds={Array []}
                 selectedSystemIds={Array []}
-                systems={Array []}
                 toggleAddSystemModal={[Function]}
               >
                 <Modal
@@ -472,7 +475,10 @@ exports[`ConnectedDriftTable should render loading rows 1`] = `
       }
     >
       <withRouter(Connect(DriftTable))
+        baselines={Array []}
         error={Object {}}
+        historicalProfiles={Array []}
+        systems={Array []}
         updateReferenceId={
           [MockFunction] {
             "calls": Array [
@@ -490,7 +496,9 @@ exports[`ConnectedDriftTable should render loading rows 1`] = `
         }
       >
         <Connect(DriftTable)
+          baselines={Array []}
           error={Object {}}
+          historicalProfiles={Array []}
           history={
             Object {
               "action": "POP",
@@ -537,6 +545,7 @@ exports[`ConnectedDriftTable should render loading rows 1`] = `
               "url": "/",
             }
           }
+          systems={Array []}
           updateReferenceId={
             [MockFunction] {
               "calls": Array [
@@ -637,15 +646,12 @@ exports[`ConnectedDriftTable should render loading rows 1`] = `
             >
               <AddSystemModal
                 addSystemModalOpened={false}
-                baselines={Array []}
                 confirmModal={[Function]}
-                historicalProfiles={Array []}
                 selectActiveTab={[Function]}
                 selectBaseline={[Function]}
                 selectedBaselineIds={Array []}
                 selectedHSPIds={Array []}
                 selectedSystemIds={Array []}
-                systems={Array []}
                 toggleAddSystemModal={[Function]}
               >
                 <Modal
@@ -1276,6 +1282,56 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
       }
     >
       <withRouter(Connect(DriftTable))
+        baselines={
+          Array [
+            Object {
+              "display_name": "baseline1",
+              "id": "9bbbefcc-8f23-4d97-07f2-142asdl234e9",
+              "last_updated": "2019-01-15T14:53:15.886891Z",
+              "type": "baseline",
+            },
+            Object {
+              "display_name": "baseline2",
+              "id": "fdmk59dj-fn42-dfjk-alv3-bmn2854mnn29",
+              "last_updated": "2019-01-15T15:25:16.304899Z",
+              "type": "baseline",
+            },
+          ]
+        }
+        historicalProfiles={
+          Array [
+            Object {
+              "display_name": "system1",
+              "id": "9bbbefcc-8f23-4d97-07f2-142asdl234e8",
+              "last_updated": "2019-01-15T14:53:15.886891Z",
+              "system_id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+              "type": "historical-system-profile",
+            },
+            Object {
+              "display_name": "system1",
+              "id": "edmk59dj-fn42-dfjk-alv3-bmn2854mnn27",
+              "last_updated": "2019-01-15T15:25:16.304899Z",
+              "system_id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+              "type": "historical-system-profile",
+            },
+          ]
+        }
+        systems={
+          Array [
+            Object {
+              "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
+              "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+              "last_updated": "2019-01-15T14:53:15.886891Z",
+              "type": "system",
+            },
+            Object {
+              "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
+              "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
+              "last_updated": "2019-01-15T15:25:16.304899Z",
+              "type": "system",
+            },
+          ]
+        }
         updateReferenceId={
           [MockFunction] {
             "calls": Array [
@@ -1293,6 +1349,40 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
         }
       >
         <Connect(DriftTable)
+          baselines={
+            Array [
+              Object {
+                "display_name": "baseline1",
+                "id": "9bbbefcc-8f23-4d97-07f2-142asdl234e9",
+                "last_updated": "2019-01-15T14:53:15.886891Z",
+                "type": "baseline",
+              },
+              Object {
+                "display_name": "baseline2",
+                "id": "fdmk59dj-fn42-dfjk-alv3-bmn2854mnn29",
+                "last_updated": "2019-01-15T15:25:16.304899Z",
+                "type": "baseline",
+              },
+            ]
+          }
+          historicalProfiles={
+            Array [
+              Object {
+                "display_name": "system1",
+                "id": "9bbbefcc-8f23-4d97-07f2-142asdl234e8",
+                "last_updated": "2019-01-15T14:53:15.886891Z",
+                "system_id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+                "type": "historical-system-profile",
+              },
+              Object {
+                "display_name": "system1",
+                "id": "edmk59dj-fn42-dfjk-alv3-bmn2854mnn27",
+                "last_updated": "2019-01-15T15:25:16.304899Z",
+                "system_id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+                "type": "historical-system-profile",
+              },
+            ]
+          }
           history={
             Object {
               "action": "POP",
@@ -1338,6 +1428,22 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
               "path": "/",
               "url": "/",
             }
+          }
+          systems={
+            Array [
+              Object {
+                "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
+                "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+                "last_updated": "2019-01-15T14:53:15.886891Z",
+                "type": "system",
+              },
+              Object {
+                "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
+                "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
+                "last_updated": "2019-01-15T15:25:16.304899Z",
+                "type": "system",
+              },
+            ]
           }
           updateReferenceId={
             [MockFunction] {
@@ -1972,41 +2078,7 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
             >
               <AddSystemModal
                 addSystemModalOpened={false}
-                baselines={
-                  Array [
-                    Object {
-                      "display_name": "baseline1",
-                      "id": "9bbbefcc-8f23-4d97-07f2-142asdl234e9",
-                      "last_updated": "2019-01-15T14:53:15.886891Z",
-                      "type": "baseline",
-                    },
-                    Object {
-                      "display_name": "baseline2",
-                      "id": "fdmk59dj-fn42-dfjk-alv3-bmn2854mnn29",
-                      "last_updated": "2019-01-15T15:25:16.304899Z",
-                      "type": "baseline",
-                    },
-                  ]
-                }
                 confirmModal={[Function]}
-                historicalProfiles={
-                  Array [
-                    Object {
-                      "display_name": "system1",
-                      "id": "9bbbefcc-8f23-4d97-07f2-142asdl234e8",
-                      "last_updated": "2019-01-15T14:53:15.886891Z",
-                      "system_id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
-                      "type": "historical-system-profile",
-                    },
-                    Object {
-                      "display_name": "system1",
-                      "id": "edmk59dj-fn42-dfjk-alv3-bmn2854mnn27",
-                      "last_updated": "2019-01-15T15:25:16.304899Z",
-                      "system_id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
-                      "type": "historical-system-profile",
-                    },
-                  ]
-                }
                 selectActiveTab={[Function]}
                 selectBaseline={[Function]}
                 selectedBaselineIds={Array []}
@@ -2015,22 +2087,6 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
                   Array [
                     "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
                     "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
-                  ]
-                }
-                systems={
-                  Array [
-                    Object {
-                      "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
-                      "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
-                      "last_updated": "2019-01-15T14:53:15.886891Z",
-                      "type": "system",
-                    },
-                    Object {
-                      "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
-                      "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
-                      "last_updated": "2019-01-15T15:25:16.304899Z",
-                      "type": "system",
-                    },
                   ]
                 }
                 toggleAddSystemModal={[Function]}
@@ -7326,6 +7382,56 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
       }
     >
       <withRouter(Connect(DriftTable))
+        baselines={
+          Array [
+            Object {
+              "display_name": "baseline1",
+              "id": "9bbbefcc-8f23-4d97-07f2-142asdl234e9",
+              "last_updated": "2019-01-15T14:53:15.886891Z",
+              "type": "baseline",
+            },
+            Object {
+              "display_name": "baseline2",
+              "id": "fdmk59dj-fn42-dfjk-alv3-bmn2854mnn29",
+              "last_updated": "2019-01-15T15:25:16.304899Z",
+              "type": "baseline",
+            },
+          ]
+        }
+        historicalProfiles={
+          Array [
+            Object {
+              "display_name": "system1",
+              "id": "9bbbefcc-8f23-4d97-07f2-142asdl234e8",
+              "last_updated": "2019-01-15T14:53:15.886891Z",
+              "system_id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+              "type": "historical-system-profile",
+            },
+            Object {
+              "display_name": "system1",
+              "id": "edmk59dj-fn42-dfjk-alv3-bmn2854mnn27",
+              "last_updated": "2019-01-15T15:25:16.304899Z",
+              "system_id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+              "type": "historical-system-profile",
+            },
+          ]
+        }
+        systems={
+          Array [
+            Object {
+              "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
+              "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+              "last_updated": "2019-01-15T14:53:15.886891Z",
+              "type": "system",
+            },
+            Object {
+              "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
+              "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
+              "last_updated": "2019-01-15T15:25:16.304899Z",
+              "type": "system",
+            },
+          ]
+        }
         updateReferenceId={
           [MockFunction] {
             "calls": Array [
@@ -7343,6 +7449,40 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
         }
       >
         <Connect(DriftTable)
+          baselines={
+            Array [
+              Object {
+                "display_name": "baseline1",
+                "id": "9bbbefcc-8f23-4d97-07f2-142asdl234e9",
+                "last_updated": "2019-01-15T14:53:15.886891Z",
+                "type": "baseline",
+              },
+              Object {
+                "display_name": "baseline2",
+                "id": "fdmk59dj-fn42-dfjk-alv3-bmn2854mnn29",
+                "last_updated": "2019-01-15T15:25:16.304899Z",
+                "type": "baseline",
+              },
+            ]
+          }
+          historicalProfiles={
+            Array [
+              Object {
+                "display_name": "system1",
+                "id": "9bbbefcc-8f23-4d97-07f2-142asdl234e8",
+                "last_updated": "2019-01-15T14:53:15.886891Z",
+                "system_id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+                "type": "historical-system-profile",
+              },
+              Object {
+                "display_name": "system1",
+                "id": "edmk59dj-fn42-dfjk-alv3-bmn2854mnn27",
+                "last_updated": "2019-01-15T15:25:16.304899Z",
+                "system_id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+                "type": "historical-system-profile",
+              },
+            ]
+          }
           history={
             Object {
               "action": "POP",
@@ -7388,6 +7528,22 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
               "path": "/",
               "url": "/",
             }
+          }
+          systems={
+            Array [
+              Object {
+                "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
+                "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+                "last_updated": "2019-01-15T14:53:15.886891Z",
+                "type": "system",
+              },
+              Object {
+                "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
+                "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
+                "last_updated": "2019-01-15T15:25:16.304899Z",
+                "type": "system",
+              },
+            ]
           }
           updateReferenceId={
             [MockFunction] {
@@ -7633,41 +7789,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
             >
               <AddSystemModal
                 addSystemModalOpened={false}
-                baselines={
-                  Array [
-                    Object {
-                      "display_name": "baseline1",
-                      "id": "9bbbefcc-8f23-4d97-07f2-142asdl234e9",
-                      "last_updated": "2019-01-15T14:53:15.886891Z",
-                      "type": "baseline",
-                    },
-                    Object {
-                      "display_name": "baseline2",
-                      "id": "fdmk59dj-fn42-dfjk-alv3-bmn2854mnn29",
-                      "last_updated": "2019-01-15T15:25:16.304899Z",
-                      "type": "baseline",
-                    },
-                  ]
-                }
                 confirmModal={[Function]}
-                historicalProfiles={
-                  Array [
-                    Object {
-                      "display_name": "system1",
-                      "id": "9bbbefcc-8f23-4d97-07f2-142asdl234e8",
-                      "last_updated": "2019-01-15T14:53:15.886891Z",
-                      "system_id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
-                      "type": "historical-system-profile",
-                    },
-                    Object {
-                      "display_name": "system1",
-                      "id": "edmk59dj-fn42-dfjk-alv3-bmn2854mnn27",
-                      "last_updated": "2019-01-15T15:25:16.304899Z",
-                      "system_id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
-                      "type": "historical-system-profile",
-                    },
-                  ]
-                }
                 selectActiveTab={[Function]}
                 selectBaseline={[Function]}
                 selectedBaselineIds={Array []}
@@ -7676,22 +7798,6 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                   Array [
                     "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
                     "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
-                  ]
-                }
-                systems={
-                  Array [
-                    Object {
-                      "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
-                      "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
-                      "last_updated": "2019-01-15T14:53:15.886891Z",
-                      "type": "system",
-                    },
-                    Object {
-                      "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
-                      "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
-                      "last_updated": "2019-01-15T15:25:16.304899Z",
-                      "type": "system",
-                    },
                   ]
                 }
                 toggleAddSystemModal={[Function]}
@@ -11570,11 +11676,12 @@ exports[`DriftTable should render correctly 1`] = `
     >
       <thead>
         <ComparisonHeader
-          factSort=""
+          factSort="asc"
           fetchCompare={[Function]}
           masterList={Array []}
           removeSystem={[Function]}
-          stateSort=""
+          setHistory={[MockFunction]}
+          stateSort="desc"
           systemIds={Array []}
           toggleFactSort={[MockFunction]}
           toggleStateSort={[MockFunction]}

--- a/src/SmartComponents/DriftPage/DriftToolbar/DriftToolbar.js
+++ b/src/SmartComponents/DriftPage/DriftToolbar/DriftToolbar.js
@@ -9,7 +9,6 @@ import SearchBar from '../SearchBar/SearchBar';
 import ActionKebab from '../ActionKebab/ActionKebab';
 import AddSystemButton from '../AddSystemButton/AddSystemButton';
 import ExportCSVButton from '../../ExportCSVButton/ExportCSVButton';
-import { setHistory } from '../../../Utilities/SetHistory';
 import { TablePagination } from '../../Pagination/Pagination';
 
 export class DriftToolbar extends Component {
@@ -81,33 +80,35 @@ export class DriftToolbar extends Component {
         });
     }
 
-    removeChip = (type = '', id = '') => {
-        const { activeFactFilters, addStateFilter, clearAllFactFilters, filterByFact, handleFactFilter, stateFilters } = this.props;
+    removeChip = async (type = '', id = '') => {
+        const { activeFactFilters, addStateFilter, clearAllFactFilters, filterByFact, handleFactFilter, setHistory, stateFilters } = this.props;
 
         if (type) {
             if (type === 'State') {
                 if (id === '') {
                     this.clearAllStateChips();
                 } else {
-                    stateFilters.forEach(function(stateFilter) {
+                    stateFilters.forEach(async function(stateFilter) {
                         if (stateFilter.display === id) {
-                            addStateFilter(stateFilter);
+                            await addStateFilter(stateFilter);
                         }
                     });
                 }
             } else {
                 if (id === '') {
-                    clearAllFactFilters();
+                    await clearAllFactFilters();
                 } else if (activeFactFilters.includes(id)) {
-                    handleFactFilter(id);
+                    await handleFactFilter(id);
                 } else {
-                    filterByFact('');
+                    await filterByFact('');
                 }
             }
         } else {
             this.clearAllStateChips();
             this.clearAllFactChips();
         }
+
+        setHistory();
     }
 
     setIsEmpty = (isEmpty) => {
@@ -128,19 +129,20 @@ export class DriftToolbar extends Component {
         clearComparisonFilters();
     }
 
-    clearComparison = () => {
-        const { history, clearComparison, clearSelectedBaselines, setIsFirstReference, updateReferenceId } = this.props;
+    clearComparison = async () => {
+        const { clearComparison, clearSelectedBaselines, setHistory, setIsFirstReference, updateReferenceId } = this.props;
 
-        clearComparison();
-        clearSelectedBaselines('CHECKBOX');
-        setIsFirstReference(true);
-        updateReferenceId();
-        setHistory(history, []);
+        await clearComparison();
+        await clearSelectedBaselines('CHECKBOX');
+        await setIsFirstReference(true);
+        await updateReferenceId();
+        setHistory();
+
     }
 
     render() {
-        const { activeFactFilters, factFilter, filterByFact, handleFactFilter,
-            loading, page, perPage, stateFilters, totalFacts, updatePagination } = this.props;
+        const { activeFactFilters, factFilter, filterByFact, handleFactFilter, loading,
+            page, perPage, setHistory, stateFilters, totalFacts, updatePagination } = this.props;
         const { actionKebabItems, dropdownItems, dropdownOpen, isEmpty } = this.state;
 
         return (
@@ -159,6 +161,7 @@ export class DriftToolbar extends Component {
                                     activeFactFilters={ activeFactFilters }
                                     handleFactFilter={ handleFactFilter }
                                     filterByFact={ filterByFact }
+                                    setHistory={ setHistory }
                                 />
                             </ToolbarFilter>
                             <ToolbarFilter
@@ -167,7 +170,7 @@ export class DriftToolbar extends Component {
                                 deleteChipGroup={ this.removeChip }
                                 categoryName="State"
                             >
-                                <FilterDropDown />
+                                <FilterDropDown setHistory={ setHistory } />
                             </ToolbarFilter>
                         </ToolbarGroup>
                         <ToolbarGroup variant='button-group'>
@@ -238,7 +241,8 @@ DriftToolbar.propTypes = {
     addStateFilter: PropTypes.func,
     activeFactFilters: PropTypes.array,
     handleFactFilter: PropTypes.func,
-    clearAllFactFilters: PropTypes.func
+    clearAllFactFilters: PropTypes.func,
+    setHistory: PropTypes.func
 };
 
 export default DriftToolbar;

--- a/src/SmartComponents/DriftPage/DriftToolbar/__tests__/DriftToolbar.tests.js
+++ b/src/SmartComponents/DriftPage/DriftToolbar/__tests__/DriftToolbar.tests.js
@@ -27,7 +27,8 @@ describe('DriftToolbar', () => {
             addStateFilter: jest.fn(),
             filterByFact: jest.fn(),
             handleFactFilter: jest.fn(),
-            clearAllFactFilters: jest.fn()
+            clearAllFactFilters: jest.fn(),
+            setHistory: jest.fn()
         };
     });
 
@@ -100,6 +101,7 @@ describe('DriftToolbar', () => {
         expect(props.addStateFilter).toHaveBeenCalledWith(
             { filter: 'SAME', display: 'Same', selected: true }
         );
+        expect(props.setHistory).toHaveBeenCalled();
     });
 
     it('should remove all state chips', () => {
@@ -119,13 +121,14 @@ describe('DriftToolbar', () => {
         );
     });
 
-    it('should remove fact filter chip', () => {
+    it('should remove fact filter chip', async () => {
         const wrapper = shallow(
             <DriftToolbar { ...props } />
         );
         wrapper.instance().removeChip('Fact name', 'blah');
 
-        expect(props.filterByFact).toHaveBeenCalledWith('');
+        await expect(props.filterByFact).toHaveBeenCalledWith('');
+        expect(props.setHistory).toHaveBeenCalled();
     });
 
     it('should remove active fact filter chip', () => {

--- a/src/SmartComponents/DriftPage/DriftToolbar/__tests__/__snapshots__/DriftToolbar.tests.js.snap
+++ b/src/SmartComponents/DriftPage/DriftToolbar/__tests__/__snapshots__/DriftToolbar.tests.js.snap
@@ -25,6 +25,7 @@ exports[`DriftToolbar should render correctly 1`] = `
             factFilter=""
             filterByFact={[MockFunction]}
             handleFactFilter={[MockFunction]}
+            setHistory={[MockFunction]}
           />
         </ToolbarFilter>
         <ToolbarFilter
@@ -40,7 +41,9 @@ exports[`DriftToolbar should render correctly 1`] = `
           deleteChipGroup={[Function]}
           showToolbarItem={true}
         >
-          <Connect(FilterDropDown) />
+          <Connect(FilterDropDown)
+            setHistory={[MockFunction]}
+          />
         </ToolbarFilter>
       </ForwardRef>
       <ForwardRef
@@ -153,6 +156,7 @@ exports[`DriftToolbar should render with fact filter chips 1`] = `
             factFilter="dog"
             filterByFact={[MockFunction]}
             handleFactFilter={[MockFunction]}
+            setHistory={[MockFunction]}
           />
         </ToolbarFilter>
         <ToolbarFilter
@@ -168,7 +172,9 @@ exports[`DriftToolbar should render with fact filter chips 1`] = `
           deleteChipGroup={[Function]}
           showToolbarItem={true}
         >
-          <Connect(FilterDropDown) />
+          <Connect(FilterDropDown)
+            setHistory={[MockFunction]}
+          />
         </ToolbarFilter>
       </ForwardRef>
       <ForwardRef

--- a/src/SmartComponents/DriftPage/FilterDropDown/FilterDropDown.js
+++ b/src/SmartComponents/DriftPage/FilterDropDown/FilterDropDown.js
@@ -17,6 +17,13 @@ class FilterDropDown extends Component {
         this.props.toggleDropDown();
     }
 
+    addStateFilter = async (stateFilter) => {
+        const { addStateFilter, setHistory } = this.props;
+
+        await addStateFilter(stateFilter);
+        setHistory();
+    }
+
     createDropdownItem(stateFilter) {
         let dropdownItem =
             <DropdownItem
@@ -27,8 +34,7 @@ class FilterDropDown extends Component {
                     data-ouia-component-id={ 'state-filter-option-checkbox-' + stateFilter.display }
                     label={ stateFilter.display }
                     isChecked={ stateFilter.selected }
-                    onChange={ () =>
-                        this.props.addStateFilter(stateFilter) }
+                    onChange={ () => this.addStateFilter(stateFilter) }
                 />
             </DropdownItem>;
         return dropdownItem;
@@ -95,7 +101,8 @@ FilterDropDown.propTypes = {
     toggleDropDown: PropTypes.func,
     filterDropdownOpened: PropTypes.bool,
     stateFilters: PropTypes.array,
-    addStateFilter: PropTypes.func
+    addStateFilter: PropTypes.func,
+    setHistory: PropTypes.func
 };
 
 function mapStateToProps(state) {

--- a/src/SmartComponents/DriftPage/SearchBar/SearchBar.js
+++ b/src/SmartComponents/DriftPage/SearchBar/SearchBar.js
@@ -20,23 +20,31 @@ export class SearchBar extends Component {
         }
     }
 
+    async addToActiveFactFilters(filter) {
+        const { handleFactFilter, setHistory } = this.props;
+
+        await handleFactFilter(filter);
+        setHistory();
+    }
+
     updateFactFilter = (filter) => {
         this.setState({ filter });
         this.setFactFilter(filter);
     }
 
-    setFactFilter = _.debounce(function(filter) {
-        this.props.filterByFact(filter);
+    setFactFilter = _.debounce(async function(filter) {
+        await this.props.filterByFact(filter);
+        this.props.setHistory();
     }, 250);
 
     checkKeyPress = (event) => {
-        const { activeFactFilters, handleFactFilter } = this.props;
+        const { activeFactFilters } = this.props;
         const { filter } = this.state;
 
         if (event.key === 'Enter') {
             event.preventDefault();
             if (!activeFactFilters.includes(filter)) {
-                handleFactFilter(filter);
+                this.addToActiveFactFilters(filter);
             }
         }
     }
@@ -71,7 +79,8 @@ SearchBar.propTypes = {
     filterByFact: PropTypes.func,
     factFilter: PropTypes.string,
     handleFactFilter: PropTypes.func,
-    activeFactFilters: PropTypes.array
+    activeFactFilters: PropTypes.array,
+    setHistory: PropTypes.func
 };
 
 export default SearchBar;

--- a/src/SmartComponents/DriftPage/SearchBar/__tests__/SearchBar.tests.js
+++ b/src/SmartComponents/DriftPage/SearchBar/__tests__/SearchBar.tests.js
@@ -12,7 +12,8 @@ describe('SearchBar', () => {
             factFilter: '',
             activeFactFilters: [],
             handleFactFilter: jest.fn(),
-            changeFactFilter: jest.fn()
+            changeFactFilter: jest.fn(),
+            setHistory: jest.fn()
         };
     });
 
@@ -48,7 +49,7 @@ describe('SearchBar', () => {
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 
-    it('should catch Enter on keypress', () => {
+    it('should catch Enter on keypress', async() => {
         props.factFilter = 'quadrupel';
         const event = { key: 'Enter', preventDefault: jest.fn() };
         const wrapper = shallow(
@@ -57,6 +58,7 @@ describe('SearchBar', () => {
 
         wrapper.find('FormGroup').simulate('keypress', event);
 
-        expect(props.handleFactFilter).toHaveBeenCalledWith('quadrupel');
+        await expect(props.handleFactFilter).toHaveBeenCalledWith('quadrupel');
+        expect(props.setHistory).toHaveBeenCalled();
     });
 });

--- a/src/SmartComponents/DriftPage/__tests__/DriftPage.tests.js
+++ b/src/SmartComponents/DriftPage/__tests__/DriftPage.tests.js
@@ -6,7 +6,11 @@ import { Provider } from 'react-redux';
 import toJson from 'enzyme-to-json';
 
 import ConnectedDriftPage, { DriftPage } from '../DriftPage';
-import { compareReducerPayload, baselinesPayload } from '../../modules/__tests__/reducer.fixtures';
+import { compareReducerPayload, systemsPayload, baselinesPayload, historicalProfilesPayload } from '../../modules/__tests__/reducer.fixtures';
+import { systemIds, baselineIds, HSPIds } from './fixtures/DriftPage.fixtures';
+import { allStatesTrue } from '../../modules/__tests__/state-filter.fixtures';
+import { ASC, DESC } from '../../../constants';
+import * as setHistory from '../../../Utilities/SetHistory';
 import { PermissionContext } from '../../../App';
 
 describe('DriftPage', () => {
@@ -18,14 +22,21 @@ describe('DriftPage', () => {
             loading: false,
             systems: [],
             baselines: [],
+            historicalProfiles: [],
             emptyState: false,
+            factFilter: '',
+            activeFactFilters: [],
+            factSort: DESC,
+            stateSort: ASC,
+            referenceId: undefined,
+            stateFilters: allStatesTrue,
+            history: { location: { search: '' }, push: jest.fn() },
             clearSelectedBaselines: jest.fn(),
             toggleErrorAlert: jest.fn(),
             clearComparison: jest.fn(),
             clearComparisonFilters: jest.fn(),
             selectHistoricProfiles: jest.fn(),
             updateReferenceId: jest.fn(),
-            history: { push: jest.fn() },
             revertCompareData: jest.fn()
         };
     });
@@ -55,6 +66,38 @@ describe('DriftPage', () => {
 
         wrapper.instance().onClose();
         expect(props.revertCompareData).toHaveBeenCalled();
+    });
+
+    it('should call setHistory', async () => {
+        props.systems = systemsPayload;
+        props.baselines = baselinesPayload;
+        props.historicalProfiles = historicalProfilesPayload;
+        const setHistorySpy = jest.spyOn(setHistory, 'setHistory');
+
+        const wrapper = shallow(
+            <DriftPage { ...props } />
+        );
+
+        await wrapper.instance().setHistory();
+        await expect(setHistorySpy).toHaveBeenCalledWith(
+            props.history, systemIds, baselineIds, HSPIds, undefined, [], '', allStatesTrue, DESC, ASC
+        );
+    });
+
+    it('should call setHistory', async () => {
+        props.systems = systemsPayload;
+        props.baselines = baselinesPayload;
+        props.historicalProfiles = historicalProfilesPayload;
+        const setHistorySpy = jest.spyOn(setHistory, 'setHistory');
+
+        const wrapper = shallow(
+            <DriftPage { ...props } />
+        );
+
+        await wrapper.instance().setHistory();
+        await expect(setHistorySpy).toHaveBeenCalledWith(
+            props.history, systemIds, baselineIds, HSPIds, undefined, [], '', allStatesTrue, DESC, ASC
+        );
     });
 });
 

--- a/src/SmartComponents/DriftPage/__tests__/__snapshots__/DriftPage.tests.js.snap
+++ b/src/SmartComponents/DriftPage/__tests__/__snapshots__/DriftPage.tests.js.snap
@@ -100,6 +100,7 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
           <DriftPage
             activeFactFilters={Array []}
             addStateFilter={[Function]}
+            baselines={Array []}
             clearAllFactFilters={[Function]}
             clearComparison={[Function]}
             clearComparisonFilters={[Function]}
@@ -110,6 +111,7 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
             factFilter=""
             filterByFact={[Function]}
             handleFactFilter={[Function]}
+            historicalProfiles={Array []}
             history={
               Object {
                 "action": "POP",
@@ -180,6 +182,7 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
                 },
               ]
             }
+            systems={Array []}
             updatePagination={[Function]}
             updateReferenceId={[Function]}
           >
@@ -283,6 +286,7 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
                                 }
                               }
                               loading={false}
+                              setHistory={[Function]}
                               setIsFirstReference={[Function]}
                               stateFilters={
                                 Array [
@@ -353,6 +357,7 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
                                                         factFilter=""
                                                         filterByFact={[Function]}
                                                         handleFactFilter={[Function]}
+                                                        setHistory={[Function]}
                                                       >
                                                         <Form>
                                                           <form
@@ -634,9 +639,12 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
                                                     <div
                                                       className="pf-c-toolbar__item"
                                                     >
-                                                      <Connect(FilterDropDown)>
+                                                      <Connect(FilterDropDown)
+                                                        setHistory={[Function]}
+                                                      >
                                                         <FilterDropDown
                                                           addStateFilter={[Function]}
+                                                          setHistory={[Function]}
                                                           stateFilters={
                                                             Array [
                                                               Object {
@@ -3137,15 +3145,48 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
                               </Toolbar>
                             </DriftToolbar>
                             <withRouter(Connect(DriftTable))
+                              activeFactFilters={Array []}
+                              addStateFilter={[Function]}
+                              baselines={Array []}
                               clearComparison={[Function]}
                               error={Object {}}
+                              factFilter=""
+                              handleFactFilter={[Function]}
+                              historicalProfiles={Array []}
                               isFirstReference={true}
+                              setHistory={[Function]}
                               setIsFirstReference={[Function]}
+                              stateFilters={
+                                Array [
+                                  Object {
+                                    "display": "Same",
+                                    "filter": "SAME",
+                                    "selected": true,
+                                  },
+                                  Object {
+                                    "display": "Different",
+                                    "filter": "DIFFERENT",
+                                    "selected": true,
+                                  },
+                                  Object {
+                                    "display": "Incomplete data",
+                                    "filter": "INCOMPLETE_DATA",
+                                    "selected": true,
+                                  },
+                                ]
+                              }
+                              systems={Array []}
                               updateReferenceId={[Function]}
                             >
                               <Connect(DriftTable)
+                                activeFactFilters={Array []}
+                                addStateFilter={[Function]}
+                                baselines={Array []}
                                 clearComparison={[Function]}
                                 error={Object {}}
+                                factFilter=""
+                                handleFactFilter={[Function]}
+                                historicalProfiles={Array []}
                                 history={
                                   Object {
                                     "action": "POP",
@@ -3193,18 +3234,43 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
                                     "url": "/",
                                   }
                                 }
+                                setHistory={[Function]}
                                 setIsFirstReference={[Function]}
+                                stateFilters={
+                                  Array [
+                                    Object {
+                                      "display": "Same",
+                                      "filter": "SAME",
+                                      "selected": true,
+                                    },
+                                    Object {
+                                      "display": "Different",
+                                      "filter": "DIFFERENT",
+                                      "selected": true,
+                                    },
+                                    Object {
+                                      "display": "Incomplete data",
+                                      "filter": "INCOMPLETE_DATA",
+                                      "selected": true,
+                                    },
+                                  ]
+                                }
+                                systems={Array []}
                                 updateReferenceId={[Function]}
                               >
                                 <DriftTable
+                                  activeFactFilters={Array []}
+                                  addStateFilter={[Function]}
                                   addSystemModalOpened={false}
                                   baselines={Array []}
                                   clearComparison={[Function]}
                                   emptyState={false}
                                   error={Object {}}
                                   expandRow={[Function]}
+                                  factFilter=""
                                   fetchCompare={[Function]}
                                   fullCompareData={Array []}
+                                  handleFactFilter={[Function]}
                                   historicalProfiles={Array []}
                                   history={
                                     Object {
@@ -3255,8 +3321,28 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
                                     }
                                   }
                                   selectHistoricProfiles={[Function]}
+                                  setHistory={[Function]}
                                   setIsFirstReference={[Function]}
                                   setSelectedBaselines={[Function]}
+                                  stateFilters={
+                                    Array [
+                                      Object {
+                                        "display": "Same",
+                                        "filter": "SAME",
+                                        "selected": true,
+                                      },
+                                      Object {
+                                        "display": "Different",
+                                        "filter": "DIFFERENT",
+                                        "selected": true,
+                                      },
+                                      Object {
+                                        "display": "Incomplete data",
+                                        "filter": "INCOMPLETE_DATA",
+                                        "selected": true,
+                                      },
+                                    ]
+                                  }
                                   systems={Array []}
                                   toggleFactSort={[Function]}
                                   toggleStateSort={[Function]}
@@ -3374,6 +3460,7 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
                                           fetchCompare={[Function]}
                                           masterList={Array []}
                                           removeSystem={[Function]}
+                                          setHistory={[Function]}
                                           systemIds={Array []}
                                           toggleFactSort={[Function]}
                                           toggleStateSort={[Function]}
@@ -4407,6 +4494,7 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
           <DriftPage
             activeFactFilters={Array []}
             addStateFilter={[Function]}
+            baselines={Array []}
             clearAllFactFilters={[Function]}
             clearComparison={[Function]}
             clearComparisonFilters={[Function]}
@@ -4421,6 +4509,7 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
             factFilter=""
             filterByFact={[Function]}
             handleFactFilter={[Function]}
+            historicalProfiles={Array []}
             history={
               Object {
                 "action": "POP",
@@ -4491,6 +4580,7 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                 },
               ]
             }
+            systems={Array []}
             updatePagination={[Function]}
             updateReferenceId={[Function]}
           >
@@ -4602,6 +4692,7 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                 }
                               }
                               loading={false}
+                              setHistory={[Function]}
                               setIsFirstReference={[Function]}
                               stateFilters={
                                 Array [
@@ -4672,6 +4763,7 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                                         factFilter=""
                                                         filterByFact={[Function]}
                                                         handleFactFilter={[Function]}
+                                                        setHistory={[Function]}
                                                       >
                                                         <Form>
                                                           <form
@@ -4953,9 +5045,12 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                                     <div
                                                       className="pf-c-toolbar__item"
                                                     >
-                                                      <Connect(FilterDropDown)>
+                                                      <Connect(FilterDropDown)
+                                                        setHistory={[Function]}
+                                                      >
                                                         <FilterDropDown
                                                           addStateFilter={[Function]}
+                                                          setHistory={[Function]}
                                                           stateFilters={
                                                             Array [
                                                               Object {
@@ -7456,23 +7551,56 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                               </Toolbar>
                             </DriftToolbar>
                             <withRouter(Connect(DriftTable))
+                              activeFactFilters={Array []}
+                              addStateFilter={[Function]}
+                              baselines={Array []}
                               clearComparison={[Function]}
                               error={
                                 Object {
                                   "detail": "something",
                                 }
                               }
+                              factFilter=""
+                              handleFactFilter={[Function]}
+                              historicalProfiles={Array []}
                               isFirstReference={true}
+                              setHistory={[Function]}
                               setIsFirstReference={[Function]}
+                              stateFilters={
+                                Array [
+                                  Object {
+                                    "display": "Same",
+                                    "filter": "SAME",
+                                    "selected": true,
+                                  },
+                                  Object {
+                                    "display": "Different",
+                                    "filter": "DIFFERENT",
+                                    "selected": true,
+                                  },
+                                  Object {
+                                    "display": "Incomplete data",
+                                    "filter": "INCOMPLETE_DATA",
+                                    "selected": true,
+                                  },
+                                ]
+                              }
+                              systems={Array []}
                               updateReferenceId={[Function]}
                             >
                               <Connect(DriftTable)
+                                activeFactFilters={Array []}
+                                addStateFilter={[Function]}
+                                baselines={Array []}
                                 clearComparison={[Function]}
                                 error={
                                   Object {
                                     "detail": "something",
                                   }
                                 }
+                                factFilter=""
+                                handleFactFilter={[Function]}
+                                historicalProfiles={Array []}
                                 history={
                                   Object {
                                     "action": "POP",
@@ -7520,10 +7648,33 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                     "url": "/",
                                   }
                                 }
+                                setHistory={[Function]}
                                 setIsFirstReference={[Function]}
+                                stateFilters={
+                                  Array [
+                                    Object {
+                                      "display": "Same",
+                                      "filter": "SAME",
+                                      "selected": true,
+                                    },
+                                    Object {
+                                      "display": "Different",
+                                      "filter": "DIFFERENT",
+                                      "selected": true,
+                                    },
+                                    Object {
+                                      "display": "Incomplete data",
+                                      "filter": "INCOMPLETE_DATA",
+                                      "selected": true,
+                                    },
+                                  ]
+                                }
+                                systems={Array []}
                                 updateReferenceId={[Function]}
                               >
                                 <DriftTable
+                                  activeFactFilters={Array []}
+                                  addStateFilter={[Function]}
                                   addSystemModalOpened={false}
                                   baselines={Array []}
                                   clearComparison={[Function]}
@@ -7534,8 +7685,10 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                     }
                                   }
                                   expandRow={[Function]}
+                                  factFilter=""
                                   fetchCompare={[Function]}
                                   fullCompareData={Array []}
+                                  handleFactFilter={[Function]}
                                   historicalProfiles={Array []}
                                   history={
                                     Object {
@@ -7586,8 +7739,28 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                     }
                                   }
                                   selectHistoricProfiles={[Function]}
+                                  setHistory={[Function]}
                                   setIsFirstReference={[Function]}
                                   setSelectedBaselines={[Function]}
+                                  stateFilters={
+                                    Array [
+                                      Object {
+                                        "display": "Same",
+                                        "filter": "SAME",
+                                        "selected": true,
+                                      },
+                                      Object {
+                                        "display": "Different",
+                                        "filter": "DIFFERENT",
+                                        "selected": true,
+                                      },
+                                      Object {
+                                        "display": "Incomplete data",
+                                        "filter": "INCOMPLETE_DATA",
+                                        "selected": true,
+                                      },
+                                    ]
+                                  }
                                   systems={Array []}
                                   toggleFactSort={[Function]}
                                   toggleStateSort={[Function]}
@@ -7705,6 +7878,7 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                           fetchCompare={[Function]}
                                           masterList={Array []}
                                           removeSystem={[Function]}
+                                          setHistory={[Function]}
                                           systemIds={Array []}
                                           toggleFactSort={[Function]}
                                           toggleStateSort={[Function]}

--- a/src/SmartComponents/DriftPage/__tests__/fixtures/DriftPage.fixtures.js
+++ b/src/SmartComponents/DriftPage/__tests__/fixtures/DriftPage.fixtures.js
@@ -1,0 +1,11 @@
+export const systemIds = ([
+    '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9', 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2'
+]);
+
+export const baselineIds = ([
+    '9bbbefcc-8f23-4d97-07f2-142asdl234e9', 'fdmk59dj-fn42-dfjk-alv3-bmn2854mnn29'
+]);
+
+export const HSPIds = ([
+    '9bbbefcc-8f23-4d97-07f2-142asdl234e8', 'edmk59dj-fn42-dfjk-alv3-bmn2854mnn27'
+]);

--- a/src/SmartComponents/modules/__tests__/reducer.fixtures.js
+++ b/src/SmartComponents/modules/__tests__/reducer.fixtures.js
@@ -918,6 +918,19 @@ export const paginatedStatePageTwo = ({
     ]
 });
 
+export const systemsPayload = ([
+    {
+        display_name: 'sgi-xe500-01.rhts.eng.bos.redhat.com',
+        id: '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9',
+        last_updated: '2019-01-15T14:53:15.886891Z'
+    },
+    {
+        display_name: 'ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com',
+        id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2',
+        last_updated: '2019-01-15T15:25:16.304899Z'
+    }
+]);
+
 export const baselinesPayload = ([
     {
         display_name: 'baseline1',

--- a/src/Utilities/SetHistory.js
+++ b/src/Utilities/SetHistory.js
@@ -1,14 +1,39 @@
 import queryString from 'query-string';
+import { ASC, DESC } from '../constants';
 
-export function setHistory(history, systemIds = [], baselineIds = [], hspIds = [], referenceId) {
+export function setHistory(
+    history, systemIds = [], baselineIds = [], hspIds = [], referenceId, activeFactFilters = [], factFilter, stateFilters, factSort, stateSort
+) {
+    let nameFilters = [ ...activeFactFilters, ...factFilter ? [ factFilter ] : [] ];
+    let filterState = [ ...stateFilters?.filter(({ selected }) => selected)?.map(({ filter }) => filter?.toLowerCase()) || [] ];
+    let sort = [
+        ...[ ASC, DESC ].includes(stateSort) ? [ `${ stateSort === DESC ? '-' : '' }state` ] : [],
+        ...[ ASC, DESC ].includes(factSort) ? [ `${ factSort === DESC ? '-' : '' }fact` ] : []
+    ];
+    let searchPrefix = '?';
+
     /*eslint-disable camelcase*/
     history.push({
-        search: '?' + queryString.stringify({
+        search: searchPrefix + queryString.stringify({
             system_ids: systemIds,
             baseline_ids: baselineIds,
             hsp_ids: hspIds,
             reference_id: referenceId
         })
+    });
+
+    searchPrefix = '&';
+
+    if (!systemIds.length && !baselineIds.length && !hspIds.length && !referenceId) {
+        searchPrefix = '';
+    }
+
+    history.push({
+        search: history.location.search + searchPrefix + queryString.stringify({
+            'filter[name]': nameFilters,
+            'filter[state]': filterState,
+            sort
+        }, { arrayFormat: 'comma', encode: false })
     });
     /*eslint-enable camelcase*/
 }


### PR DESCRIPTION
To test:
- Create a comparison with any number of systems (to test best, add a system, baseline and hsp)
- See the filters and sort in the url
- Modify the url manually to achieve results
- Modify the filters and sorting via normal means (clicking buttons, typing in filters, etc)
- Add and remove systems to ensure that the url properly updates in response to your actions
- Ensure that the page updates in response to your edits to the url

For filtering and sorting, we are using the following rules based on the provided links.
- For filtering rules, see: https://jsonapi.org/recommendations/#filtering
- For sorting rules, see: https://jsonapi.org/format/#fetching-sorting

Here are some rules for how the urls are expected to look:
- Fact name filters are comma separated and follow `filter[name]=`
- State filters are comma separated and follow `filter[state]=`. If they are in the url, they should be selected. If they do not appear in the url, then they should be deselected
- Sorts are comma separated and follow `sort=`. A dash symbol in front of the sort signifies that it is a descending sort. No symbol signifies ascending sort. If fact is not added to the sort, the app will automatically set it to default descending. If state is not included in the sort, it will be set to no sort.

Here is an example of a complete filtering/sorting url:
`?filter[name]=bios,arch&filter[state]=same,incomplete_data&sort=-state,fact`

Here is an example of a full url with system ids and filtering/sorting:
`/insights/drift/?baseline_ids=<baseline_id>&hsp_ids=<hsp_id>&reference_id=<reference_id&system_ids=<system_id>&filter[state]=same,different,incomplete_data&sort=-state,fact`