### PR TITLE
Add DevEntry for redux logging

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -8,7 +8,10 @@ const { config: webpackConfig, plugins } = config({
 
 plugins.push(
     require('@redhat-cloud-services/frontend-components-config/federated-modules')({
-        root: resolve(__dirname, '../')
+        root: resolve(__dirname, '../'),
+        exposes: {
+            './RootApp': resolve(__dirname, '../src/DevEntry')
+        }
     })
 );
 

--- a/src/DevEntry.js
+++ b/src/DevEntry.js
@@ -3,15 +3,16 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import { init } from './store';
 import App from './App';
+import logger from 'redux-logger';
 
 import getBaseName from './Utilities/getBaseName';
 
-const Drift = () => (
-    <Provider store={ init().getStore() }>
+const DriftDev = () => (
+    <Provider store={ init(logger).getStore() }>
         <Router basename={ getBaseName(window.location.pathname) }>
             <App/>
         </Router>
     </Provider>
 );
 
-export default Drift;
+export default DriftDev;

--- a/src/bootstrap-dev.js
+++ b/src/bootstrap-dev.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import logger from 'redux-logger';
-import Drift from './AppEntry';
+import DriftDev from './DevEntry';
 
-ReactDOM.render(<Drift logger={ logger } />, document.getElementById('root'));
+ReactDOM.render(<DriftDev />, document.getElementById('root'));


### PR DESCRIPTION
Dev environment stopped logging redux actions in the browser console. This PR creates a dev-specific entry point into the app where logging is passed, exclusively.

To repro:
Open app and open developer tools in browser
You should not see any redux actions in the console

This fix will expose the action logging.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [x] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
