### PR TITLE
Fix number to select in bulk select dropdown

### DIFF
--- a/src/SmartComponents/SystemsTable/NotificationsSystemsTable.js
+++ b/src/SmartComponents/SystemsTable/NotificationsSystemsTable.js
@@ -159,7 +159,7 @@ export const SystemsTable = connect(null, mapDispatchToProps)(({
                             onSelect('none');
                         }
                     }, {
-                        title: `Select page (${ registry.entities?.count || 0 })`,
+                        title: `Select page (${ entities?.count || 0 })`,
                         onClick: () => {
                             onSelect('page');
                         }


### PR DESCRIPTION
I have 3 baseline systems.  In the dropdown, it says Select page (0).  I believe it should say 3 in parentheses.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
