### PR TITLE
Add pointer on hover of notifications toolbar dropdown

### DIFF
--- a/src/SmartComponents/SystemsTable/NotificationsSystemsTable.js
+++ b/src/SmartComponents/SystemsTable/NotificationsSystemsTable.js
@@ -174,7 +174,11 @@ export const SystemsTable = connect(null, mapDispatchToProps)(({
                 actionsConfig={{
                     actions: [
                         toolbarButton,
-                        <div key="delete-baseline-notification" onClick={ () => deleteNotifications(entities?.selectedSystemIds) }>
+                        <div
+                            className='pointer'
+                            key="delete-baseline-notification"
+                            onClick={ () => deleteNotifications(entities?.selectedSystemIds) }
+                        >
                             { entities?.selectedSystemIds?.length > 1 ? 'Delete notifications' : 'Delete notification' }
                         </div>
                     ]


### PR DESCRIPTION
Go to baseline details
Click "Systems" tab
Click dropdown in toolbar

Hovering over dropdown item doesn't show pointer. This PR fixes that.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
