### PR TITLE
[DRFT-192] Fixes issue with error when changing baseline fact name

### DIFF
--- a/src/SmartComponents/BaselinesPage/EditBaseline/EditBaseline.js
+++ b/src/SmartComponents/BaselinesPage/EditBaseline/EditBaseline.js
@@ -342,7 +342,7 @@ export class EditBaseline extends Component {
             row.push(editBaselineHelpers.renderKebab({ factName: fact[FACT_NAME], factValue: fact[FACT_VALUE], factData, hasWritePermissions }));
             rows.push(<tr
                 data-ouia-component-type='PF4/TableRow'
-                data-ouia-component-id={ 'edit-baseline-table-row-' + factData.name }
+                data-ouia-component-id={ 'edit-baseline-table-row-' + factData?.name }
                 key={ fact[FACT_NAME] }>{ row }</tr>);
         }
 

--- a/src/api.js
+++ b/src/api.js
@@ -1,11 +1,9 @@
 import axios from 'axios';
 import { DRIFT_API_ROOT, BASELINE_API_ROOT, HISTORICAL_PROFILES_API_ROOT } from './constants';
-//import { mockMultiValueFacts } from './SmartComponents/modules/__tests__/reducer.fixtures';
 
 async function post(path, body = {}) {
     const request = await axios.post(DRIFT_API_ROOT.concat(path), body);
     return request.data;
-    //return mockMultiValueFacts;
 }
 
 async function getBaselines(path, getParams = {}) {


### PR DESCRIPTION
To reproduce:

- Navigate to baseline details view
- edit fact
- change Fact name
- click Save

Empty, grey view is shown. The fact/category in question is successfully edited/deleted, just the UI breaks.

This PR fixes that issue. The edit baseline table should properly load after modal closes.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
