### PR TITLE
Change ouiaId for create baseline modal submit button for Pendo

### DIFF
--- a/src/SmartComponents/BaselinesPage/CreateBaselineModal/CreateBaselineModal.js
+++ b/src/SmartComponents/BaselinesPage/CreateBaselineModal/CreateBaselineModal.js
@@ -46,6 +46,21 @@ export class CreateBaselineModal extends Component {
         };
     }
 
+    findSelectedRadio() {
+        const { copyBaselineChecked, copySystemChecked, fromScratchChecked } = this.state;
+        const radioChecked = { copyBaselineChecked, copySystemChecked, fromScratchChecked };
+        let keys = Object.keys(radioChecked);
+        let selectedKey;
+
+        keys.forEach(function(key) {
+            if (radioChecked[key]) {
+                selectedKey = key.substring(0, key.length - 7).toLowerCase();
+            }
+        });
+
+        return selectedKey;
+    }
+
     async submitBaselineName() {
         const { baselineName, fromScratchChecked, copyBaselineChecked, copySystemChecked } = this.state;
         const { createBaseline, toggleCreateBaselineModal, selectedBaselineIds,
@@ -237,7 +252,7 @@ export class CreateBaselineModal extends Component {
                     key="confirm"
                     variant="primary"
                     isDisabled
-                    ouiaId="create-baseline-modal-create-button"
+                    ouiaId={ 'create-baseline-button-' + this.findSelectedRadio() }
                 >
                     Create baseline
                 </Button>,
@@ -256,7 +271,7 @@ export class CreateBaselineModal extends Component {
                     key="confirm"
                     variant="primary"
                     onClick={ this.submitBaselineName }
-                    ouiaId="create-baseline-modal-create-button"
+                    ouiaId={ 'create-baseline-button-' + this.findSelectedRadio() }
                 >
                     Create baseline
                 </Button>,

--- a/src/SmartComponents/BaselinesPage/CreateBaselineModal/__tests__/__snapshots__/CreateBaselineModal.tests.js.snap
+++ b/src/SmartComponents/BaselinesPage/CreateBaselineModal/__tests__/__snapshots__/CreateBaselineModal.tests.js.snap
@@ -164,7 +164,7 @@ exports[`ConnectedCreateBaselineModal should render correctly 1`] = `
                 Array [
                   <Button
                     isDisabled={true}
-                    ouiaId="create-baseline-modal-create-button"
+                    ouiaId="create-baseline-button-fromscratch"
                     variant="primary"
                   >
                     Create baseline
@@ -378,7 +378,7 @@ exports[`ConnectedCreateBaselineModal should render correctly 1`] = `
                             <button
                               aria-disabled="true"
                               class="pf-c-button pf-m-primary pf-m-disabled"
-                              data-ouia-component-id="create-baseline-modal-create-button"
+                              data-ouia-component-id="create-baseline-button-fromscratch"
                               data-ouia-component-type="PF4/Button"
                               data-ouia-safe="true"
                               disabled=""
@@ -408,7 +408,7 @@ exports[`ConnectedCreateBaselineModal should render correctly 1`] = `
                     Array [
                       <Button
                         isDisabled={true}
-                        ouiaId="create-baseline-modal-create-button"
+                        ouiaId="create-baseline-button-fromscratch"
                         variant="primary"
                       >
                         Create baseline
@@ -784,14 +784,14 @@ exports[`ConnectedCreateBaselineModal should render correctly 1`] = `
                                   <Button
                                     isDisabled={true}
                                     key="confirm"
-                                    ouiaId="create-baseline-modal-create-button"
+                                    ouiaId="create-baseline-button-fromscratch"
                                     variant="primary"
                                   >
                                     <button
                                       aria-disabled={true}
                                       aria-label={null}
                                       className="pf-c-button pf-m-primary pf-m-disabled"
-                                      data-ouia-component-id="create-baseline-modal-create-button"
+                                      data-ouia-component-id="create-baseline-button-fromscratch"
                                       data-ouia-component-type="PF4/Button"
                                       data-ouia-safe={true}
                                       disabled={true}
@@ -848,7 +848,7 @@ exports[`CreateBaselineModal should render correctly 1`] = `
     Array [
       <Button
         isDisabled={true}
-        ouiaId="create-baseline-modal-create-button"
+        ouiaId="create-baseline-button-fromscratch"
         variant="primary"
       >
         Create baseline
@@ -958,7 +958,7 @@ exports[`CreateBaselineModal should render mount correctly 1`] = `
       Array [
         <Button
           isDisabled={true}
-          ouiaId="create-baseline-modal-create-button"
+          ouiaId="create-baseline-button-fromscratch"
           variant="primary"
         >
           Create baseline
@@ -996,7 +996,7 @@ exports[`CreateBaselineModal should render mount correctly 1`] = `
           Array [
             <Button
               isDisabled={true}
-              ouiaId="create-baseline-modal-create-button"
+              ouiaId="create-baseline-button-fromscratch"
               variant="primary"
             >
               Create baseline

--- a/src/SmartComponents/BaselinesPage/__tests__/__snapshots__/BaselinesPage.tests.js.snap
+++ b/src/SmartComponents/BaselinesPage/__tests__/__snapshots__/BaselinesPage.tests.js.snap
@@ -273,7 +273,7 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                       Array [
                         <Button
                           isDisabled={true}
-                          ouiaId="create-baseline-modal-create-button"
+                          ouiaId="create-baseline-button-fromscratch"
                           variant="primary"
                         >
                           Create baseline
@@ -311,7 +311,7 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                           Array [
                             <Button
                               isDisabled={true}
-                              ouiaId="create-baseline-modal-create-button"
+                              ouiaId="create-baseline-button-fromscratch"
                               variant="primary"
                             >
                               Create baseline
@@ -5589,7 +5589,7 @@ exports[`ConnectedBaselinesPage should render empty state 1`] = `
                       Array [
                         <Button
                           isDisabled={true}
-                          ouiaId="create-baseline-modal-create-button"
+                          ouiaId="create-baseline-button-fromscratch"
                           variant="primary"
                         >
                           Create baseline
@@ -5627,7 +5627,7 @@ exports[`ConnectedBaselinesPage should render empty state 1`] = `
                           Array [
                             <Button
                               isDisabled={true}
-                              ouiaId="create-baseline-modal-create-button"
+                              ouiaId="create-baseline-button-fromscratch"
                               variant="primary"
                             >
                               Create baseline


### PR DESCRIPTION
This change will allow us to determine which radio button was selected when a user creates a baseline from the create baseline modal. We will set 3 features in Pendo to track each ouiaId and see how users are creating baselines.

To test, go to the create baselines modal and open the developer tools in your browser. Use the element inspector to select the 'Create Baseline' button (you'll need to type something in the Baseline name input box to get the 'Create baseline' button to be selectable. As you change the selected radio button, you should see the `data-ouia-component-id` update with one of the following strings:

- `copy-baseline-button-fromscratch`
- `copy-baseline-button-copybaseline`
- `copy-baseline-button-copysystem`