### PR TITLE
[DRFT-328] Await add notifications

### DIFF
--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/SystemNotification/SystemNotification.js
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/SystemNotification/SystemNotification.js
@@ -46,7 +46,7 @@ export class SystemNotification extends Component {
         const { systemsToAdd } = this.state;
         const { addNotifications, baselineId } = this.props;
 
-        addNotifications(baselineId, systemsToAdd);
+        await addNotifications(baselineId, systemsToAdd);
         this.setState({ systemsToAdd: []});
 
         this.toggleModal();


### PR DESCRIPTION
Add `await` to add notifications action to ensure notifications are added before the fetch is fired off.

To repro:
- open a baseline notifications tab
- make sure there is at least one system present
- click Add system
- try to add using Bulk select
- click Submit

New systems added may not be present. Doesn't happen 100% of the time, but happens often enough to find the issue.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
