### PR TITLE
Fix pagination and tags issues with Inventory table

### DIFF
--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaselinePage.js
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaselinePage.js
@@ -188,14 +188,14 @@ export class EditBaselinePage extends Component {
             >
                 <Tab
                     eventKey={ 0 }
-                    title="baseline"
+                    title="Facts"
                     id="baseline-tab"
                     data-ouia-component-id="baseline-tab-button"
                 >
                 </Tab>
                 <Tab
                     eventKey={ 1 }
-                    title="system notifications"
+                    title="Systems"
                     id="system-notifications-tab"
                     data-ouia-component-id=""
                 >

--- a/src/SmartComponents/SystemsTable/NotificationsSystemsTable.js
+++ b/src/SmartComponents/SystemsTable/NotificationsSystemsTable.js
@@ -135,10 +135,9 @@ export const SystemsTable = connect(null, mapDispatchToProps)(({
                     const data = await getEntities.current?.(
                         currIds,
                         {
-                            ...config,
                             hasItems: true
                         },
-                        false
+                        true
                     );
                     return {
                         ...data,

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -108,10 +108,9 @@ export const SystemsTable = ({
                         const data = await getEntities.current?.(
                             currIds,
                             {
-                                ...config,
                                 hasItems: true
                             },
-                            false
+                            true
                         );
 
                         return {
@@ -126,7 +125,7 @@ export const SystemsTable = ({
                         };
                     }
                     : async (_items, config) => {
-                        const data = await getEntities.current?.([], config);
+                        const data = await getEntities.current?.([], config, true);
                         return { ...data };
                     } }
                 bulkSelect={ onSelect && {


### PR DESCRIPTION
Fixes:

- DRFT-312
  - To repro:
    - open a baseline
    - change to `system notifications` tab
    - add several systems, such that there are at least two pages in the table
    - change to next page
    - The table is stuck on loading, see attached error in console.
- DRFT-317
  - To repro:
    - Navigate to systems table (for example in Add to Comparison modal)
    - All the systems have "1" displayed as the tags count. This amount is displayed for ALL systems, regardless of their actual tags (as can be seen when opening the tags modal).

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
