### PR TITLE
[DRFT-314] Disable delete notification when nothing selected

### DIFF
--- a/src/SmartComponents/SystemsTable/NotificationsSystemsTable.js
+++ b/src/SmartComponents/SystemsTable/NotificationsSystemsTable.js
@@ -178,6 +178,7 @@ export const SystemsTable = connect(null, mapDispatchToProps)(({
                             className='pointer'
                             key="delete-baseline-notification"
                             onClick={ () => deleteNotifications(entities?.selectedSystemIds) }
+                            isDisabled={ !entities?.selectedSystemIds?.length }
                         >
                             { entities?.selectedSystemIds?.length > 1 ? 'Delete notifications' : 'Delete notification' }
                         </div>


### PR DESCRIPTION
To reproduce:

- open a baseline
- navigate to system notifications
- make sure no systems are selected
- click toolbar kebab
- select Delete notification

The modal appears, and clicking delete does nothing. This PR disables the Delete notification button when no systems are selected.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
