### PR TITLE
Remove React root element mutation.

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -8,29 +8,14 @@ const DriftPage = asyncComponent(() => import ('./SmartComponents/DriftPage/Drif
 const BaselinesPage = asyncComponent(() => import ('./SmartComponents/BaselinesPage/BaselinesPage'));
 const EditBaseline = asyncComponent(() => import ('./SmartComponents/BaselinesPage/EditBaseline/EditBaseline'));
 
-const InsightsRoute = ({ component: Component, rootClass, title, ...rest }) => {
+const InsightsRoute = ({ component: Component, title, ...rest }) => {
     title ? document.title = title : null;
-    /**
-     * @deprecated
-     * Mutating chrome root element is deprecated.
-     * Please add custom classes on different elements exclusive to drift UI DOM.
-     * This functionality will no longer exist in chrome 2 to prevent global styling issues
-     */
-    const root = document.getElementById('root');
-    root.removeAttribute('class');
-    /**
-     * Adding root class to root element to scope the CSS classes.
-     * Chrome 2 will add this class automatically to root element.
-     */
-    root.classList.add(`page__${rootClass}`, 'pf-l-page__main', 'pf-c-page__main', 'drift');
-    root.setAttribute('role', 'main');
 
     return (<Route { ...rest } component={ Component } />);
 };
 
 InsightsRoute.propTypes = {
     component: PropTypes.func,
-    rootClass: PropTypes.string,
     title: PropTypes.string
 };
 


### PR DESCRIPTION
Chrome 2 deletes the `document.getElementById('root')` element if a chrome 2 ready app is rendered. Legacy code can cause runtime crashes.

The code can be safely removed because the root class was not used.

cc @johnsonm325 