### PR TITLE
Fix text in delete notification modal

### DIFF
--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/SystemNotification/DeleteNotificationModal/DeleteNotificationModal.js
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/SystemNotification/DeleteNotificationModal/DeleteNotificationModal.js
@@ -27,7 +27,7 @@ export class DeleteNotificationModal extends Component {
                     className="drift"
                     ouiaId='delete-baseline-notification-modal'
                     variant={ ModalVariant.small }
-                    title="Delete baseline notificatoin"
+                    title={ systemsToDelete?.length === 1 ? 'Delete baseline notification' : 'Delete baseline notifications' }
                     isOpen={ deleteNotificationsModalOpened }
                     onClose={ () => toggleDeleteNotificationsModal() }
                     actions = { [
@@ -37,7 +37,7 @@ export class DeleteNotificationModal extends Component {
                             variant="danger"
                             onClick={ this.deleteNotification }
                         >
-                            { systemsToDelete?.length > 1 ? 'Delete notifications' : 'Delete notification' }
+                            Delete
                         </Button>,
                         <Button
                             key="cancel"
@@ -49,7 +49,7 @@ export class DeleteNotificationModal extends Component {
                         </Button>
                     ] }
                 >
-                    You have selected { ' ' } { systemsToDelete?.length > 1 ? 'multiple baseline notifications' : null }
+                    You have selected { ' ' } { systemsToDelete?.length === 1 ? 'a baseline notification' : 'multiple baseline notifications' }
                     { ' ' } to be deleted.
                     <br></br>
                     { <div className="md-padding-top">Deleting a baseline notification cannot be undone.</div> }

--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/SystemNotification/SystemKebab/SystemKebab.js
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/SystemNotification/SystemKebab/SystemKebab.js
@@ -60,7 +60,6 @@ export class SystemKebab extends Component {
 
 SystemKebab.propTypes = {
     systemIds: PropTypes.array,
-    systemName: PropTypes.string,
     deleteNotifications: PropTypes.func
 };
 

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -99,7 +99,6 @@ function selectedReducer(
                     row.system_notification = <React.Fragment>
                         <SystemKebab
                             systemIds={ systemIds }
-                            systemName={ row.display_name }
                             deleteNotifications={ deleteNotifications }
                         />
                     </React.Fragment>;


### PR DESCRIPTION
- [DRFT-319] The delete baseline notification confirmation prompt says:
  - "You have selected to be deleted"
- [DRFT-318] Changed to `You have selected a baseline notification/multiple baseline notifications to be deleted.`
- Fixed typo in title `Delete baseline notificatoin`.
- Changed title to read `Delete baseline notification(s)` depending on number of systems selected.
- Changed confirmation button to read `Delete`.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
