### PR TITLE
[DRFT-135] Fix incorrect tooltip on obfuscated values

### DIFF
--- a/src/SmartComponents/modules/__tests__/helpers-tests.js
+++ b/src/SmartComponents/modules/__tests__/helpers-tests.js
@@ -30,11 +30,23 @@ describe('helpers', () => {
         expect(helpers.getState(state, stateFilters)).toEqual(stateFiltersFixtures.sameStateFalse[0]);
     });
 
+    it('should return INCOMPLETE_DATA filter on obfuscated getState', () => {
+        const state = 'INCOMPLETE_DATA_OBFUSCATED';
+        const stateFilters = stateFiltersFixtures.allStatesTrue;
+        expect(helpers.getState(state, stateFilters)).toEqual(stateFiltersFixtures.allStatesTrue[2]);
+    });
+
     it('should set tooltip when reference set', () => {
         const data = { name: 'system1', state: 'DIFFERENT' };
         const referenceId = 'abcd-1234-efgh-5678';
         helpers.setTooltip(data, stateFiltersFixtures.allStatesTrue, referenceId);
         expect(data.tooltip).toEqual('Different - At least one system fact value in this row differs from the reference.');
+    });
+
+    it('should set tooltip obfuscated', () => {
+        const data = { name: 'system1', state: 'INCOMPLETE_DATA_OBFUSCATED' };
+        helpers.setTooltip(data, stateFiltersFixtures.allStatesTrue);
+        expect(data.tooltip).toEqual('Incomplete data - At least one system fact value in this row is redacted.');
     });
 
     it('should return full category when filtered by full category name', () => {

--- a/src/SmartComponents/modules/helpers.js
+++ b/src/SmartComponents/modules/helpers.js
@@ -34,11 +34,11 @@ function getStateSelected(state, stateFilters) {
 function getState(state, stateFilters) {
     let isStateSelected;
 
-    isStateSelected = stateFilters.find(function(stateFilter) {
+    stateFilters.find(function(stateFilter) {
         if (stateFilter.filter === state) {
-            return stateFilter;
+            isStateSelected = stateFilter;
         } else if (state === 'INCOMPLETE_DATA_OBFUSCATED') {
-            return getState('INCOMPLETE_DATA', stateFilters);
+            isStateSelected = getState('INCOMPLETE_DATA', stateFilters);
         }
     });
 


### PR DESCRIPTION
Steps to reproduce:
1. Create comparison with a system having an obfuscated value
2. Hover over state icon to read tooltip

Tooltip should read 'Same - At least one system fact value in this row is redacted.'

This PR correctly sets the tooltip to 'Incomplete data - At least one system fact value in this row is redacted.'