### PR TITLE
[DRFT-325] Disable 'Add system' button with no baselinesWrite perms

### DIFF
--- a/src/SmartComponents/AddSystemModal/AddSystemModal.js
+++ b/src/SmartComponents/AddSystemModal/AddSystemModal.js
@@ -173,9 +173,9 @@ export class AddSystemModal extends Component {
 
     render() {
         const { activeTab, addSystemModalOpened, baselineTableData, globalFilterState, handleBaselineSelection, handleHSPSelection,
-            hasBaselinesReadPermissions, hasBaselinesWritePermissions, hasInventoryReadPermissions, hasHSPReadPermissions, historicalProfiles,
-            loading, entities, selectEntity, selectHistoricProfiles, selectedBaselineIds, selectedBaselineContent, selectedHSPContent, selectedHSPIds,
-            selectBaseline, selectedSystemContent, selectedSystemIds, setSelectedSystemIds, totalBaselines } = this.props;
+            historicalProfiles, loading, entities, permissions, selectEntity, selectHistoricProfiles, selectedBaselineIds, selectedBaselineContent,
+            selectedHSPContent, selectedHSPIds, selectBaseline, selectedSystemContent, selectedSystemIds, setSelectedSystemIds,
+            totalBaselines } = this.props;
         const { columns, basketIsVisible } = this.state;
 
         return (
@@ -243,10 +243,10 @@ export class AddSystemModal extends Component {
                         >
                             <SystemsTable
                                 selectedSystemIds={ selectedSystemIds }
-                                hasHistoricalDropdown={ hasHSPReadPermissions }
+                                hasHistoricalDropdown={ permissions.hspRead }
                                 historicalProfiles={ historicalProfiles }
                                 hasMultiSelect={ true }
-                                hasInventoryReadPermissions={ hasInventoryReadPermissions }
+                                permissions={ permissions }
                                 entities={ entities }
                                 selectVariant='checkbox'
                                 onSystemSelect={ setSelectedSystemIds }
@@ -268,8 +268,7 @@ export class AddSystemModal extends Component {
                                 onBulkSelect={ this.onBulkSelect }
                                 selectedBaselineIds={ selectedBaselineIds }
                                 totalBaselines={ totalBaselines }
-                                hasReadPermissions={ hasBaselinesReadPermissions }
-                                hasWritePermissions={ hasBaselinesWritePermissions }
+                                permissions={ permissions }
                                 kebab={ false }
                                 basketIsVisible={ basketIsVisible }
                             />
@@ -300,10 +299,7 @@ AddSystemModal.propTypes = {
     historicalProfiles: PropTypes.array,
     referenceId: PropTypes.string,
     totalBaselines: PropTypes.number,
-    hasInventoryReadPermissions: PropTypes.bool,
-    hasBaselinesReadPermissions: PropTypes.bool,
-    hasBaselinesWritePermissions: PropTypes.bool,
-    hasHSPReadPermissions: PropTypes.bool,
+    permissions: PropTypes.object,
     globalFilterState: PropTypes.object,
     selectedSystemIds: PropTypes.array,
     setSelectedSystemIds: PropTypes.func,

--- a/src/SmartComponents/AddSystemModal/__tests__/AddSystemModal.tests.js
+++ b/src/SmartComponents/AddSystemModal/__tests__/AddSystemModal.tests.js
@@ -31,8 +31,10 @@ describe('AddSystemModal', () => {
             loading: false,
             baselineTableData: [],
             historicalProfiles: [],
-            hasInventoryReadPermissions: true,
-            hasHSPReadPermissions: true,
+            permissions: {
+                hspRead: true,
+                inventoryRead: true
+            },
             referenceId: undefined,
             selectedBaselineContent: [],
             selectedHSPContent: [],
@@ -264,8 +266,10 @@ describe('ConnectedAddSystemModal', () => {
         };
 
         props = {
-            hasInventoryReadPermissions: true,
-            hasHSPReadPermissions: true,
+            permissions: {
+                hspRead: true,
+                inventoryRead: true
+            },
             selectedSystemIds: [],
             selectedBaselineIds: [],
             selectedHSPIds: []
@@ -288,7 +292,7 @@ describe('ConnectedAddSystemModal', () => {
 
     it('should render hasHistoricalDropdown false with no hsp read permissions', () => {
         const store = mockStore(initialState);
-        props.hasHSPReadPermissions = false;
+        props.permissions.hspRead = false;
 
         const wrapper = mount(
             <MemoryRouter keyLength={ 0 }>
@@ -303,7 +307,7 @@ describe('ConnectedAddSystemModal', () => {
 
     it('should render disabled with no inventory permissions', () => {
         const store = mockStore(initialState);
-        props.hasInventoryReadPermissions = false;
+        props.permissions.inventoryRead = false;
 
         const wrapper = mount(
             <MemoryRouter keyLength={ 0 }>

--- a/src/SmartComponents/AddSystemModal/__tests__/__snapshots__/AddSystemModal.tests.js.snap
+++ b/src/SmartComponents/AddSystemModal/__tests__/__snapshots__/AddSystemModal.tests.js.snap
@@ -100,9 +100,14 @@ exports[`AddSystemModal should render correctly 1`] = `
             }
           }
           hasHistoricalDropdown={true}
-          hasInventoryReadPermissions={true}
           hasMultiSelect={true}
           historicalProfiles={Array []}
+          permissions={
+            Object {
+              "hspRead": true,
+              "inventoryRead": true,
+            }
+          }
           selectVariant="checkbox"
         />
       </Tab>
@@ -136,6 +141,12 @@ exports[`AddSystemModal should render correctly 1`] = `
           loading={false}
           onBulkSelect={[Function]}
           onSelect={[Function]}
+          permissions={
+            Object {
+              "hspRead": true,
+              "inventoryRead": true,
+            }
+          }
           selectedBaselineIds={Array []}
           tableData={Array []}
           tableId="COMPARISON"
@@ -9356,8 +9367,12 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
       }
     >
       <Connect(AddSystemModal)
-        hasHSPReadPermissions={true}
-        hasInventoryReadPermissions={true}
+        permissions={
+          Object {
+            "hspRead": true,
+            "inventoryRead": true,
+          }
+        }
         selectedBaselineIds={Array []}
         selectedHSPIds={Array []}
         selectedSystemIds={Array []}
@@ -9383,10 +9398,14 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
           handleBaselineSelection={[Function]}
           handleHSPSelection={[Function]}
           handleSystemSelection={[Function]}
-          hasHSPReadPermissions={true}
-          hasInventoryReadPermissions={true}
           historicalProfiles={Array []}
           loading={false}
+          permissions={
+            Object {
+              "hspRead": true,
+              "inventoryRead": true,
+            }
+          }
           selectActiveTab={[Function]}
           selectBaseline={[Function]}
           selectEntity={[Function]}
@@ -11001,10 +11020,15 @@ Try changing your filter settings.
                                             }
                                           }
                                           hasHistoricalDropdown={true}
-                                          hasInventoryReadPermissions={true}
                                           hasMultiSelect={true}
                                           historicalProfiles={Array []}
                                           onSystemSelect={[Function]}
+                                          permissions={
+                                            Object {
+                                              "hspRead": true,
+                                              "inventoryRead": true,
+                                            }
+                                          }
                                           selectVariant="checkbox"
                                           selectedSystemIds={Array []}
                                         />
@@ -11029,10 +11053,15 @@ Try changing your filter settings.
                                               }
                                             }
                                             hasHistoricalDropdown={true}
-                                            hasInventoryReadPermissions={true}
                                             hasMultiSelect={true}
                                             historicalProfiles={Array []}
                                             onSystemSelect={[Function]}
+                                            permissions={
+                                              Object {
+                                                "hspRead": true,
+                                                "inventoryRead": true,
+                                              }
+                                            }
                                             selectVariant="checkbox"
                                             selectedSystemIds={Array []}
                                           />
@@ -11058,10 +11087,15 @@ Try changing your filter settings.
                                             }
                                           }
                                           hasHistoricalDropdown={true}
-                                          hasInventoryReadPermissions={true}
                                           hasMultiSelect={true}
                                           historicalProfiles={Array []}
                                           onSystemSelect={[Function]}
+                                          permissions={
+                                            Object {
+                                              "hspRead": true,
+                                              "inventoryRead": true,
+                                            }
+                                          }
                                           selectVariant="checkbox"
                                           selectedSystemIds={Array []}
                                         >
@@ -11073,10 +11107,15 @@ Try changing your filter settings.
                                               }
                                             }
                                             hasHistoricalDropdown={true}
-                                            hasInventoryReadPermissions={true}
                                             hasMultiSelect={true}
                                             historicalProfiles={Array []}
                                             onSystemSelect={[Function]}
+                                            permissions={
+                                              Object {
+                                                "hspRead": true,
+                                                "inventoryRead": true,
+                                              }
+                                            }
                                             selectEntities={[Function]}
                                             selectHistoricProfiles={[Function]}
                                             selectSingleHSP={[Function]}
@@ -11602,6 +11641,12 @@ Try changing your filter settings.
                                           loading={false}
                                           onBulkSelect={[Function]}
                                           onSelect={[Function]}
+                                          permissions={
+                                            Object {
+                                              "hspRead": true,
+                                              "inventoryRead": true,
+                                            }
+                                          }
                                           selectedBaselineIds={Array []}
                                           tableData={Array []}
                                           tableId="COMPARISON"
@@ -11645,6 +11690,12 @@ Try changing your filter settings.
                                             loading={false}
                                             onBulkSelect={[Function]}
                                             onSelect={[Function]}
+                                            permissions={
+                                              Object {
+                                                "hspRead": true,
+                                                "inventoryRead": true,
+                                              }
+                                            }
                                             selectedBaselineIds={Array []}
                                             tableData={Array []}
                                             tableId="COMPARISON"
@@ -11689,6 +11740,12 @@ Try changing your filter settings.
                                           loading={false}
                                           onBulkSelect={[Function]}
                                           onSelect={[Function]}
+                                          permissions={
+                                            Object {
+                                              "hspRead": true,
+                                              "inventoryRead": true,
+                                            }
+                                          }
                                           selectedBaselineIds={Array []}
                                           tableData={Array []}
                                           tableId="COMPARISON"
@@ -11720,6 +11777,12 @@ Try changing your filter settings.
                                             loading={false}
                                             onBulkSelect={[Function]}
                                             onSelect={[Function]}
+                                            permissions={
+                                              Object {
+                                                "hspRead": true,
+                                                "inventoryRead": true,
+                                              }
+                                            }
                                             selectedBaselineIds={Array []}
                                             tableData={Array []}
                                             tableId="COMPARISON"
@@ -11736,6 +11799,12 @@ Try changing your filter settings.
                                               onSearch={[Function]}
                                               page={1}
                                               perPage={20}
+                                              permissions={
+                                                Object {
+                                                  "hspRead": true,
+                                                  "inventoryRead": true,
+                                                }
+                                              }
                                               selectedBaselineIds={Array []}
                                               tableData={Array []}
                                               tableId="COMPARISON"
@@ -15683,8 +15752,12 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
       }
     >
       <Connect(AddSystemModal)
-        hasHSPReadPermissions={true}
-        hasInventoryReadPermissions={true}
+        permissions={
+          Object {
+            "hspRead": true,
+            "inventoryRead": true,
+          }
+        }
         selectedBaselineIds={Array []}
         selectedHSPIds={Array []}
         selectedSystemIds={Array []}
@@ -15710,10 +15783,14 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
           handleBaselineSelection={[Function]}
           handleHSPSelection={[Function]}
           handleSystemSelection={[Function]}
-          hasHSPReadPermissions={true}
-          hasInventoryReadPermissions={true}
           historicalProfiles={Array []}
           loading={false}
+          permissions={
+            Object {
+              "hspRead": true,
+              "inventoryRead": true,
+            }
+          }
           selectActiveTab={[Function]}
           selectBaseline={[Function]}
           selectEntity={[Function]}
@@ -17328,10 +17405,15 @@ Try changing your filter settings.
                                             }
                                           }
                                           hasHistoricalDropdown={true}
-                                          hasInventoryReadPermissions={true}
                                           hasMultiSelect={true}
                                           historicalProfiles={Array []}
                                           onSystemSelect={[Function]}
+                                          permissions={
+                                            Object {
+                                              "hspRead": true,
+                                              "inventoryRead": true,
+                                            }
+                                          }
                                           selectVariant="checkbox"
                                           selectedSystemIds={Array []}
                                         />
@@ -17356,10 +17438,15 @@ Try changing your filter settings.
                                               }
                                             }
                                             hasHistoricalDropdown={true}
-                                            hasInventoryReadPermissions={true}
                                             hasMultiSelect={true}
                                             historicalProfiles={Array []}
                                             onSystemSelect={[Function]}
+                                            permissions={
+                                              Object {
+                                                "hspRead": true,
+                                                "inventoryRead": true,
+                                              }
+                                            }
                                             selectVariant="checkbox"
                                             selectedSystemIds={Array []}
                                           />
@@ -17385,10 +17472,15 @@ Try changing your filter settings.
                                             }
                                           }
                                           hasHistoricalDropdown={true}
-                                          hasInventoryReadPermissions={true}
                                           hasMultiSelect={true}
                                           historicalProfiles={Array []}
                                           onSystemSelect={[Function]}
+                                          permissions={
+                                            Object {
+                                              "hspRead": true,
+                                              "inventoryRead": true,
+                                            }
+                                          }
                                           selectVariant="checkbox"
                                           selectedSystemIds={Array []}
                                         >
@@ -17400,10 +17492,15 @@ Try changing your filter settings.
                                               }
                                             }
                                             hasHistoricalDropdown={true}
-                                            hasInventoryReadPermissions={true}
                                             hasMultiSelect={true}
                                             historicalProfiles={Array []}
                                             onSystemSelect={[Function]}
+                                            permissions={
+                                              Object {
+                                                "hspRead": true,
+                                                "inventoryRead": true,
+                                              }
+                                            }
                                             selectEntities={[Function]}
                                             selectHistoricProfiles={[Function]}
                                             selectSingleHSP={[Function]}
@@ -17877,6 +17974,12 @@ Try changing your filter settings.
                                           loading={false}
                                           onBulkSelect={[Function]}
                                           onSelect={[Function]}
+                                          permissions={
+                                            Object {
+                                              "hspRead": true,
+                                              "inventoryRead": true,
+                                            }
+                                          }
                                           selectedBaselineIds={Array []}
                                           tableData={Array []}
                                           tableId="COMPARISON"
@@ -17920,6 +18023,12 @@ Try changing your filter settings.
                                             loading={false}
                                             onBulkSelect={[Function]}
                                             onSelect={[Function]}
+                                            permissions={
+                                              Object {
+                                                "hspRead": true,
+                                                "inventoryRead": true,
+                                              }
+                                            }
                                             selectedBaselineIds={Array []}
                                             tableData={Array []}
                                             tableId="COMPARISON"
@@ -17964,6 +18073,12 @@ Try changing your filter settings.
                                           loading={false}
                                           onBulkSelect={[Function]}
                                           onSelect={[Function]}
+                                          permissions={
+                                            Object {
+                                              "hspRead": true,
+                                              "inventoryRead": true,
+                                            }
+                                          }
                                           selectedBaselineIds={Array []}
                                           tableData={Array []}
                                           tableId="COMPARISON"
@@ -17995,6 +18110,12 @@ Try changing your filter settings.
                                             loading={false}
                                             onBulkSelect={[Function]}
                                             onSelect={[Function]}
+                                            permissions={
+                                              Object {
+                                                "hspRead": true,
+                                                "inventoryRead": true,
+                                              }
+                                            }
                                             selectedBaselineIds={Array []}
                                             tableData={Array []}
                                             tableId="COMPARISON"
@@ -18011,6 +18132,12 @@ Try changing your filter settings.
                                               onSearch={[Function]}
                                               page={1}
                                               perPage={20}
+                                              permissions={
+                                                Object {
+                                                  "hspRead": true,
+                                                  "inventoryRead": true,
+                                                }
+                                              }
                                               selectedBaselineIds={Array []}
                                               tableData={Array []}
                                               tableId="COMPARISON"
@@ -21958,8 +22085,12 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
       }
     >
       <Connect(AddSystemModal)
-        hasHSPReadPermissions={true}
-        hasInventoryReadPermissions={false}
+        permissions={
+          Object {
+            "hspRead": true,
+            "inventoryRead": false,
+          }
+        }
         selectedBaselineIds={Array []}
         selectedHSPIds={Array []}
         selectedSystemIds={Array []}
@@ -21985,10 +22116,14 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
           handleBaselineSelection={[Function]}
           handleHSPSelection={[Function]}
           handleSystemSelection={[Function]}
-          hasHSPReadPermissions={true}
-          hasInventoryReadPermissions={false}
           historicalProfiles={Array []}
           loading={false}
+          permissions={
+            Object {
+              "hspRead": true,
+              "inventoryRead": false,
+            }
+          }
           selectActiveTab={[Function]}
           selectBaseline={[Function]}
           selectEntity={[Function]}
@@ -23617,10 +23752,15 @@ Try changing your filter settings.
                                             }
                                           }
                                           hasHistoricalDropdown={true}
-                                          hasInventoryReadPermissions={false}
                                           hasMultiSelect={true}
                                           historicalProfiles={Array []}
                                           onSystemSelect={[Function]}
+                                          permissions={
+                                            Object {
+                                              "hspRead": true,
+                                              "inventoryRead": false,
+                                            }
+                                          }
                                           selectVariant="checkbox"
                                           selectedSystemIds={Array []}
                                         />
@@ -23645,10 +23785,15 @@ Try changing your filter settings.
                                               }
                                             }
                                             hasHistoricalDropdown={true}
-                                            hasInventoryReadPermissions={false}
                                             hasMultiSelect={true}
                                             historicalProfiles={Array []}
                                             onSystemSelect={[Function]}
+                                            permissions={
+                                              Object {
+                                                "hspRead": true,
+                                                "inventoryRead": false,
+                                              }
+                                            }
                                             selectVariant="checkbox"
                                             selectedSystemIds={Array []}
                                           />
@@ -23674,10 +23819,15 @@ Try changing your filter settings.
                                             }
                                           }
                                           hasHistoricalDropdown={true}
-                                          hasInventoryReadPermissions={false}
                                           hasMultiSelect={true}
                                           historicalProfiles={Array []}
                                           onSystemSelect={[Function]}
+                                          permissions={
+                                            Object {
+                                              "hspRead": true,
+                                              "inventoryRead": false,
+                                            }
+                                          }
                                           selectVariant="checkbox"
                                           selectedSystemIds={Array []}
                                         >
@@ -23689,10 +23839,15 @@ Try changing your filter settings.
                                               }
                                             }
                                             hasHistoricalDropdown={true}
-                                            hasInventoryReadPermissions={false}
                                             hasMultiSelect={true}
                                             historicalProfiles={Array []}
                                             onSystemSelect={[Function]}
+                                            permissions={
+                                              Object {
+                                                "hspRead": true,
+                                                "inventoryRead": false,
+                                              }
+                                            }
                                             selectEntities={[Function]}
                                             selectHistoricProfiles={[Function]}
                                             selectSingleHSP={[Function]}
@@ -23813,6 +23968,12 @@ Try changing your filter settings.
                                           loading={false}
                                           onBulkSelect={[Function]}
                                           onSelect={[Function]}
+                                          permissions={
+                                            Object {
+                                              "hspRead": true,
+                                              "inventoryRead": false,
+                                            }
+                                          }
                                           selectedBaselineIds={Array []}
                                           tableData={Array []}
                                           tableId="COMPARISON"
@@ -23856,6 +24017,12 @@ Try changing your filter settings.
                                             loading={false}
                                             onBulkSelect={[Function]}
                                             onSelect={[Function]}
+                                            permissions={
+                                              Object {
+                                                "hspRead": true,
+                                                "inventoryRead": false,
+                                              }
+                                            }
                                             selectedBaselineIds={Array []}
                                             tableData={Array []}
                                             tableId="COMPARISON"
@@ -23900,6 +24067,12 @@ Try changing your filter settings.
                                           loading={false}
                                           onBulkSelect={[Function]}
                                           onSelect={[Function]}
+                                          permissions={
+                                            Object {
+                                              "hspRead": true,
+                                              "inventoryRead": false,
+                                            }
+                                          }
                                           selectedBaselineIds={Array []}
                                           tableData={Array []}
                                           tableId="COMPARISON"
@@ -23931,6 +24104,12 @@ Try changing your filter settings.
                                             loading={false}
                                             onBulkSelect={[Function]}
                                             onSelect={[Function]}
+                                            permissions={
+                                              Object {
+                                                "hspRead": true,
+                                                "inventoryRead": false,
+                                              }
+                                            }
                                             selectedBaselineIds={Array []}
                                             tableData={Array []}
                                             tableId="COMPARISON"
@@ -23947,6 +24126,12 @@ Try changing your filter settings.
                                               onSearch={[Function]}
                                               page={1}
                                               perPage={20}
+                                              permissions={
+                                                Object {
+                                                  "hspRead": true,
+                                                  "inventoryRead": false,
+                                                }
+                                              }
                                               selectedBaselineIds={Array []}
                                               tableData={Array []}
                                               tableId="COMPARISON"

--- a/src/SmartComponents/BaselinesPage/BaselinesPage.js
+++ b/src/SmartComponents/BaselinesPage/BaselinesPage.js
@@ -77,7 +77,7 @@ export class BaselinesPage extends Component {
         selectBaseline(ids, isSelected, 'CHECKBOX');
     }
 
-    renderTable(hasReadPermissions, hasWritePermissions) {
+    renderTable(permissions) {
         const { baselineTableData, loading, createBaselineModalOpened, clearEditBaselineData, selectedBaselineIds,
             totalBaselines } = this.props;
         const { columns } = this.state;
@@ -102,15 +102,14 @@ export class BaselinesPage extends Component {
                         onBulkSelect={ this.onBulkSelect }
                         selectedBaselineIds={ selectedBaselineIds }
                         totalBaselines={ totalBaselines }
-                        hasReadPermissions={ hasReadPermissions }
-                        hasWritePermissions={ hasWritePermissions }
+                        permissions={ permissions }
                     />
                 </div>
             </CardBody>
         );
     }
 
-    renderEmptyState = (hasBaselinesWritePermissions) => {
+    renderEmptyState = (permissions) => {
         const { baselineError, emptyState, loading, revertBaselineFetch } = this.props;
         const { emptyStateMessage, errorMessage } = this.state;
 
@@ -121,7 +120,7 @@ export class BaselinesPage extends Component {
                 text={ emptyStateMessage }
                 button={ <CreateBaselineButton
                     emptyState={ emptyState }
-                    hasWritePermissions={ hasBaselinesWritePermissions }
+                    permissions={ permissions }
                     loading={ loading } /> }
             />;
         } else if (baselineError.status !== 200 && baselineError.status !== undefined) {
@@ -147,10 +146,7 @@ export class BaselinesPage extends Component {
                 { value =>
                     <React.Fragment>
                         <CreateBaselineModal
-                            hasInventoryReadPermissions={ value.permissions.inventoryRead }
-                            hasHSPReadPermissions={ value.permissions.hspRead }
-                            hasReadPermissions={ value.permissions.baselinesRead }
-                            hasWritePermissions={ value.permissions.baselinesWrite }
+                            permissions={ value.permissions }
                             selectHistoricProfiles={ selectHistoricProfiles }
                             setSelectedSystemIds={ setSelectedSystemIds }
                         />
@@ -166,7 +162,7 @@ export class BaselinesPage extends Component {
                                     text={ [ 'Contact your organization administrator(s) for more information.' ] }
                                 />
                                 : emptyState && !loading
-                                    ? this.renderEmptyState(value.permissions.baselinesWrite)
+                                    ? this.renderEmptyState(value.permissions)
                                     : <React.Fragment>
                                         <ErrorAlert
                                             error={ !emptyState && baselineError ? baselineError : {} }
@@ -175,7 +171,7 @@ export class BaselinesPage extends Component {
                                         />
                                         <Card className='pf-t-light pf-m-opaque-100'>
                                             {
-                                                this.renderTable(value.permissions.baselinesRead, value.permissions.baselinesWrite)
+                                                this.renderTable(value.permissions)
                                             }
                                         </Card>
                                     </React.Fragment>

--- a/src/SmartComponents/BaselinesPage/CreateBaselineButton/CreateBaselineButton.js
+++ b/src/SmartComponents/BaselinesPage/CreateBaselineButton/CreateBaselineButton.js
@@ -27,11 +27,11 @@ export class CreateBaselineButton extends Component {
     }
 
     render() {
-        const { emptyState, hasWritePermissions, loading } = this.props;
+        const { emptyState, loading, permissions } = this.props;
 
         return (
             <React.Fragment>
-                { !hasWritePermissions && hasWritePermissions !== undefined
+                { !permissions.baselinesWrite && permissions.baselinesWrite !== undefined
                     ? <Tooltip
                         content={ <div>You do not have permissions to perform this action</div> }
                     >
@@ -67,8 +67,8 @@ CreateBaselineButton.propTypes = {
     history: PropTypes.object,
     addSystemModalOpened: PropTypes.bool,
     loading: PropTypes.bool,
-    hasWritePermissions: PropTypes.bool,
-    emptyState: PropTypes.bool
+    emptyState: PropTypes.bool,
+    permissions: PropTypes.object
 };
 
 function mapStateToProps(state) {

--- a/src/SmartComponents/BaselinesPage/CreateBaselineButton/__tests__/CreateBaselineButton.tests.js
+++ b/src/SmartComponents/BaselinesPage/CreateBaselineButton/__tests__/CreateBaselineButton.tests.js
@@ -13,8 +13,10 @@ describe('CreateBaselineButton', () => {
     beforeEach(() => {
         props = {
             addSystemModalOpened: false,
-            hasWritePermissions: true,
-            loading: false
+            loading: false,
+            permissions: {
+                baselinesWrite: true
+            }
         };
     });
 
@@ -28,7 +30,7 @@ describe('CreateBaselineButton', () => {
     });
 
     it('should render disabled with no write permissions', () => {
-        props.hasWritePermissions = false;
+        props.permissions.baselinesWrite = false;
         const wrapper = shallow(
             <CreateBaselineButton { ...props }/>
         );
@@ -98,7 +100,9 @@ describe('ConnectedCreateBaselineButton', () => {
         };
 
         props = {
-            hasWritePermissions: true
+            permissions: {
+                baselinesWrite: true
+            }
         };
     });
 

--- a/src/SmartComponents/BaselinesPage/CreateBaselineButton/__tests__/__snapshots__/CreateBaselineButton.tests.js.snap
+++ b/src/SmartComponents/BaselinesPage/CreateBaselineButton/__tests__/__snapshots__/CreateBaselineButton.tests.js.snap
@@ -49,10 +49,13 @@ exports[`ConnectedCreateBaselineButton should render correctly 1`] = `
       }
     >
       <withRouter(Connect(CreateBaselineButton))
-        hasWritePermissions={true}
+        permissions={
+          Object {
+            "baselinesWrite": true,
+          }
+        }
       >
         <Connect(CreateBaselineButton)
-          hasWritePermissions={true}
           history={
             Object {
               "action": "POP",
@@ -99,10 +102,14 @@ exports[`ConnectedCreateBaselineButton should render correctly 1`] = `
               "url": "/",
             }
           }
+          permissions={
+            Object {
+              "baselinesWrite": true,
+            }
+          }
         >
           <CreateBaselineButton
             addSystemModalOpened={false}
-            hasWritePermissions={true}
             history={
               Object {
                 "action": "POP",
@@ -147,6 +154,11 @@ exports[`ConnectedCreateBaselineButton should render correctly 1`] = `
                 "params": Object {},
                 "path": "/",
                 "url": "/",
+              }
+            }
+            permissions={
+              Object {
+                "baselinesWrite": true,
               }
             }
             toggleAddSystemModal={[Function]}
@@ -199,8 +211,12 @@ exports[`CreateBaselineButton should render correctly 1`] = `
 exports[`CreateBaselineButton should render mount correctly 1`] = `
 <CreateBaselineButton
   addSystemModalOpened={false}
-  hasWritePermissions={true}
   loading={false}
+  permissions={
+    Object {
+      "baselinesWrite": true,
+    }
+  }
 >
   <Button
     id="create-baseline-button"

--- a/src/SmartComponents/BaselinesPage/CreateBaselineModal/CreateBaselineModal.js
+++ b/src/SmartComponents/BaselinesPage/CreateBaselineModal/CreateBaselineModal.js
@@ -166,8 +166,7 @@ export class CreateBaselineModal extends Component {
     }
 
     renderCopyBaseline() {
-        const { baselineTableData, createBaselineModalOpened, hasReadPermissions, hasWritePermissions, loading,
-            selectedBaselineIds, totalBaselines } = this.props;
+        const { baselineTableData, createBaselineModalOpened, loading, permissions, selectedBaselineIds, totalBaselines } = this.props;
         const { columns } = this.state;
 
         return (<React.Fragment>
@@ -180,8 +179,7 @@ export class CreateBaselineModal extends Component {
                 createBaselineModalOpened={ createBaselineModalOpened }
                 columns={ columns }
                 totalBaselines={ totalBaselines }
-                hasReadPermissions={ hasReadPermissions }
-                hasWritePermissions={ hasWritePermissions }
+                permissions={ permissions }
                 hasMultiSelect={ false }
                 selectedBaselineIds={ selectedBaselineIds }
             />
@@ -190,17 +188,17 @@ export class CreateBaselineModal extends Component {
     }
 
     renderCopySystem() {
-        const { entities, hasHSPReadPermissions, hasInventoryReadPermissions } = this.props;
+        const { entities, permissions } = this.props;
 
         return (<React.Fragment>
             <b>Select system to copy from</b>
             <br></br>
             <SystemsTable
                 createBaselineModal={ true }
-                hasHistoricalDropdown={ hasHSPReadPermissions }
+                hasHistoricalDropdown={ permissions.hspRead }
                 hasMultiSelect={ false }
                 historicalProfiles={ entities?.selectedHSP ? [ entities.selectedHSP ] : [] }
-                hasInventoryReadPermissions={ hasInventoryReadPermissions }
+                permissions={ permissions }
                 entities={ entities }
                 selectVariant='radio'
                 deselectHistoricalProfiles={ this.deselectHistoricalProfiles }
@@ -362,10 +360,7 @@ CreateBaselineModal.propTypes = {
     totalBaselines: PropTypes.number,
     updatePagination: PropTypes.func,
     historicalProfiles: PropTypes.array,
-    hasHSPReadPermissions: PropTypes.bool,
-    hasInventoryReadPermissions: PropTypes.bool,
-    hasReadPermissions: PropTypes.bool,
-    hasWritePermissions: PropTypes.bool,
+    permissions: PropTypes.object,
     globalFilterState: PropTypes.object,
     selectHistoricProfiles: PropTypes.func,
     setSelectedSystemIds: PropTypes.func,

--- a/src/SmartComponents/BaselinesPage/CreateBaselineModal/__tests__/CreateBaselineModal.tests.js
+++ b/src/SmartComponents/BaselinesPage/CreateBaselineModal/__tests__/CreateBaselineModal.tests.js
@@ -16,7 +16,9 @@ describe('CreateBaselineModal', () => {
             createBaselineModalOpened: false,
             baselineData: [],
             entities: {},
-            hasHSPReadPermissions: true,
+            permissions: {
+                hspRead: true
+            },
             selectedBaselineIds: [],
             createBaselineError: {},
             clearSelectedBaselines: jest.fn(),

--- a/src/SmartComponents/BaselinesPage/CreateBaselineModal/__tests__/__snapshots__/CreateBaselineModal.tests.js.snap
+++ b/src/SmartComponents/BaselinesPage/CreateBaselineModal/__tests__/__snapshots__/CreateBaselineModal.tests.js.snap
@@ -952,7 +952,11 @@ exports[`CreateBaselineModal should render mount correctly 1`] = `
   createBaselineModalOpened={false}
   entities={Object {}}
   handleChecked={[MockFunction]}
-  hasHSPReadPermissions={true}
+  permissions={
+    Object {
+      "hspRead": true,
+    }
+  }
   selectedBaselineIds={Array []}
 >
   <Modal

--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/AddFactButton/AddFactButton.js
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/AddFactButton/AddFactButton.js
@@ -18,11 +18,11 @@ class AddFactButton extends Component {
     }
 
     render() {
-        const { editBaselineEmptyState, hasWritePermissions, isDisabled } = this.props;
+        const { editBaselineEmptyState, isDisabled, permissions } = this.props;
 
         return (
             <React.Fragment>
-                { !hasWritePermissions && hasWritePermissions !== undefined
+                { !permissions.baselinesWrite && permissions.baselinesWrite !== undefined
                     ? <Tooltip
                         content={ <div>You do not have permissions to perform this action</div> }
                     >
@@ -55,7 +55,7 @@ AddFactButton.propTypes = {
     toggleFactModal: PropTypes.func,
     setFactData: PropTypes.func,
     isDisabled: PropTypes.bool,
-    hasWritePermissions: PropTypes.bool,
+    permissions: PropTypes.object,
     editBaselineEmptyState: PropTypes.bool
 };
 

--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaseline/EditBaseline.js
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaseline/EditBaseline.js
@@ -39,13 +39,13 @@ class EditBaseline extends Component {
         this.fetchBaselineId();
     }
 
-    renderHeaderRow(hasWritePermissions) {
+    renderHeaderRow(baselinesWrite) {
         return (
             <tr
                 key='edit-baseline-table-header'
                 data-ouia-component-type='PF4/TableHeaderRow'
                 data-ouia-component-id='edit-baseline-table-header-row'>
-                { hasWritePermissions ? <th></th> : null }
+                { baselinesWrite ? <th></th> : null }
                 <th className="edit-baseline-header"><div>Fact</div></th>
                 <th className="edit-baseline-header"><div>Value</div></th>
                 <th></th>
@@ -152,7 +152,7 @@ class EditBaseline extends Component {
         );
     }
 
-    renderRowData(fact, hasWritePermissions) {
+    renderRowData(fact, baselinesWrite) {
         const { expandedRows, baselineData } = this.props;
         let row = [];
         let rows = [];
@@ -161,7 +161,7 @@ class EditBaseline extends Component {
             return baselineFact.name === fact[FACT_NAME];
         });
 
-        hasWritePermissions
+        baselinesWrite
             ? row.push(<td
                 className={ expandedRows.includes(fact[FACT_NAME]) ? 'pf-c-table__check nested-fact' : 'pf-c-table__check' }>
                 { this.renderCheckbox(fact) }
@@ -172,7 +172,7 @@ class EditBaseline extends Component {
             row.push(<td>
                 { this.renderExpandableRowButton(fact[FACT_NAME]) } { fact[FACT_NAME] }</td>);
             row.push(<td></td>);
-            row.push(editBaselineHelpers.renderKebab({ factName: fact[FACT_NAME], factData, isCategory: true, hasWritePermissions }));
+            row.push(editBaselineHelpers.renderKebab({ factName: fact[FACT_NAME], factData, isCategory: true, baselinesWrite }));
             rows.push(<tr
                 data-ouia-component-type='PF4/TableRow'
                 data-ouia-component-id={ 'edit-baseline-table-row-' + factData?.name }
@@ -181,7 +181,7 @@ class EditBaseline extends Component {
             if (expandedRows.includes(fact[FACT_NAME])) {
                 editBaselineHelpers.baselineSubFacts(fact).forEach((subFact) => {
                     row = [];
-                    hasWritePermissions
+                    baselinesWrite
                         ? row.push(<td className='pf-c-table__check nested-fact'>{ this.renderCheckbox(subFact) }</td>)
                         : null;
                     row.push(<td>
@@ -193,7 +193,7 @@ class EditBaseline extends Component {
                         factValue: subFact[FACT_VALUE],
                         factData,
                         isSubFact: true,
-                        hasWritePermissions
+                        baselinesWrite
                     }));
                     rows.push(<tr
                         data-ouia-component-type='PF4/TableRow'
@@ -205,7 +205,7 @@ class EditBaseline extends Component {
         } else {
             row.push(<td>{ fact[FACT_NAME] }</td>);
             row.push(<td>{ fact[FACT_VALUE] }</td>);
-            row.push(editBaselineHelpers.renderKebab({ factName: fact[FACT_NAME], factValue: fact[FACT_VALUE], factData, hasWritePermissions }));
+            row.push(editBaselineHelpers.renderKebab({ factName: fact[FACT_NAME], factValue: fact[FACT_VALUE], factData, baselinesWrite }));
             rows.push(<tr
                 data-ouia-component-type='PF4/TableRow'
                 data-ouia-component-id={ 'edit-baseline-table-row-' + factData?.name }
@@ -215,7 +215,7 @@ class EditBaseline extends Component {
         return rows;
     }
 
-    renderRows(hasWritePermissions) {
+    renderRows(baselinesWrite) {
         const { editBaselineTableData } = this.props;
         let facts = editBaselineTableData;
         let rows = [];
@@ -223,7 +223,7 @@ class EditBaseline extends Component {
 
         if (facts.length !== 0) {
             for (let i = 0; i < facts.length; i += 1) {
-                rowData = this.renderRowData(facts[i], hasWritePermissions);
+                rowData = this.renderRowData(facts[i], baselinesWrite);
                 rows.push(rowData);
             }
         }
@@ -231,7 +231,7 @@ class EditBaseline extends Component {
         return rows;
     }
 
-    renderEmptyState(hasWritePermissions) {
+    renderEmptyState(permissions) {
         const { editBaselineEmptyState, editBaselineError } = this.props;
         const { errorMessage } = this.state;
 
@@ -252,21 +252,21 @@ class EditBaseline extends Component {
                 title={ 'No facts' }
                 text={ [ 'No facts or categories have been added to this baseline yet.' ] }
                 button={ <AddFactButton
-                    hasWritePermissions={ hasWritePermissions }
+                    permissions={ permissions }
                     editBaselineEmptyState={ editBaselineEmptyState }
                 /> }
             />;
         }
     }
 
-    renderTable(hasWritePermissions) {
+    renderTable({ baselinesWrite }) {
         return (
             <table className="pf-c-table ins-c-table pf-m-grid-md ins-entity-table">
                 <thead>
-                    { this.renderHeaderRow(hasWritePermissions) }
+                    { this.renderHeaderRow(baselinesWrite) }
                 </thead>
                 <tbody key='edit-baseline-table'>
-                    { this.renderRows(hasWritePermissions) }
+                    { this.renderRows(baselinesWrite) }
                 </tbody>
             </table>
         );
@@ -274,7 +274,7 @@ class EditBaseline extends Component {
 
     render() {
         const { baselineData, baselineDataLoading, editBaselineTableData, exportToCSV, factModalOpened,
-            editBaselineEmptyState, editBaselineError, clearErrorData, hasWritePermissions } = this.props;
+            editBaselineEmptyState, editBaselineError, clearErrorData, permissions } = this.props;
         let selected = editBaselineHelpers.findSelected(editBaselineTableData);
 
         return (
@@ -288,22 +288,22 @@ class EditBaseline extends Component {
                     onClose={ clearErrorData }
                 />
                 { editBaselineEmptyState
-                    ? this.renderEmptyState(hasWritePermissions)
+                    ? this.renderEmptyState(permissions)
                     : <Card className='pf-t-light pf-m-opaque-100'>
                         <CardBody>
                             <EditBaselineToolbar
                                 selected={ selected }
                                 onBulkSelect={ this.onBulkSelect }
-                                isDisabled={ editBaselineTableData.length === 0 || !hasWritePermissions }
+                                isDisabled={ editBaselineTableData.length === 0 || !permissions.baselinesWrite }
                                 totalFacts={ editBaselineHelpers.findFactCount(editBaselineTableData) }
                                 baselineData={ baselineData }
                                 exportToCSV={ exportToCSV }
                                 tableData={ editBaselineTableData }
-                                hasWritePermissions={ hasWritePermissions }
+                                permissions={ permissions }
                             />
                             { baselineDataLoading
                                 ? this.renderLoadingRows()
-                                : this.renderTable(hasWritePermissions)
+                                : this.renderTable(permissions)
                             }
                         </CardBody>
                     </Card>
@@ -327,7 +327,7 @@ EditBaseline.propTypes = {
     editBaselineError: PropTypes.object,
     editBaselineEmptyState: PropTypes.bool,
     exportToCSV: PropTypes.func,
-    hasWritePermissions: PropTypes.bool
+    permissions: PropTypes.object
 };
 
 export default EditBaseline;

--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaseline/__tests__/EditBaseline.tests.js
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaseline/__tests__/EditBaseline.tests.js
@@ -9,13 +9,11 @@ import helpersFixtures from './helpers.fixtures';
 //import editBaselineFixtures from './helpers.fixtures';
 import EditBaseline from '../EditBaseline';
 //import api from '../../../../../api';
-import { PermissionContext } from '../../../../../App';
 
 describe('EditBaseline', () => {
     let initialState;
     let props;
     let mockStore;
-    let value;
 
     beforeEach(() => {
         mockStore = configureStore();
@@ -43,13 +41,7 @@ describe('EditBaseline', () => {
             editBaselineEmptyState: false,
             editBaselineError: {},
             expandedRows: [],
-            hasWritePermissions: true
-        };
-
-        value = {
             permissions: {
-                compareRead: true,
-                baselinesRead: true,
                 baselinesWrite: true
             }
         };
@@ -77,7 +69,7 @@ describe('EditBaseline', () => {
     });*/
 
     it('should render disabled with no write permissions', () => {
-        props.hasWritePermissions = false;
+        props.permissions.baselinesWrite = false;
         const wrapper = shallow(
             <EditBaseline { ...props }/>
         );
@@ -394,13 +386,11 @@ describe('EditBaseline', () => {
         const store = mockStore(initialState);
 
         const wrapper = mount(
-            <PermissionContext.Provider value={ value }>
-                <MemoryRouter keyLength={ 0 }>
-                    <Provider store={ store }>
-                        <EditBaseline { ...props }/>
-                    </Provider>
-                </MemoryRouter>
-            </PermissionContext.Provider>
+            <MemoryRouter keyLength={ 0 }>
+                <Provider store={ store }>
+                    <EditBaseline { ...props }/>
+                </Provider>
+            </MemoryRouter>
         );
 
         wrapper.find('[className="pointer not-active edit-icon-margin"]').at(1).simulate('click');

--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaseline/__tests__/__snapshots__/EditBaseline.tests.js.snap
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaseline/__tests__/__snapshots__/EditBaseline.tests.js.snap
@@ -12,9 +12,13 @@ exports[`EditBaseline should render correctly 1`] = `
     <CardBody>
       <EditBaselineToolbar
         baselineData={Array []}
-        hasWritePermissions={true}
         isDisabled={true}
         onBulkSelect={[Function]}
+        permissions={
+          Object {
+            "baselinesWrite": true,
+          }
+        }
         selected={0}
         tableData={Array []}
         totalFacts={0}
@@ -65,7 +69,11 @@ exports[`EditBaseline should render empty baseline 1`] = `
     button={
       <Memo(Connect(AddFactButton))
         editBaselineEmptyState={true}
-        hasWritePermissions={true}
+        permissions={
+          Object {
+            "baselinesWrite": true,
+          }
+        }
       />
     }
     text={
@@ -146,9 +154,13 @@ exports[`EditBaseline should render expandable rows closed 1`] = `
             "id": "38gnw73l-fn36-5829-1287-2m5ghs46801c",
           }
         }
-        hasWritePermissions={true}
         isDisabled={false}
         onBulkSelect={[Function]}
+        permissions={
+          Object {
+            "baselinesWrite": true,
+          }
+        }
         selected={0}
         tableData={
           Array [
@@ -484,9 +496,13 @@ exports[`EditBaseline should render expandable rows opened 1`] = `
             "id": "38gnw73l-fn36-5829-1287-2m5ghs46801c",
           }
         }
-        hasWritePermissions={true}
         isDisabled={false}
         onBulkSelect={[Function]}
+        permissions={
+          Object {
+            "baselinesWrite": true,
+          }
+        }
         selected={0}
         tableData={
           Array [
@@ -1503,9 +1519,13 @@ exports[`EditBaseline should render loading rows 1`] = `
   >
     <CardBody>
       <EditBaselineToolbar
-        hasWritePermissions={true}
         isDisabled={true}
         onBulkSelect={[Function]}
+        permissions={
+          Object {
+            "baselinesWrite": true,
+          }
+        }
         selected={0}
         tableData={Array []}
         totalFacts={0}

--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaseline/helpers.js
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaseline/helpers.js
@@ -3,9 +3,9 @@ import jiff from 'jiff';
 import FactKebab from '../FactKebab/FactKebab';
 
 /*eslint-disable react/prop-types*/
-function renderKebab({ factName, factValue, factData, isCategory, isSubFact, hasWritePermissions } = {}) {
+function renderKebab({ factName, factValue, factData, isCategory, isSubFact, baselinesWrite } = {}) {
     return (
-        hasWritePermissions
+        baselinesWrite
             ? <td>
                 <FactKebab
                     factName={ factName }

--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaselinePage.js
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaselinePage.js
@@ -92,7 +92,7 @@ export class EditBaselinePage extends Component {
         this.fetchBaselineId();
     }
 
-    renderBreadcrumb(baselineData, hasReadPermissions) {
+    renderBreadcrumb(baselineData, baselinesRead) {
         let breadcrumb;
 
         /*eslint-disable camelcase*/
@@ -102,7 +102,7 @@ export class EditBaselinePage extends Component {
                     Baselines
                 </a>
             </BreadcrumbItem>
-            { baselineData && hasReadPermissions
+            { baselineData && baselinesRead
                 ? <BreadcrumbHeading>
                     { baselineData.display_name }
                 </BreadcrumbHeading>
@@ -114,11 +114,11 @@ export class EditBaselinePage extends Component {
         return breadcrumb;
     }
 
-    renderPageTitle(baselineData, hasReadPermissions, hasWritePermissions) {
+    renderPageTitle(baselineData, baselinesRead, baselinesWrite) {
         let pageTitle;
 
-        if (hasReadPermissions) {
-            if (hasWritePermissions) {
+        if (baselinesRead) {
+            if (baselinesWrite) {
                 pageTitle = <React.Fragment>
                     <span className='pf-c-title pf-m-2xl'>
                         { !_.isEmpty(baselineData) ? baselineData.display_name : null }
@@ -141,7 +141,7 @@ export class EditBaselinePage extends Component {
         return pageTitle;
     }
 
-    renderPageHeader = (hasReadPermissions, hasWritePermissions) => {
+    renderPageHeader = ({ baselinesRead, baselinesWrite }) => {
         const { modalOpened } = this.state;
         const { baselineData, baselineDataLoading, inlineError } = this.props;
         let pageHeader;
@@ -160,9 +160,9 @@ export class EditBaselinePage extends Component {
                         error={ inlineError }
                     />
                     <PageHeader className='bottom-padding-0'>
-                        { this.renderBreadcrumb(baselineData, hasReadPermissions) }
+                        { this.renderBreadcrumb(baselineData, baselinesRead) }
                         <div id="edit-baseline-title">
-                            { this.renderPageTitle(baselineData, hasReadPermissions, hasWritePermissions) }
+                            { this.renderPageTitle(baselineData, baselinesRead, baselinesWrite) }
                         </div>
                         { this.renderTabs() }
                     </PageHeader>
@@ -204,7 +204,7 @@ export class EditBaselinePage extends Component {
         </div>;
     }
 
-    renderMain(baselinesWrite, inventoryRead) {
+    renderMain(permissions) {
         const { baselineData, baselineDataLoading, clearErrorData, driftClearFilters, editBaselineEmptyState, editBaselineError,
             editBaselineTableData, entities, expandRow, expandedRows, exportToCSV, factModalOpened, selectFact,
             match: { params }, selectEntities, selectHistoricProfiles, setSelectedSystemIds, updateColumns } = this.props;
@@ -223,7 +223,7 @@ export class EditBaselinePage extends Component {
                 expandedRows={ expandedRows }
                 exportToCSV={ exportToCSV }
                 factModalOpened={ factModalOpened }
-                hasWritePermissions={ baselinesWrite }
+                permissions={ permissions }
                 history={ history }
                 selectFact={ selectFact }
             />;
@@ -231,7 +231,7 @@ export class EditBaselinePage extends Component {
             body = <SystemNotification
                 baselineId={ params.id }
                 baselineName={ baselineData?.display_name }
-                hasInventoryReadPermissions={ inventoryRead }
+                permissions={ permissions }
                 entities={ entities }
                 driftClearFilters={ driftClearFilters }
                 selectEntities={ selectEntities }
@@ -250,7 +250,7 @@ export class EditBaselinePage extends Component {
             <PermissionContext.Consumer>
                 { value =>
                     <React.Fragment>
-                        { this.renderPageHeader(value.permissions.baselinesRead, value.permissions.baselinesWrite) }
+                        { this.renderPageHeader(value.permissions) }
                         <Main>
                             { value.permissions.baselinesRead === false
                                 ? <EmptyStateDisplay
@@ -259,7 +259,7 @@ export class EditBaselinePage extends Component {
                                     title={ 'You do not have access to view this Baseline' }
                                     text={ [ 'Contact your organization administrator(s) for more information.' ] }
                                 />
-                                : this.renderMain(value.permissions.baselinesWrite, value.permissions.inventoryRead)
+                                : this.renderMain(value.permissions)
                             }
                         </Main>
                     </React.Fragment>
@@ -287,7 +287,6 @@ EditBaselinePage.propTypes = {
     inlineError: PropTypes.object,
     editBaselineEmptyState: PropTypes.bool,
     exportToCSV: PropTypes.func,
-    hasWritePermissions: PropTypes.bool,
     fetchBaselines: PropTypes.func,
     entities: PropTypes.object,
     selectHistoricProfiles: PropTypes.func,

--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaselineToolbar/EditBaselineToolbar.js
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaselineToolbar/EditBaselineToolbar.js
@@ -46,7 +46,7 @@ export class EditBaselineToolbar extends Component {
     }
 
     render() {
-        const { hasWritePermissions, isDisabled, onBulkSelect, selected, totalFacts } = this.props;
+        const { isDisabled, onBulkSelect, permissions, selected, totalFacts } = this.props;
         const { bulkSelectItems, dropdownItems, dropdownOpen } = this.state;
 
         return (
@@ -65,7 +65,7 @@ export class EditBaselineToolbar extends Component {
                     <ToolbarItem>
                         <AddFactButton
                             isDisabled={ isDisabled }
-                            hasWritePermissions={ hasWritePermissions }
+                            permissions={ permissions }
                         />
                     </ToolbarItem>
                     <ToolbarGroup variant='icon-button-group'>
@@ -95,7 +95,7 @@ EditBaselineToolbar.propTypes = {
     exportToCSV: PropTypes.func,
     tableData: PropTypes.array,
     baselineData: PropTypes.object,
-    hasWritePermissions: PropTypes.bool
+    permissions: PropTypes.object
 };
 
 export default EditBaselineToolbar;

--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaselineToolbar/__tests__/EditBaselineToolbar.tests.js
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaselineToolbar/__tests__/EditBaselineToolbar.tests.js
@@ -17,7 +17,9 @@ describe('EditBaselineToolbar', () => {
             totalFacts: 2,
             isDisabled: false,
             selected: 0,
-            hasWritePermissions: true,
+            permissions: {
+                baselinesWrite: true
+            },
             onBulkSelect: jest.fn(),
             exportToCSV: jest.fn()
         };
@@ -48,7 +50,9 @@ describe('ConnectedEditBaselineToolbar', () => {
             totalFacts: 2,
             isDisabled: false,
             selected: 0,
-            hasWritePermissions: true,
+            permissions: {
+                baselinesWrite: true
+            },
             onBulkSelect: jest.fn(),
             exportToCSV: jest.fn()
         };
@@ -68,7 +72,7 @@ describe('ConnectedEditBaselineToolbar', () => {
     });
 
     it('should render disabled with no write permissions', () => {
-        props.hasWritePermissions = false;
+        props.permissions.baselinesWrite = false;
         const store = mockStore(initialState);
         const wrapper = mount(
             <MemoryRouter keyLength={ 0 }>

--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaselineToolbar/__tests__/__snapshots__/EditBaselineToolbar.tests.js.snap
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaselineToolbar/__tests__/__snapshots__/EditBaselineToolbar.tests.js.snap
@@ -50,9 +50,13 @@ exports[`ConnectedEditBaselineToolbar should render correctly 1`] = `
     >
       <EditBaselineToolbar
         exportToCSV={[MockFunction]}
-        hasWritePermissions={true}
         isDisabled={false}
         onBulkSelect={[MockFunction]}
+        permissions={
+          Object {
+            "baselinesWrite": true,
+          }
+        }
         selected={0}
         totalFacts={2}
       >
@@ -455,12 +459,20 @@ exports[`ConnectedEditBaselineToolbar should render correctly 1`] = `
                         className="pf-c-toolbar__item"
                       >
                         <Connect(AddFactButton)
-                          hasWritePermissions={true}
                           isDisabled={false}
+                          permissions={
+                            Object {
+                              "baselinesWrite": true,
+                            }
+                          }
                         >
                           <AddFactButton
-                            hasWritePermissions={true}
                             isDisabled={false}
+                            permissions={
+                              Object {
+                                "baselinesWrite": true,
+                              }
+                            }
                             setFactData={[Function]}
                             toggleFactModal={[Function]}
                           >
@@ -1171,8 +1183,12 @@ exports[`EditBaselineToolbar should render correctly 1`] = `
     </ToolbarItem>
     <ToolbarItem>
       <Connect(AddFactButton)
-        hasWritePermissions={true}
         isDisabled={false}
+        permissions={
+          Object {
+            "baselinesWrite": true,
+          }
+        }
       />
     </ToolbarItem>
     <ForwardRef

--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/SystemNotification/SystemNotification.js
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/SystemNotification/SystemNotification.js
@@ -54,11 +54,14 @@ export class SystemNotification extends Component {
     }
 
     buildNotificationsButton = () => {
+        const { permissions } = this.props;
+
         return <Button
             key="add-baseline-notification"
             variant="primary"
             onClick={ this.toggleModal }
             ouiaId="add-baseline-notification-button"
+            isDisabled={ !permissions.baselinesWrite }
         >
             Add system
         </Button>;
@@ -76,7 +79,7 @@ export class SystemNotification extends Component {
 
     render() {
         const { baselineId, baselineName, deleteNotifications, deleteNotificationsModalOpened, driftClearFilters, entities,
-            hasInventoryReadPermissions, selectEntities, selectHistoricProfiles, setSelectedSystemIds, systemNotificationIds,
+            permissions, selectEntities, selectHistoricProfiles, setSelectedSystemIds, systemNotificationIds,
             systemsToDelete, toggleDeleteNotificationsModal, updateColumns, systemNotificationLoaded } = this.props;
         const { modalOpened } = this.state;
 
@@ -118,7 +121,7 @@ export class SystemNotification extends Component {
                 >
                     <SystemsTable
                         hasMultiSelect={ true }
-                        hasInventoryReadPermissions={ hasInventoryReadPermissions }
+                        permissions={ permissions }
                         entities={ entities }
                         selectVariant='checkbox'
                         systemNotificationIds={ systemNotificationIds }
@@ -134,7 +137,7 @@ export class SystemNotification extends Component {
                 </Modal>
                 { systemNotificationLoaded ? <NotificationsSystemsTable
                     hasMultiSelect={ true }
-                    hasInventoryReadPermissions={ hasInventoryReadPermissions }
+                    permissions={ permissions }
                     selectVariant='checkbox'
                     systemNotificationIds={ systemNotificationIds }
                     baselineId={ baselineId }
@@ -155,8 +158,8 @@ SystemNotification.propTypes = {
     addNotifications: PropTypes.func,
     baselineId: PropTypes.string,
     baselineName: PropTypes.string,
-    hasInventoryReadPermissions: PropTypes.bool,
     entities: PropTypes.object,
+    permissions: PropTypes.object,
     selectHistoricProfiles: PropTypes.func,
     setSelectedSystemIds: PropTypes.func,
     driftClearFilters: PropTypes.func,

--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/SystemNotification/__tests__/SystemNotification.tests.js
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/SystemNotification/__tests__/SystemNotification.tests.js
@@ -1,0 +1,87 @@
+import { shallow, mount } from 'enzyme';
+import { MemoryRouter } from 'react-router-dom';
+import configureStore from 'redux-mock-store';
+import { Provider } from 'react-redux';
+import toJson from 'enzyme-to-json';
+
+import ConnectedSystemNotification, { SystemNotification } from '../SystemNotification';
+
+describe('SystemNotification', () => {
+    let props;
+
+    beforeEach(() => {
+        props = {
+            hasWritePermissions: true
+        };
+    });
+
+    it('should render', () => {
+        const wrapper = shallow(
+            <SystemNotification { ...props } />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});
+
+describe('ConnectedSystemNotification', () => {
+    let initialState;
+    let mockStore;
+    let props;
+
+    beforeEach(() => {
+        mockStore = configureStore();
+
+        props = {
+            permissions: {
+                baselinesWrite: true
+            }
+        };
+
+        initialState = {
+            systemNotificationsState: {
+                deleteNotificationsModalOpened: false,
+                systemNotificationIds: [],
+                systemNotificationLoaded: false,
+                systemsToDelete: []
+            },
+            addNotifications: jest.fn(),
+            toggleDeleteNotificationsModal: jest.fn(),
+            setSystemsToDelete: jest.fn(),
+            deleteNotifications: jest.fn(),
+            getNotifications: jest.fn(),
+            setSelectedSystemIds: jest.fn()
+        };
+    });
+
+    it('should render correctly', () => {
+        initialState.systemNotificationsState.systemNotificationLoaded = true;
+
+        const store = mockStore(initialState);
+        const wrapper = mount(
+            <MemoryRouter keyLength={ 0 }>
+                <Provider store={ store }>
+                    <ConnectedSystemNotification { ...props } />
+                </Provider>
+            </MemoryRouter>
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('should disable Add system button', () => {
+        initialState.systemNotificationsState.systemNotificationLoaded = true;
+        props.permissions.baselinesWrite = false;
+
+        const store = mockStore(initialState);
+        const wrapper = mount(
+            <MemoryRouter keyLength={ 0 }>
+                <Provider store={ store }>
+                    <ConnectedSystemNotification { ...props } />
+                </Provider>
+            </MemoryRouter>
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});

--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/SystemNotification/__tests__/__snapshots__/SystemNotification.tests.js.snap
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/SystemNotification/__tests__/__snapshots__/SystemNotification.tests.js.snap
@@ -1,0 +1,913 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ConnectedSystemNotification should disable Add system button 1`] = `
+<MemoryRouter
+  keyLength={0}
+>
+  <Router
+    history={
+      Object {
+        "action": "POP",
+        "block": [Function],
+        "canGo": [Function],
+        "createHref": [Function],
+        "entries": Array [
+          Object {
+            "hash": "",
+            "pathname": "/",
+            "search": "",
+            "state": undefined,
+          },
+        ],
+        "go": [Function],
+        "goBack": [Function],
+        "goForward": [Function],
+        "index": 0,
+        "length": 1,
+        "listen": [Function],
+        "location": Object {
+          "hash": "",
+          "pathname": "/",
+          "search": "",
+          "state": undefined,
+        },
+        "push": [Function],
+        "replace": [Function],
+      }
+    }
+  >
+    <Provider
+      store={
+        Object {
+          "clearActions": [Function],
+          "dispatch": [Function],
+          "getActions": [Function],
+          "getState": [Function],
+          "replaceReducer": [Function],
+          "subscribe": [Function],
+        }
+      }
+    >
+      <Connect(SystemNotification)
+        permissions={
+          Object {
+            "baselinesWrite": false,
+          }
+        }
+      >
+        <SystemNotification
+          addNotifications={[Function]}
+          deleteNotifications={[Function]}
+          deleteNotificationsModalOpened={false}
+          getNotifications={[Function]}
+          permissions={
+            Object {
+              "baselinesWrite": false,
+            }
+          }
+          setSelectedSystemIds={[Function]}
+          setSystemsToDelete={[Function]}
+          systemNotificationIds={Array []}
+          systemNotificationLoaded={true}
+          systemsToDelete={Array []}
+          toggleDeleteNotificationsModal={[Function]}
+        >
+          <DeleteNotificationModal
+            deleteNotifications={[Function]}
+            deleteNotificationsModalOpened={false}
+            fetchSystems={[Function]}
+            systemsToDelete={Array []}
+            toggleDeleteNotificationsModal={[Function]}
+          >
+            <Modal
+              actions={
+                Array [
+                  <Button
+                    onClick={[Function]}
+                    ouiaId="delete-baseline-notification-button"
+                    variant="danger"
+                  >
+                    Delete
+                  </Button>,
+                  <Button
+                    onClick={[Function]}
+                    ouiaId="delete-baseline-notification-cancel-button"
+                    variant="link"
+                  >
+                    Cancel
+                  </Button>,
+                ]
+              }
+              appendTo={[Function]}
+              aria-describedby=""
+              aria-label=""
+              aria-labelledby=""
+              className="drift"
+              hasNoBodyWrapper={false}
+              isOpen={false}
+              onClose={[Function]}
+              ouiaId="delete-baseline-notification-modal"
+              ouiaSafe={true}
+              showClose={true}
+              title="Delete baseline notifications"
+              titleIconVariant={null}
+              titleLabel=""
+              variant="small"
+            >
+              <Portal
+                containerInfo={<div />}
+              >
+                <ModalContent
+                  actions={
+                    Array [
+                      <Button
+                        onClick={[Function]}
+                        ouiaId="delete-baseline-notification-button"
+                        variant="danger"
+                      >
+                        Delete
+                      </Button>,
+                      <Button
+                        onClick={[Function]}
+                        ouiaId="delete-baseline-notification-cancel-button"
+                        variant="link"
+                      >
+                        Cancel
+                      </Button>,
+                    ]
+                  }
+                  aria-describedby=""
+                  aria-label=""
+                  aria-labelledby=""
+                  boxId="pf-modal-part-2"
+                  className="drift"
+                  descriptorId="pf-modal-part-4"
+                  hasNoBodyWrapper={false}
+                  isOpen={false}
+                  labelId="pf-modal-part-3"
+                  onClose={[Function]}
+                  ouiaId="delete-baseline-notification-modal"
+                  ouiaSafe={true}
+                  showClose={true}
+                  title="Delete baseline notifications"
+                  titleIconVariant={null}
+                  titleLabel=""
+                  variant="small"
+                />
+              </Portal>
+            </Modal>
+          </DeleteNotificationModal>
+          <Modal
+            actions={
+              Array [
+                <Button
+                  onClick={[Function]}
+                  ouiaId="add-baseline-notification-button"
+                  variant="primary"
+                >
+                  Submit
+                </Button>,
+                <Button
+                  onClick={[Function]}
+                  ouiaId="add-baseline-notification-cancel-button"
+                  variant="link"
+                >
+                  Cancel
+                </Button>,
+              ]
+            }
+            appendTo={[Function]}
+            aria-describedby=""
+            aria-label=""
+            aria-labelledby=""
+            className="drift"
+            hasNoBodyWrapper={false}
+            isOpen={false}
+            onClose={[Function]}
+            ouiaId="add-baseline-notification-modal"
+            ouiaSafe={true}
+            showClose={true}
+            title="Associate system with undefined"
+            titleIconVariant={null}
+            titleLabel=""
+            variant="medium"
+          >
+            <Portal
+              containerInfo={<div />}
+            >
+              <ModalContent
+                actions={
+                  Array [
+                    <Button
+                      onClick={[Function]}
+                      ouiaId="add-baseline-notification-button"
+                      variant="primary"
+                    >
+                      Submit
+                    </Button>,
+                    <Button
+                      onClick={[Function]}
+                      ouiaId="add-baseline-notification-cancel-button"
+                      variant="link"
+                    >
+                      Cancel
+                    </Button>,
+                  ]
+                }
+                aria-describedby=""
+                aria-label=""
+                aria-labelledby=""
+                boxId="pf-modal-part-3"
+                className="drift"
+                descriptorId="pf-modal-part-5"
+                hasNoBodyWrapper={false}
+                isOpen={false}
+                labelId="pf-modal-part-4"
+                onClose={[Function]}
+                ouiaId="add-baseline-notification-modal"
+                ouiaSafe={true}
+                showClose={true}
+                title="Associate system with undefined"
+                titleIconVariant={null}
+                titleLabel=""
+                variant="medium"
+              />
+            </Portal>
+          </Modal>
+          <SystemsTableWithContext
+            deleteNotifications={[Function]}
+            hasMultiSelect={true}
+            onSystemSelect={[Function]}
+            permissions={
+              Object {
+                "baselinesWrite": false,
+              }
+            }
+            selectVariant="checkbox"
+            systemNotificationIds={Array []}
+            toolbarButton={
+              <Button
+                isDisabled={true}
+                onClick={[Function]}
+                ouiaId="add-baseline-notification-button"
+                variant="primary"
+              >
+                Add system
+              </Button>
+            }
+          >
+            <Provider
+              store={
+                Object {
+                  "@@observable": [Function],
+                  "dispatch": [Function],
+                  "getState": [Function],
+                  "replaceReducer": [Function],
+                  "subscribe": [Function],
+                }
+              }
+            >
+              <Connect(Component)
+                addNewListener={[Function]}
+                deleteNotifications={[Function]}
+                hasMultiSelect={true}
+                onSystemSelect={[Function]}
+                permissions={
+                  Object {
+                    "baselinesWrite": false,
+                  }
+                }
+                registry={
+                  ReducerRegistry {
+                    "reducers": Object {},
+                    "store": Object {
+                      "@@observable": [Function],
+                      "dispatch": [Function],
+                      "getState": [Function],
+                      "replaceReducer": [Function],
+                      "subscribe": [Function],
+                    },
+                  }
+                }
+                selectVariant="checkbox"
+                selectedSystemIds={Array []}
+                systemNotificationIds={Array []}
+                toolbarButton={
+                  <Button
+                    isDisabled={true}
+                    onClick={[Function]}
+                    ouiaId="add-baseline-notification-button"
+                    variant="primary"
+                  >
+                    Add system
+                  </Button>
+                }
+              >
+                <Component
+                  addNewListener={[Function]}
+                  deleteNotifications={[Function]}
+                  driftClearFilters={[Function]}
+                  hasMultiSelect={true}
+                  onSystemSelect={[Function]}
+                  permissions={
+                    Object {
+                      "baselinesWrite": false,
+                    }
+                  }
+                  registry={
+                    ReducerRegistry {
+                      "reducers": Object {},
+                      "store": Object {
+                        "@@observable": [Function],
+                        "dispatch": [Function],
+                        "getState": [Function],
+                        "replaceReducer": [Function],
+                        "subscribe": [Function],
+                      },
+                    }
+                  }
+                  selectEntities={[Function]}
+                  selectVariant="checkbox"
+                  selectedSystemIds={Array []}
+                  setSelectedSystemIds={[Function]}
+                  systemNotificationIds={Array []}
+                  toolbarButton={
+                    <Button
+                      isDisabled={true}
+                      onClick={[Function]}
+                      ouiaId="add-baseline-notification-button"
+                      variant="primary"
+                    >
+                      Add system
+                    </Button>
+                  }
+                  updateColumns={[Function]}
+                >
+                  <EmptyStateDisplay
+                    color="#6a6e73"
+                    icon={[Function]}
+                    text={
+                      Array [
+                        "Contact your organization administrator(s) for more information.",
+                      ]
+                    }
+                    title="You do not have access to the inventory"
+                  >
+                    <EmptyState
+                      variant="large"
+                    >
+                      <div
+                        className="pf-c-empty-state pf-m-lg"
+                      >
+                        <div
+                          className="pf-c-empty-state__content"
+                        >
+                          <EmptyStateIcon
+                            className={null}
+                            color="#6a6e73"
+                            icon={[Function]}
+                          >
+                            <LockIcon
+                              aria-hidden="true"
+                              className="pf-c-empty-state__icon"
+                              color="#6a6e73"
+                              noVerticalAlign={false}
+                              size="sm"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                aria-labelledby={null}
+                                className="pf-c-empty-state__icon"
+                                fill="#6a6e73"
+                                height="1em"
+                                role="img"
+                                style={
+                                  Object {
+                                    "verticalAlign": "-0.125em",
+                                  }
+                                }
+                                viewBox="0 0 448 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M400 224h-24v-72C376 68.2 307.8 0 224 0S72 68.2 72 152v72H48c-26.5 0-48 21.5-48 48v192c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V272c0-26.5-21.5-48-48-48zm-104 0H152v-72c0-39.7 32.3-72 72-72s72 32.3 72 72v72z"
+                                />
+                              </svg>
+                            </LockIcon>
+                          </EmptyStateIcon>
+                          <br />
+                          <Title
+                            headingLevel="h1"
+                            size="lg"
+                          >
+                            <h1
+                              className="pf-c-title pf-m-lg"
+                            >
+                              You do not have access to the inventory
+                            </h1>
+                          </Title>
+                          <EmptyStateBody>
+                            <div
+                              className="pf-c-empty-state__body"
+                            >
+                              Contact your organization administrator(s) for more information.
+                            </div>
+                          </EmptyStateBody>
+                        </div>
+                      </div>
+                    </EmptyState>
+                  </EmptyStateDisplay>
+                </Component>
+              </Connect(Component)>
+            </Provider>
+          </SystemsTableWithContext>
+        </SystemNotification>
+      </Connect(SystemNotification)>
+    </Provider>
+  </Router>
+</MemoryRouter>
+`;
+
+exports[`ConnectedSystemNotification should render correctly 1`] = `
+<MemoryRouter
+  keyLength={0}
+>
+  <Router
+    history={
+      Object {
+        "action": "POP",
+        "block": [Function],
+        "canGo": [Function],
+        "createHref": [Function],
+        "entries": Array [
+          Object {
+            "hash": "",
+            "pathname": "/",
+            "search": "",
+            "state": undefined,
+          },
+        ],
+        "go": [Function],
+        "goBack": [Function],
+        "goForward": [Function],
+        "index": 0,
+        "length": 1,
+        "listen": [Function],
+        "location": Object {
+          "hash": "",
+          "pathname": "/",
+          "search": "",
+          "state": undefined,
+        },
+        "push": [Function],
+        "replace": [Function],
+      }
+    }
+  >
+    <Provider
+      store={
+        Object {
+          "clearActions": [Function],
+          "dispatch": [Function],
+          "getActions": [Function],
+          "getState": [Function],
+          "replaceReducer": [Function],
+          "subscribe": [Function],
+        }
+      }
+    >
+      <Connect(SystemNotification)
+        permissions={
+          Object {
+            "baselinesWrite": true,
+          }
+        }
+      >
+        <SystemNotification
+          addNotifications={[Function]}
+          deleteNotifications={[Function]}
+          deleteNotificationsModalOpened={false}
+          getNotifications={[Function]}
+          permissions={
+            Object {
+              "baselinesWrite": true,
+            }
+          }
+          setSelectedSystemIds={[Function]}
+          setSystemsToDelete={[Function]}
+          systemNotificationIds={Array []}
+          systemNotificationLoaded={true}
+          systemsToDelete={Array []}
+          toggleDeleteNotificationsModal={[Function]}
+        >
+          <DeleteNotificationModal
+            deleteNotifications={[Function]}
+            deleteNotificationsModalOpened={false}
+            fetchSystems={[Function]}
+            systemsToDelete={Array []}
+            toggleDeleteNotificationsModal={[Function]}
+          >
+            <Modal
+              actions={
+                Array [
+                  <Button
+                    onClick={[Function]}
+                    ouiaId="delete-baseline-notification-button"
+                    variant="danger"
+                  >
+                    Delete
+                  </Button>,
+                  <Button
+                    onClick={[Function]}
+                    ouiaId="delete-baseline-notification-cancel-button"
+                    variant="link"
+                  >
+                    Cancel
+                  </Button>,
+                ]
+              }
+              appendTo={[Function]}
+              aria-describedby=""
+              aria-label=""
+              aria-labelledby=""
+              className="drift"
+              hasNoBodyWrapper={false}
+              isOpen={false}
+              onClose={[Function]}
+              ouiaId="delete-baseline-notification-modal"
+              ouiaSafe={true}
+              showClose={true}
+              title="Delete baseline notifications"
+              titleIconVariant={null}
+              titleLabel=""
+              variant="small"
+            >
+              <Portal
+                containerInfo={<div />}
+              >
+                <ModalContent
+                  actions={
+                    Array [
+                      <Button
+                        onClick={[Function]}
+                        ouiaId="delete-baseline-notification-button"
+                        variant="danger"
+                      >
+                        Delete
+                      </Button>,
+                      <Button
+                        onClick={[Function]}
+                        ouiaId="delete-baseline-notification-cancel-button"
+                        variant="link"
+                      >
+                        Cancel
+                      </Button>,
+                    ]
+                  }
+                  aria-describedby=""
+                  aria-label=""
+                  aria-labelledby=""
+                  boxId="pf-modal-part-0"
+                  className="drift"
+                  descriptorId="pf-modal-part-2"
+                  hasNoBodyWrapper={false}
+                  isOpen={false}
+                  labelId="pf-modal-part-1"
+                  onClose={[Function]}
+                  ouiaId="delete-baseline-notification-modal"
+                  ouiaSafe={true}
+                  showClose={true}
+                  title="Delete baseline notifications"
+                  titleIconVariant={null}
+                  titleLabel=""
+                  variant="small"
+                />
+              </Portal>
+            </Modal>
+          </DeleteNotificationModal>
+          <Modal
+            actions={
+              Array [
+                <Button
+                  onClick={[Function]}
+                  ouiaId="add-baseline-notification-button"
+                  variant="primary"
+                >
+                  Submit
+                </Button>,
+                <Button
+                  onClick={[Function]}
+                  ouiaId="add-baseline-notification-cancel-button"
+                  variant="link"
+                >
+                  Cancel
+                </Button>,
+              ]
+            }
+            appendTo={[Function]}
+            aria-describedby=""
+            aria-label=""
+            aria-labelledby=""
+            className="drift"
+            hasNoBodyWrapper={false}
+            isOpen={false}
+            onClose={[Function]}
+            ouiaId="add-baseline-notification-modal"
+            ouiaSafe={true}
+            showClose={true}
+            title="Associate system with undefined"
+            titleIconVariant={null}
+            titleLabel=""
+            variant="medium"
+          >
+            <Portal
+              containerInfo={<div />}
+            >
+              <ModalContent
+                actions={
+                  Array [
+                    <Button
+                      onClick={[Function]}
+                      ouiaId="add-baseline-notification-button"
+                      variant="primary"
+                    >
+                      Submit
+                    </Button>,
+                    <Button
+                      onClick={[Function]}
+                      ouiaId="add-baseline-notification-cancel-button"
+                      variant="link"
+                    >
+                      Cancel
+                    </Button>,
+                  ]
+                }
+                aria-describedby=""
+                aria-label=""
+                aria-labelledby=""
+                boxId="pf-modal-part-1"
+                className="drift"
+                descriptorId="pf-modal-part-3"
+                hasNoBodyWrapper={false}
+                isOpen={false}
+                labelId="pf-modal-part-2"
+                onClose={[Function]}
+                ouiaId="add-baseline-notification-modal"
+                ouiaSafe={true}
+                showClose={true}
+                title="Associate system with undefined"
+                titleIconVariant={null}
+                titleLabel=""
+                variant="medium"
+              />
+            </Portal>
+          </Modal>
+          <SystemsTableWithContext
+            deleteNotifications={[Function]}
+            hasMultiSelect={true}
+            onSystemSelect={[Function]}
+            permissions={
+              Object {
+                "baselinesWrite": true,
+              }
+            }
+            selectVariant="checkbox"
+            systemNotificationIds={Array []}
+            toolbarButton={
+              <Button
+                isDisabled={false}
+                onClick={[Function]}
+                ouiaId="add-baseline-notification-button"
+                variant="primary"
+              >
+                Add system
+              </Button>
+            }
+          >
+            <Provider
+              store={
+                Object {
+                  "@@observable": [Function],
+                  "dispatch": [Function],
+                  "getState": [Function],
+                  "replaceReducer": [Function],
+                  "subscribe": [Function],
+                }
+              }
+            >
+              <Connect(Component)
+                addNewListener={[Function]}
+                deleteNotifications={[Function]}
+                hasMultiSelect={true}
+                onSystemSelect={[Function]}
+                permissions={
+                  Object {
+                    "baselinesWrite": true,
+                  }
+                }
+                registry={
+                  ReducerRegistry {
+                    "reducers": Object {},
+                    "store": Object {
+                      "@@observable": [Function],
+                      "dispatch": [Function],
+                      "getState": [Function],
+                      "replaceReducer": [Function],
+                      "subscribe": [Function],
+                    },
+                  }
+                }
+                selectVariant="checkbox"
+                selectedSystemIds={Array []}
+                systemNotificationIds={Array []}
+                toolbarButton={
+                  <Button
+                    isDisabled={false}
+                    onClick={[Function]}
+                    ouiaId="add-baseline-notification-button"
+                    variant="primary"
+                  >
+                    Add system
+                  </Button>
+                }
+              >
+                <Component
+                  addNewListener={[Function]}
+                  deleteNotifications={[Function]}
+                  driftClearFilters={[Function]}
+                  hasMultiSelect={true}
+                  onSystemSelect={[Function]}
+                  permissions={
+                    Object {
+                      "baselinesWrite": true,
+                    }
+                  }
+                  registry={
+                    ReducerRegistry {
+                      "reducers": Object {},
+                      "store": Object {
+                        "@@observable": [Function],
+                        "dispatch": [Function],
+                        "getState": [Function],
+                        "replaceReducer": [Function],
+                        "subscribe": [Function],
+                      },
+                    }
+                  }
+                  selectEntities={[Function]}
+                  selectVariant="checkbox"
+                  selectedSystemIds={Array []}
+                  setSelectedSystemIds={[Function]}
+                  systemNotificationIds={Array []}
+                  toolbarButton={
+                    <Button
+                      isDisabled={false}
+                      onClick={[Function]}
+                      ouiaId="add-baseline-notification-button"
+                      variant="primary"
+                    >
+                      Add system
+                    </Button>
+                  }
+                  updateColumns={[Function]}
+                >
+                  <EmptyStateDisplay
+                    color="#6a6e73"
+                    icon={[Function]}
+                    text={
+                      Array [
+                        "Contact your organization administrator(s) for more information.",
+                      ]
+                    }
+                    title="You do not have access to the inventory"
+                  >
+                    <EmptyState
+                      variant="large"
+                    >
+                      <div
+                        className="pf-c-empty-state pf-m-lg"
+                      >
+                        <div
+                          className="pf-c-empty-state__content"
+                        >
+                          <EmptyStateIcon
+                            className={null}
+                            color="#6a6e73"
+                            icon={[Function]}
+                          >
+                            <LockIcon
+                              aria-hidden="true"
+                              className="pf-c-empty-state__icon"
+                              color="#6a6e73"
+                              noVerticalAlign={false}
+                              size="sm"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                aria-labelledby={null}
+                                className="pf-c-empty-state__icon"
+                                fill="#6a6e73"
+                                height="1em"
+                                role="img"
+                                style={
+                                  Object {
+                                    "verticalAlign": "-0.125em",
+                                  }
+                                }
+                                viewBox="0 0 448 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M400 224h-24v-72C376 68.2 307.8 0 224 0S72 68.2 72 152v72H48c-26.5 0-48 21.5-48 48v192c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V272c0-26.5-21.5-48-48-48zm-104 0H152v-72c0-39.7 32.3-72 72-72s72 32.3 72 72v72z"
+                                />
+                              </svg>
+                            </LockIcon>
+                          </EmptyStateIcon>
+                          <br />
+                          <Title
+                            headingLevel="h1"
+                            size="lg"
+                          >
+                            <h1
+                              className="pf-c-title pf-m-lg"
+                            >
+                              You do not have access to the inventory
+                            </h1>
+                          </Title>
+                          <EmptyStateBody>
+                            <div
+                              className="pf-c-empty-state__body"
+                            >
+                              Contact your organization administrator(s) for more information.
+                            </div>
+                          </EmptyStateBody>
+                        </div>
+                      </div>
+                    </EmptyState>
+                  </EmptyStateDisplay>
+                </Component>
+              </Connect(Component)>
+            </Provider>
+          </SystemsTableWithContext>
+        </SystemNotification>
+      </Connect(SystemNotification)>
+    </Provider>
+  </Router>
+</MemoryRouter>
+`;
+
+exports[`SystemNotification should render 1`] = `
+<Fragment>
+  <DeleteNotificationModal
+    fetchSystems={[Function]}
+  />
+  <Modal
+    actions={
+      Array [
+        <Button
+          onClick={[Function]}
+          ouiaId="add-baseline-notification-button"
+          variant="primary"
+        >
+          Submit
+        </Button>,
+        <Button
+          onClick={[Function]}
+          ouiaId="add-baseline-notification-cancel-button"
+          variant="link"
+        >
+          Cancel
+        </Button>,
+      ]
+    }
+    appendTo={[Function]}
+    aria-describedby=""
+    aria-label=""
+    aria-labelledby=""
+    className="drift"
+    hasNoBodyWrapper={false}
+    isOpen={false}
+    onClose={[Function]}
+    ouiaId="add-baseline-notification-modal"
+    ouiaSafe={true}
+    showClose={true}
+    title="Associate system with undefined"
+    titleIconVariant={null}
+    titleLabel=""
+    variant="medium"
+  >
+    <Connect(SystemsTable)
+      hasMultiSelect={true}
+      isAddSystemNotifications={true}
+      selectSystemsToAdd={[Function]}
+      selectVariant="checkbox"
+      selectedSystemIds={Array []}
+    />
+  </Modal>
+  <Bullseye>
+    <Spinner
+      size="xl"
+    />
+  </Bullseye>
+</Fragment>
+`;

--- a/src/SmartComponents/BaselinesPage/__tests__/__snapshots__/BaselinesPage.tests.js.snap
+++ b/src/SmartComponents/BaselinesPage/__tests__/__snapshots__/BaselinesPage.tests.js.snap
@@ -157,14 +157,17 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
             setSelectedSystemIds={[Function]}
           >
             <withRouter(Connect(CreateBaselineModal))
-              hasReadPermissions={true}
-              hasWritePermissions={true}
+              permissions={
+                Object {
+                  "baselinesRead": true,
+                  "baselinesWrite": true,
+                  "compareRead": true,
+                }
+              }
               selectHistoricProfiles={[Function]}
               setSelectedSystemIds={[Function]}
             >
               <Connect(CreateBaselineModal)
-                hasReadPermissions={true}
-                hasWritePermissions={true}
                 history={
                   Object {
                     "action": "POP",
@@ -211,6 +214,13 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                     "url": "/",
                   }
                 }
+                permissions={
+                  Object {
+                    "baselinesRead": true,
+                    "baselinesWrite": true,
+                    "compareRead": true,
+                  }
+                }
                 selectHistoricProfiles={[Function]}
                 setSelectedSystemIds={[Function]}
               >
@@ -220,8 +230,6 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                   createBaselineError={Object {}}
                   createBaselineModalOpened={false}
                   emptyState={false}
-                  hasReadPermissions={true}
-                  hasWritePermissions={true}
                   history={
                     Object {
                       "action": "POP",
@@ -267,6 +275,13 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                       "params": Object {},
                       "path": "/",
                       "url": "/",
+                    }
+                  }
+                  permissions={
+                    Object {
+                      "baselinesRead": true,
+                      "baselinesWrite": true,
+                      "compareRead": true,
                     }
                   }
                   selectBaseline={[Function]}
@@ -446,13 +461,18 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                               createButton={true}
                               exportButton={true}
                               hasMultiSelect={true}
-                              hasReadPermissions={true}
-                              hasWritePermissions={true}
                               kebab={true}
                               loading={false}
                               onBulkSelect={[Function]}
                               onClick={[Function]}
                               onSelect={[Function]}
+                              permissions={
+                                Object {
+                                  "baselinesRead": true,
+                                  "baselinesWrite": true,
+                                  "compareRead": true,
+                                }
+                              }
                               selectedBaselineIds={Array []}
                               tableData={Array []}
                               tableId="CHECKBOX"
@@ -488,13 +508,18 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                                 exportToCSV={[Function]}
                                 fetchBaselines={[Function]}
                                 hasMultiSelect={true}
-                                hasReadPermissions={true}
-                                hasWritePermissions={true}
                                 kebab={true}
                                 loading={false}
                                 onBulkSelect={[Function]}
                                 onClick={[Function]}
                                 onSelect={[Function]}
+                                permissions={
+                                  Object {
+                                    "baselinesRead": true,
+                                    "baselinesWrite": true,
+                                    "compareRead": true,
+                                  }
+                                }
                                 selectedBaselineIds={Array []}
                                 tableData={Array []}
                                 tableId="CHECKBOX"
@@ -505,8 +530,6 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                                   exportToCSV={[Function]}
                                   fetchWithParams={[Function]}
                                   hasMultiSelect={true}
-                                  hasReadPermissions={true}
-                                  hasWritePermissions={true}
                                   isDeleteDisabled={true}
                                   kebab={true}
                                   loading={false}
@@ -514,6 +537,13 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                                   onSearch={[Function]}
                                   page={1}
                                   perPage={20}
+                                  permissions={
+                                    Object {
+                                      "baselinesRead": true,
+                                      "baselinesWrite": true,
+                                      "compareRead": true,
+                                    }
+                                  }
                                   selectedBaselineIds={Array []}
                                   tableData={Array []}
                                   tableId="CHECKBOX"
@@ -1180,11 +1210,16 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                                                         className="pf-c-toolbar__item"
                                                       >
                                                         <withRouter(Connect(CreateBaselineButton))
-                                                          hasWritePermissions={true}
                                                           loading={false}
+                                                          permissions={
+                                                            Object {
+                                                              "baselinesRead": true,
+                                                              "baselinesWrite": true,
+                                                              "compareRead": true,
+                                                            }
+                                                          }
                                                         >
                                                           <Connect(CreateBaselineButton)
-                                                            hasWritePermissions={true}
                                                             history={
                                                               Object {
                                                                 "action": "POP",
@@ -1232,10 +1267,16 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                                                                 "url": "/",
                                                               }
                                                             }
+                                                            permissions={
+                                                              Object {
+                                                                "baselinesRead": true,
+                                                                "baselinesWrite": true,
+                                                                "compareRead": true,
+                                                              }
+                                                            }
                                                           >
                                                             <CreateBaselineButton
                                                               addSystemModalOpened={false}
-                                                              hasWritePermissions={true}
                                                               history={
                                                                 Object {
                                                                   "action": "POP",
@@ -1281,6 +1322,13 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                                                                   "params": Object {},
                                                                   "path": "/",
                                                                   "url": "/",
+                                                                }
+                                                              }
+                                                              permissions={
+                                                                Object {
+                                                                  "baselinesRead": true,
+                                                                  "baselinesWrite": true,
+                                                                  "compareRead": true,
                                                                 }
                                                               }
                                                               toggleAddSystemModal={[Function]}
@@ -5487,14 +5535,17 @@ exports[`ConnectedBaselinesPage should render empty state 1`] = `
             setSelectedSystemIds={[Function]}
           >
             <withRouter(Connect(CreateBaselineModal))
-              hasReadPermissions={true}
-              hasWritePermissions={true}
+              permissions={
+                Object {
+                  "baselinesRead": true,
+                  "baselinesWrite": true,
+                  "compareRead": true,
+                }
+              }
               selectHistoricProfiles={[Function]}
               setSelectedSystemIds={[Function]}
             >
               <Connect(CreateBaselineModal)
-                hasReadPermissions={true}
-                hasWritePermissions={true}
                 history={
                   Object {
                     "action": "POP",
@@ -5541,6 +5592,13 @@ exports[`ConnectedBaselinesPage should render empty state 1`] = `
                     "url": "/",
                   }
                 }
+                permissions={
+                  Object {
+                    "baselinesRead": true,
+                    "baselinesWrite": true,
+                    "compareRead": true,
+                  }
+                }
                 selectHistoricProfiles={[Function]}
                 setSelectedSystemIds={[Function]}
               >
@@ -5550,8 +5608,6 @@ exports[`ConnectedBaselinesPage should render empty state 1`] = `
                   createBaselineError={Object {}}
                   createBaselineModalOpened={false}
                   emptyState={false}
-                  hasReadPermissions={true}
-                  hasWritePermissions={true}
                   history={
                     Object {
                       "action": "POP",
@@ -5597,6 +5653,13 @@ exports[`ConnectedBaselinesPage should render empty state 1`] = `
                       "params": Object {},
                       "path": "/",
                       "url": "/",
+                    }
+                  }
+                  permissions={
+                    Object {
+                      "baselinesRead": true,
+                      "baselinesWrite": true,
+                      "compareRead": true,
                     }
                   }
                   selectBaseline={[Function]}
@@ -5724,8 +5787,14 @@ exports[`ConnectedBaselinesPage should render empty state 1`] = `
                     button={
                       <withRouter(Connect(CreateBaselineButton))
                         emptyState={true}
-                        hasWritePermissions={true}
                         loading={false}
+                        permissions={
+                          Object {
+                            "baselinesRead": true,
+                            "baselinesWrite": true,
+                            "compareRead": true,
+                          }
+                        }
                       />
                     }
                     icon={[Function]}
@@ -5800,12 +5869,17 @@ Create a baseline to use in your Comparison analysis.
                           </EmptyStateBody>
                           <withRouter(Connect(CreateBaselineButton))
                             emptyState={true}
-                            hasWritePermissions={true}
                             loading={false}
+                            permissions={
+                              Object {
+                                "baselinesRead": true,
+                                "baselinesWrite": true,
+                                "compareRead": true,
+                              }
+                            }
                           >
                             <Connect(CreateBaselineButton)
                               emptyState={true}
-                              hasWritePermissions={true}
                               history={
                                 Object {
                                   "action": "POP",
@@ -5853,11 +5927,17 @@ Create a baseline to use in your Comparison analysis.
                                   "url": "/",
                                 }
                               }
+                              permissions={
+                                Object {
+                                  "baselinesRead": true,
+                                  "baselinesWrite": true,
+                                  "compareRead": true,
+                                }
+                              }
                             >
                               <CreateBaselineButton
                                 addSystemModalOpened={false}
                                 emptyState={true}
-                                hasWritePermissions={true}
                                 history={
                                   Object {
                                     "action": "POP",
@@ -5903,6 +5983,13 @@ Create a baseline to use in your Comparison analysis.
                                     "params": Object {},
                                     "path": "/",
                                     "url": "/",
+                                  }
+                                }
+                                permissions={
+                                  Object {
+                                    "baselinesRead": true,
+                                    "baselinesWrite": true,
+                                    "compareRead": true,
                                   }
                                 }
                                 toggleAddSystemModal={[Function]}

--- a/src/SmartComponents/BaselinesTable/BaselinesTable.js
+++ b/src/SmartComponents/BaselinesTable/BaselinesTable.js
@@ -60,13 +60,13 @@ export class BaselinesTable extends Component {
 
     onSort = (_event, index, direction) => {
         const { search } = this.state;
-        const { hasWritePermissions } = this.props;
+        const { permissions } = this.props;
         let orderBy = '';
 
         if (index === 0) {
             orderBy = 'display_name';
         } else if (index === 1) {
-            orderBy = !hasWritePermissions ? 'updated' : 'display_name';
+            orderBy = !permissions.baselinesWrite ? 'updated' : 'display_name';
         } else if (index === 2) {
             orderBy = 'updated';
         }
@@ -88,7 +88,7 @@ export class BaselinesTable extends Component {
         this.fetchWithParams({ page: pagination.page, perPage: pagination.perPage });
     }
 
-    renderRows(hasWritePermissions) {
+    renderRows(baselinesWrite) {
         const { basketIsVisible, hasMultiSelect, tableData, kebab, onClick, selectedBaselineIds, tableId } = this.props;
         let table = [];
 
@@ -113,7 +113,7 @@ export class BaselinesTable extends Component {
 
             row.push(baseline[2]);
 
-            if (kebab && hasWritePermissions) {
+            if (kebab && baselinesWrite) {
                 let kebab = <BaselineTableKebab
                     tableId={ tableId }
                     baselineRowData={ baseline }
@@ -138,7 +138,7 @@ export class BaselinesTable extends Component {
         return table;
     }
 
-    renderTable(hasWritePermissions, hasReadPermissions) {
+    renderTable({ baselinesWrite, baselinesRead }) {
         const { columns, createButton, hasMultiSelect, kebab, loading, onSelect, tableData, tableId } = this.props;
         const { emptyStateMessage } = this.state;
         let tableRows = [];
@@ -171,7 +171,7 @@ export class BaselinesTable extends Component {
                     <TableBody />
                 </Table>;
             } else {
-                if (!hasReadPermissions && !createButton) {
+                if (!baselinesRead && !createButton) {
                     return <EmptyStateDisplay
                         icon={ LockIcon }
                         color='#6a6e73'
@@ -179,13 +179,13 @@ export class BaselinesTable extends Component {
                         text={ [ 'Contact your organization administrator(s) for more information.' ] }
                     />;
                 } else {
-                    tableRows = this.renderRows(hasWritePermissions);
+                    tableRows = this.renderRows(baselinesWrite);
 
                     table = <Table
                         aria-label="Baselines Table"
                         data-ouia-component-id='baselines-table'
                         onSort={ this.onSort }
-                        onSelect={ hasWritePermissions || ((tableId === 'CHECKBOX' || tableId === 'COMPARISON') && !kebab)
+                        onSelect={ baselinesWrite || ((tableId === 'CHECKBOX' || tableId === 'COMPARISON') && !kebab)
                             ? onSelect
                             : false }
                         sortBy={ this.state.sortBy }
@@ -214,8 +214,8 @@ export class BaselinesTable extends Component {
     }
 
     render() {
-        const { kebab, createButton, exportToCSV, exportButton, hasMultiSelect, loading, onBulkSelect, selectedBaselineIds,
-            tableData, tableId, totalBaselines, hasReadPermissions, hasWritePermissions } = this.props;
+        const { kebab, createButton, exportToCSV, exportButton, hasMultiSelect, loading, onBulkSelect, permissions,
+            selectedBaselineIds, tableData, tableId, totalBaselines } = this.props;
         const { page, perPage } = this.state;
 
         return (
@@ -238,17 +238,16 @@ export class BaselinesTable extends Component {
                     updatePagination={ this.updatePagination }
                     exportToCSV={ exportToCSV }
                     loading={ loading }
-                    hasWritePermissions={ hasWritePermissions }
-                    hasReadPermissions={ hasReadPermissions }
+                    permissions={ permissions }
                 />
-                { this.renderTable(hasWritePermissions, hasReadPermissions) }
+                { this.renderTable(permissions) }
                 <Toolbar>
                     <ToolbarGroup className='pf-c-pagination'>
                         <ToolbarItem>
                             <TablePagination
                                 page={ page }
                                 perPage={ perPage }
-                                total={ !hasReadPermissions ? 0 : totalBaselines }
+                                total={ !permissions.baselinesRead ? 0 : totalBaselines }
                                 isCompact={ false }
                                 updatePagination={ this.updatePagination }
                                 tableId={ tableId }
@@ -277,8 +276,7 @@ BaselinesTable.propTypes = {
     selectedBaselineIds: PropTypes.array,
     totalBaselines: PropTypes.number,
     exportToCSV: PropTypes.func,
-    hasReadPermissions: PropTypes.bool,
-    hasWritePermissions: PropTypes.bool,
+    permissions: PropTypes.object,
     basketIsVisible: PropTypes.bool
 };
 

--- a/src/SmartComponents/BaselinesTable/BaselinesToolbar/BaselinesToolbar.js
+++ b/src/SmartComponents/BaselinesTable/BaselinesToolbar/BaselinesToolbar.js
@@ -106,9 +106,8 @@ export class BaselinesToolbar extends Component {
     }, 250)
 
     render() {
-        const { createButton, exportButton, fetchWithParams, hasMultiSelect, hasReadPermissions,
-            hasWritePermissions, kebab, loading, onBulkSelect, tableData, tableId,
-            page, perPage, selectedBaselineIds, totalBaselines, updatePagination } = this.props;
+        const { createButton, exportButton, fetchWithParams, hasMultiSelect, kebab, loading, onBulkSelect,
+            tableData, tableId, page, permissions, perPage, selectedBaselineIds, totalBaselines, updatePagination } = this.props;
         const { bulkSelectItems, dropdownItems, dropdownOpen, modalOpened, nameSearch } = this.state;
         let selected = tableData.filter(baseline => baseline.selected === true).length;
 
@@ -132,8 +131,8 @@ export class BaselinesToolbar extends Component {
                                         checked={ helpers.findCheckedValue(tableData.length, selected) }
                                         onSelect={ () => onBulkSelect(!selected > 0) }
                                         isDisabled={ tableData.length === 0
-                                            || (!hasWritePermissions && kebab)
-                                            || (!hasReadPermissions && !createButton) }
+                                            || (!permissions.baselinesWrite && kebab)
+                                            || (!permissions.baselinesRead && !createButton) }
                                     />
                                 </ToolbarItem>
                             </ToolbarGroup>
@@ -151,7 +150,7 @@ export class BaselinesToolbar extends Component {
                                     data-ouia-component-type='PF4/TextInput'
                                     data-ouia-component-id='filter-by-name-baselines-table'
                                     onChange={ (event, value) => this.setTextFilter(value) }
-                                    isDisabled={ !hasReadPermissions || !hasWritePermissions }
+                                    isDisabled={ !permissions.baselinesRead || !permissions.baselinesWrite }
                                 />
                             </ToolbarFilter>
                         </ToolbarGroup>
@@ -160,7 +159,7 @@ export class BaselinesToolbar extends Component {
                                 <ToolbarItem>
                                     <CreateBaselineButton
                                         loading={ loading }
-                                        hasWritePermissions={ hasWritePermissions }
+                                        permissions={ permissions }
                                     />
                                 </ToolbarItem>
                                 : null
@@ -191,7 +190,7 @@ export class BaselinesToolbar extends Component {
                             <TablePagination
                                 page={ page }
                                 perPage={ perPage }
-                                total={ !hasReadPermissions ? 0 : totalBaselines }
+                                total={ !permissions.baselinesRead ? 0 : totalBaselines }
                                 isCompact={ true }
                                 updatePagination={ updatePagination }
                                 tableId={ tableId }
@@ -223,8 +222,7 @@ BaselinesToolbar.propTypes = {
     updatePagination: PropTypes.func,
     exportToCSV: PropTypes.func,
     loading: PropTypes.bool,
-    hasWritePermissions: PropTypes.bool,
-    hasReadPermissions: PropTypes.bool
+    permissions: PropTypes.object
 };
 
 export default BaselinesToolbar;

--- a/src/SmartComponents/BaselinesTable/BaselinesToolbar/__test__/BaselinesToolbar.test.js
+++ b/src/SmartComponents/BaselinesTable/BaselinesToolbar/__test__/BaselinesToolbar.test.js
@@ -22,8 +22,10 @@ describe('jest-tests', () => {
                 tableData: baselinesTableFixtures.baselineTableDataRows,
                 tableId: 'CHECKBOX',
                 hasMultiSelect: true,
-                hasWritePermissions: true,
-                hasReadPermissions: true,
+                permissions: {
+                    baselinesWrite: true,
+                    baselinesRead: true
+                },
                 onSearch: jest.fn()
             };
         });
@@ -37,7 +39,7 @@ describe('jest-tests', () => {
         });
 
         it('should have disabled BulkSelect with no write permissions', () => {
-            props.hasWritePermissions = false;
+            props.permissions.baselinesWrite = false;
             const wrapper = shallow(
                 <BaselinesToolbar { ...props } />
             );
@@ -46,7 +48,7 @@ describe('jest-tests', () => {
         });
 
         it('should have enabled BulkSelect with no write permissions in add system modal', () => {
-            props.hasWritePermissions = false;
+            props.permissions.baselinesWrite = false;
             props.kebab = false;
             const wrapper = shallow(
                 <BaselinesToolbar { ...props } />
@@ -127,8 +129,10 @@ describe('jest-tests', () => {
                 tableData: baselinesTableFixtures.baselineTableDataRows,
                 tableId: 'CHECKBOX',
                 hasMultiSelect: true,
-                hasWritePermissions: true,
-                hasReadPermissions: true,
+                permissions: {
+                    baselinesWrite: true,
+                    baselinesRead: true
+                },
                 selectedBaselineIds: []
             };
         });

--- a/src/SmartComponents/BaselinesTable/BaselinesToolbar/__test__/__snapshots__/BaselinesToolbar.test.js.snap
+++ b/src/SmartComponents/BaselinesTable/BaselinesToolbar/__test__/__snapshots__/BaselinesToolbar.test.js.snap
@@ -71,7 +71,12 @@ exports[`jest-tests BaselinesToolbar should render correctly 1`] = `
       >
         <ToolbarItem>
           <withRouter(Connect(CreateBaselineButton))
-            hasWritePermissions={true}
+            permissions={
+              Object {
+                "baselinesRead": true,
+                "baselinesWrite": true,
+              }
+            }
           />
         </ToolbarItem>
       </ForwardRef>
@@ -178,9 +183,13 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
         createButton={true}
         exportButton={true}
         hasMultiSelect={true}
-        hasReadPermissions={true}
-        hasWritePermissions={true}
         kebab={true}
+        permissions={
+          Object {
+            "baselinesRead": true,
+            "baselinesWrite": true,
+          }
+        }
         selectedBaselineIds={Array []}
         tableData={
           Array [
@@ -855,10 +864,14 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
                               className="pf-c-toolbar__item"
                             >
                               <withRouter(Connect(CreateBaselineButton))
-                                hasWritePermissions={true}
+                                permissions={
+                                  Object {
+                                    "baselinesRead": true,
+                                    "baselinesWrite": true,
+                                  }
+                                }
                               >
                                 <Connect(CreateBaselineButton)
-                                  hasWritePermissions={true}
                                   history={
                                     Object {
                                       "action": "POP",
@@ -905,10 +918,15 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
                                       "url": "/",
                                     }
                                   }
+                                  permissions={
+                                    Object {
+                                      "baselinesRead": true,
+                                      "baselinesWrite": true,
+                                    }
+                                  }
                                 >
                                   <CreateBaselineButton
                                     addSystemModalOpened={false}
-                                    hasWritePermissions={true}
                                     history={
                                       Object {
                                         "action": "POP",
@@ -953,6 +971,12 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
                                         "params": Object {},
                                         "path": "/",
                                         "url": "/",
+                                      }
+                                    }
+                                    permissions={
+                                      Object {
+                                        "baselinesRead": true,
+                                        "baselinesWrite": true,
                                       }
                                     }
                                     toggleAddSystemModal={[Function]}

--- a/src/SmartComponents/BaselinesTable/__tests__/BaselinesTable.tests.js
+++ b/src/SmartComponents/BaselinesTable/__tests__/BaselinesTable.tests.js
@@ -43,14 +43,16 @@ describe('ConnectedBaselinesTable', () => {
                 { title: '' }
             ],
             selectedBaselineIds: [],
-            hasReadPermissions: true,
-            hasWritePermissions: true,
+            permissions: {
+                baselinesRead: true,
+                baselinesWrite: true
+            },
             basketIsVisible: false
         };
     });
 
     it('should render no table kebabs with no write permissions', () => {
-        props.hasWritePermissions = false;
+        props.permissions.baselinesWrite = false;
         const store = mockStore(initialState);
         const wrapper = mount(
             <MemoryRouter keyLength={ 0 }>
@@ -67,7 +69,7 @@ describe('ConnectedBaselinesTable', () => {
     });
 
     it('should render no pagination in add system modal with no read permissions', () => {
-        props.hasReadPermissions = false;
+        props.permissions.baselinesRead = false;
         const store = mockStore(initialState);
         const wrapper = mount(
             <MemoryRouter keyLength={ 0 }>

--- a/src/SmartComponents/BaselinesTable/__tests__/__snapshots__/BaselinesTable.tests.js.snap
+++ b/src/SmartComponents/BaselinesTable/__tests__/__snapshots__/BaselinesTable.tests.js.snap
@@ -72,10 +72,14 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
         createButton={true}
         exportButton={true}
         hasMultiSelect={true}
-        hasReadPermissions={true}
-        hasWritePermissions={true}
         kebab={true}
         loading={false}
+        permissions={
+          Object {
+            "baselinesRead": true,
+            "baselinesWrite": true,
+          }
+        }
         selectedBaselineIds={
           Array [
             "1234",
@@ -123,10 +127,14 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
           exportToCSV={[Function]}
           fetchBaselines={[Function]}
           hasMultiSelect={true}
-          hasReadPermissions={true}
-          hasWritePermissions={true}
           kebab={true}
           loading={false}
+          permissions={
+            Object {
+              "baselinesRead": true,
+              "baselinesWrite": true,
+            }
+          }
           selectedBaselineIds={
             Array [
               "1234",
@@ -154,14 +162,18 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
             exportToCSV={[Function]}
             fetchWithParams={[Function]}
             hasMultiSelect={true}
-            hasReadPermissions={true}
-            hasWritePermissions={true}
             isDeleteDisabled={false}
             kebab={true}
             loading={false}
             onSearch={[Function]}
             page={1}
             perPage={20}
+            permissions={
+              Object {
+                "baselinesRead": true,
+                "baselinesWrite": true,
+              }
+            }
             selectedBaselineIds={
               Array [
                 "1234",
@@ -884,11 +896,15 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                   className="pf-c-toolbar__item"
                                 >
                                   <withRouter(Connect(CreateBaselineButton))
-                                    hasWritePermissions={true}
                                     loading={false}
+                                    permissions={
+                                      Object {
+                                        "baselinesRead": true,
+                                        "baselinesWrite": true,
+                                      }
+                                    }
                                   >
                                     <Connect(CreateBaselineButton)
-                                      hasWritePermissions={true}
                                       history={
                                         Object {
                                           "action": "POP",
@@ -936,10 +952,15 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                           "url": "/",
                                         }
                                       }
+                                      permissions={
+                                        Object {
+                                          "baselinesRead": true,
+                                          "baselinesWrite": true,
+                                        }
+                                      }
                                     >
                                       <CreateBaselineButton
                                         addSystemModalOpened={false}
-                                        hasWritePermissions={true}
                                         history={
                                           Object {
                                             "action": "POP",
@@ -985,6 +1006,12 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                             "params": Object {},
                                             "path": "/",
                                             "url": "/",
+                                          }
+                                        }
+                                        permissions={
+                                          Object {
+                                            "baselinesRead": true,
+                                            "baselinesWrite": true,
                                           }
                                         }
                                         toggleAddSystemModal={[Function]}
@@ -6783,10 +6810,14 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
         createButton={true}
         exportButton={true}
         hasMultiSelect={true}
-        hasReadPermissions={true}
-        hasWritePermissions={true}
         kebab={true}
         loading={false}
+        permissions={
+          Object {
+            "baselinesRead": true,
+            "baselinesWrite": true,
+          }
+        }
         selectedBaselineIds={Array []}
         tableData={
           Array [
@@ -6830,10 +6861,14 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
           exportToCSV={[Function]}
           fetchBaselines={[Function]}
           hasMultiSelect={true}
-          hasReadPermissions={true}
-          hasWritePermissions={true}
           kebab={true}
           loading={false}
+          permissions={
+            Object {
+              "baselinesRead": true,
+              "baselinesWrite": true,
+            }
+          }
           selectedBaselineIds={Array []}
           tableData={
             Array [
@@ -6857,14 +6892,18 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
             exportToCSV={[Function]}
             fetchWithParams={[Function]}
             hasMultiSelect={true}
-            hasReadPermissions={true}
-            hasWritePermissions={true}
             isDeleteDisabled={true}
             kebab={true}
             loading={false}
             onSearch={[Function]}
             page={1}
             perPage={20}
+            permissions={
+              Object {
+                "baselinesRead": true,
+                "baselinesWrite": true,
+              }
+            }
             selectedBaselineIds={Array []}
             tableData={
               Array [
@@ -7575,11 +7614,15 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                   className="pf-c-toolbar__item"
                                 >
                                   <withRouter(Connect(CreateBaselineButton))
-                                    hasWritePermissions={true}
                                     loading={false}
+                                    permissions={
+                                      Object {
+                                        "baselinesRead": true,
+                                        "baselinesWrite": true,
+                                      }
+                                    }
                                   >
                                     <Connect(CreateBaselineButton)
-                                      hasWritePermissions={true}
                                       history={
                                         Object {
                                           "action": "POP",
@@ -7627,10 +7670,15 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                           "url": "/",
                                         }
                                       }
+                                      permissions={
+                                        Object {
+                                          "baselinesRead": true,
+                                          "baselinesWrite": true,
+                                        }
+                                      }
                                     >
                                       <CreateBaselineButton
                                         addSystemModalOpened={false}
-                                        hasWritePermissions={true}
                                         history={
                                           Object {
                                             "action": "POP",
@@ -7676,6 +7724,12 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                             "params": Object {},
                                             "path": "/",
                                             "url": "/",
+                                          }
+                                        }
+                                        permissions={
+                                          Object {
+                                            "baselinesRead": true,
+                                            "baselinesWrite": true,
                                           }
                                         }
                                         toggleAddSystemModal={[Function]}
@@ -13330,10 +13384,14 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
         createButton={true}
         exportButton={true}
         hasMultiSelect={true}
-        hasReadPermissions={true}
-        hasWritePermissions={true}
         kebab={true}
         loading={true}
+        permissions={
+          Object {
+            "baselinesRead": true,
+            "baselinesWrite": true,
+          }
+        }
         selectedBaselineIds={Array []}
         tableData={
           Array [
@@ -13377,10 +13435,14 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
           exportToCSV={[Function]}
           fetchBaselines={[Function]}
           hasMultiSelect={true}
-          hasReadPermissions={true}
-          hasWritePermissions={true}
           kebab={true}
           loading={true}
+          permissions={
+            Object {
+              "baselinesRead": true,
+              "baselinesWrite": true,
+            }
+          }
           selectedBaselineIds={Array []}
           tableData={
             Array [
@@ -13404,14 +13466,18 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
             exportToCSV={[Function]}
             fetchWithParams={[Function]}
             hasMultiSelect={true}
-            hasReadPermissions={true}
-            hasWritePermissions={true}
             isDeleteDisabled={true}
             kebab={true}
             loading={true}
             onSearch={[Function]}
             page={1}
             perPage={20}
+            permissions={
+              Object {
+                "baselinesRead": true,
+                "baselinesWrite": true,
+              }
+            }
             selectedBaselineIds={Array []}
             tableData={
               Array [
@@ -14089,11 +14155,15 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                   className="pf-c-toolbar__item"
                                 >
                                   <withRouter(Connect(CreateBaselineButton))
-                                    hasWritePermissions={true}
                                     loading={true}
+                                    permissions={
+                                      Object {
+                                        "baselinesRead": true,
+                                        "baselinesWrite": true,
+                                      }
+                                    }
                                   >
                                     <Connect(CreateBaselineButton)
-                                      hasWritePermissions={true}
                                       history={
                                         Object {
                                           "action": "POP",
@@ -14141,10 +14211,15 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                           "url": "/",
                                         }
                                       }
+                                      permissions={
+                                        Object {
+                                          "baselinesRead": true,
+                                          "baselinesWrite": true,
+                                        }
+                                      }
                                     >
                                       <CreateBaselineButton
                                         addSystemModalOpened={false}
-                                        hasWritePermissions={true}
                                         history={
                                           Object {
                                             "action": "POP",
@@ -14190,6 +14265,12 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                             "params": Object {},
                                             "path": "/",
                                             "url": "/",
+                                          }
+                                        }
+                                        permissions={
+                                          Object {
+                                            "baselinesRead": true,
+                                            "baselinesWrite": true,
                                           }
                                         }
                                         toggleAddSystemModal={[Function]}
@@ -25036,10 +25117,14 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
         createButton={true}
         exportButton={true}
         hasMultiSelect={false}
-        hasReadPermissions={true}
-        hasWritePermissions={true}
         kebab={true}
         loading={true}
+        permissions={
+          Object {
+            "baselinesRead": true,
+            "baselinesWrite": true,
+          }
+        }
         selectedBaselineIds={Array []}
         tableData={
           Array [
@@ -25083,10 +25168,14 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
           exportToCSV={[Function]}
           fetchBaselines={[Function]}
           hasMultiSelect={false}
-          hasReadPermissions={true}
-          hasWritePermissions={true}
           kebab={true}
           loading={true}
+          permissions={
+            Object {
+              "baselinesRead": true,
+              "baselinesWrite": true,
+            }
+          }
           selectedBaselineIds={Array []}
           tableData={
             Array [
@@ -25110,14 +25199,18 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
             exportToCSV={[Function]}
             fetchWithParams={[Function]}
             hasMultiSelect={false}
-            hasReadPermissions={true}
-            hasWritePermissions={true}
             isDeleteDisabled={true}
             kebab={true}
             loading={true}
             onSearch={[Function]}
             page={1}
             perPage={20}
+            permissions={
+              Object {
+                "baselinesRead": true,
+                "baselinesWrite": true,
+              }
+            }
             selectedBaselineIds={Array []}
             tableData={
               Array [
@@ -25408,11 +25501,15 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
                                   className="pf-c-toolbar__item"
                                 >
                                   <withRouter(Connect(CreateBaselineButton))
-                                    hasWritePermissions={true}
                                     loading={true}
+                                    permissions={
+                                      Object {
+                                        "baselinesRead": true,
+                                        "baselinesWrite": true,
+                                      }
+                                    }
                                   >
                                     <Connect(CreateBaselineButton)
-                                      hasWritePermissions={true}
                                       history={
                                         Object {
                                           "action": "POP",
@@ -25460,10 +25557,15 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
                                           "url": "/",
                                         }
                                       }
+                                      permissions={
+                                        Object {
+                                          "baselinesRead": true,
+                                          "baselinesWrite": true,
+                                        }
+                                      }
                                     >
                                       <CreateBaselineButton
                                         addSystemModalOpened={false}
-                                        hasWritePermissions={true}
                                         history={
                                           Object {
                                             "action": "POP",
@@ -25509,6 +25611,12 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
                                             "params": Object {},
                                             "path": "/",
                                             "url": "/",
+                                          }
+                                        }
+                                        permissions={
+                                          Object {
+                                            "baselinesRead": true,
+                                            "baselinesWrite": true,
                                           }
                                         }
                                         toggleAddSystemModal={[Function]}
@@ -36355,10 +36463,14 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
         createButton={true}
         exportButton={true}
         hasMultiSelect={true}
-        hasReadPermissions={true}
-        hasWritePermissions={true}
         kebab={true}
         loading={false}
+        permissions={
+          Object {
+            "baselinesRead": true,
+            "baselinesWrite": true,
+          }
+        }
         selectedBaselineIds={Array []}
         tableData={
           Array [
@@ -36402,10 +36514,14 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
           exportToCSV={[Function]}
           fetchBaselines={[Function]}
           hasMultiSelect={true}
-          hasReadPermissions={true}
-          hasWritePermissions={true}
           kebab={true}
           loading={false}
+          permissions={
+            Object {
+              "baselinesRead": true,
+              "baselinesWrite": true,
+            }
+          }
           selectedBaselineIds={Array []}
           tableData={
             Array [
@@ -36429,14 +36545,18 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
             exportToCSV={[Function]}
             fetchWithParams={[Function]}
             hasMultiSelect={true}
-            hasReadPermissions={true}
-            hasWritePermissions={true}
             isDeleteDisabled={true}
             kebab={true}
             loading={false}
             onSearch={[Function]}
             page={1}
             perPage={20}
+            permissions={
+              Object {
+                "baselinesRead": true,
+                "baselinesWrite": true,
+              }
+            }
             selectedBaselineIds={Array []}
             tableData={
               Array [
@@ -37114,11 +37234,15 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                   className="pf-c-toolbar__item"
                                 >
                                   <withRouter(Connect(CreateBaselineButton))
-                                    hasWritePermissions={true}
                                     loading={false}
+                                    permissions={
+                                      Object {
+                                        "baselinesRead": true,
+                                        "baselinesWrite": true,
+                                      }
+                                    }
                                   >
                                     <Connect(CreateBaselineButton)
-                                      hasWritePermissions={true}
                                       history={
                                         Object {
                                           "action": "POP",
@@ -37166,10 +37290,15 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                           "url": "/",
                                         }
                                       }
+                                      permissions={
+                                        Object {
+                                          "baselinesRead": true,
+                                          "baselinesWrite": true,
+                                        }
+                                      }
                                     >
                                       <CreateBaselineButton
                                         addSystemModalOpened={false}
-                                        hasWritePermissions={true}
                                         history={
                                           Object {
                                             "action": "POP",
@@ -37215,6 +37344,12 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                             "params": Object {},
                                             "path": "/",
                                             "url": "/",
+                                          }
+                                        }
+                                        permissions={
+                                          Object {
+                                            "baselinesRead": true,
+                                            "baselinesWrite": true,
                                           }
                                         }
                                         toggleAddSystemModal={[Function]}
@@ -42862,10 +42997,14 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
         createButton={true}
         exportButton={true}
         hasMultiSelect={true}
-        hasReadPermissions={true}
-        hasWritePermissions={true}
         kebab={true}
         loading={false}
+        permissions={
+          Object {
+            "baselinesRead": true,
+            "baselinesWrite": true,
+          }
+        }
         selectedBaselineIds={Array []}
         tableData={Array []}
         tableId="CHECKBOX"
@@ -42896,10 +43035,14 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
           exportToCSV={[Function]}
           fetchBaselines={[Function]}
           hasMultiSelect={true}
-          hasReadPermissions={true}
-          hasWritePermissions={true}
           kebab={true}
           loading={false}
+          permissions={
+            Object {
+              "baselinesRead": true,
+              "baselinesWrite": true,
+            }
+          }
           selectedBaselineIds={Array []}
           tableData={Array []}
           tableId="CHECKBOX"
@@ -42910,14 +43053,18 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
             exportToCSV={[Function]}
             fetchWithParams={[Function]}
             hasMultiSelect={true}
-            hasReadPermissions={true}
-            hasWritePermissions={true}
             isDeleteDisabled={true}
             kebab={true}
             loading={false}
             onSearch={[Function]}
             page={1}
             perPage={20}
+            permissions={
+              Object {
+                "baselinesRead": true,
+                "baselinesWrite": true,
+              }
+            }
             selectedBaselineIds={Array []}
             tableData={Array []}
             tableId="CHECKBOX"
@@ -43584,11 +43731,15 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                   className="pf-c-toolbar__item"
                                 >
                                   <withRouter(Connect(CreateBaselineButton))
-                                    hasWritePermissions={true}
                                     loading={false}
+                                    permissions={
+                                      Object {
+                                        "baselinesRead": true,
+                                        "baselinesWrite": true,
+                                      }
+                                    }
                                   >
                                     <Connect(CreateBaselineButton)
-                                      hasWritePermissions={true}
                                       history={
                                         Object {
                                           "action": "POP",
@@ -43636,10 +43787,15 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                           "url": "/",
                                         }
                                       }
+                                      permissions={
+                                        Object {
+                                          "baselinesRead": true,
+                                          "baselinesWrite": true,
+                                        }
+                                      }
                                     >
                                       <CreateBaselineButton
                                         addSystemModalOpened={false}
-                                        hasWritePermissions={true}
                                         history={
                                           Object {
                                             "action": "POP",
@@ -43685,6 +43841,12 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                             "params": Object {},
                                             "path": "/",
                                             "url": "/",
+                                          }
+                                        }
+                                        permissions={
+                                          Object {
+                                            "baselinesRead": true,
+                                            "baselinesWrite": true,
                                           }
                                         }
                                         toggleAddSystemModal={[Function]}
@@ -47771,10 +47933,14 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
         createButton={true}
         exportButton={true}
         hasMultiSelect={true}
-        hasReadPermissions={true}
-        hasWritePermissions={false}
         kebab={true}
         loading={false}
+        permissions={
+          Object {
+            "baselinesRead": true,
+            "baselinesWrite": false,
+          }
+        }
         selectedBaselineIds={Array []}
         tableData={
           Array [
@@ -47818,10 +47984,14 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
           exportToCSV={[Function]}
           fetchBaselines={[Function]}
           hasMultiSelect={true}
-          hasReadPermissions={true}
-          hasWritePermissions={false}
           kebab={true}
           loading={false}
+          permissions={
+            Object {
+              "baselinesRead": true,
+              "baselinesWrite": false,
+            }
+          }
           selectedBaselineIds={Array []}
           tableData={
             Array [
@@ -47845,14 +48015,18 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
             exportToCSV={[Function]}
             fetchWithParams={[Function]}
             hasMultiSelect={true}
-            hasReadPermissions={true}
-            hasWritePermissions={false}
             isDeleteDisabled={true}
             kebab={true}
             loading={false}
             onSearch={[Function]}
             page={1}
             perPage={20}
+            permissions={
+              Object {
+                "baselinesRead": true,
+                "baselinesWrite": false,
+              }
+            }
             selectedBaselineIds={Array []}
             tableData={
               Array [
@@ -48532,11 +48706,15 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                   className="pf-c-toolbar__item"
                                 >
                                   <withRouter(Connect(CreateBaselineButton))
-                                    hasWritePermissions={false}
                                     loading={false}
+                                    permissions={
+                                      Object {
+                                        "baselinesRead": true,
+                                        "baselinesWrite": false,
+                                      }
+                                    }
                                   >
                                     <Connect(CreateBaselineButton)
-                                      hasWritePermissions={false}
                                       history={
                                         Object {
                                           "action": "POP",
@@ -48584,10 +48762,15 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                           "url": "/",
                                         }
                                       }
+                                      permissions={
+                                        Object {
+                                          "baselinesRead": true,
+                                          "baselinesWrite": false,
+                                        }
+                                      }
                                     >
                                       <CreateBaselineButton
                                         addSystemModalOpened={false}
-                                        hasWritePermissions={false}
                                         history={
                                           Object {
                                             "action": "POP",
@@ -48633,6 +48816,12 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                             "params": Object {},
                                             "path": "/",
                                             "url": "/",
+                                          }
+                                        }
+                                        permissions={
+                                          Object {
+                                            "baselinesRead": true,
+                                            "baselinesWrite": false,
                                           }
                                         }
                                         toggleAddSystemModal={[Function]}

--- a/src/SmartComponents/DriftPage/DriftPage.js
+++ b/src/SmartComponents/DriftPage/DriftPage.js
@@ -155,10 +155,7 @@ export class DriftPage extends Component {
                                                     handleBaselineSelection={ handleBaselineSelection }
                                                     handleHSPSelection={ handleHSPSelection }
                                                     handleSystemSelection={ handleSystemSelection }
-                                                    hasBaselinesReadPermissions={ value.permissions.baselinesRead }
-                                                    hasBaselinesWritePermissions={ value.permissions.baselinesWrite }
-                                                    hasInventoryReadPermissions={ value.permissions.inventoryRead }
-                                                    hasHSPReadPermissions={ value.permissions.hspRead }
+                                                    permissions={ value.permissions }
                                                     handleFactFilter={ handleFactFilter }
                                                     addStateFilter={ addStateFilter }
                                                     stateFilters={ stateFilters }

--- a/src/SmartComponents/DriftPage/DriftTable/ComparisonHeader/ComparisonHeader.js
+++ b/src/SmartComponents/DriftPage/DriftTable/ComparisonHeader/ComparisonHeader.js
@@ -48,7 +48,7 @@ class ComparisonHeader extends Component {
     }
 
     renderSystemHeaders() {
-        const { fetchCompare, hasHSPReadPermissions, masterList, referenceId, removeSystem, selectedBaselineIds,
+        const { fetchCompare, masterList, permissions, referenceId, removeSystem, selectedBaselineIds,
             selectedHSPIds, selectHistoricProfiles, systemIds, updateReferenceId } = this.props;
 
         let row = [];
@@ -118,7 +118,7 @@ class ComparisonHeader extends Component {
                                 ? this.formatDate(item.last_updated)
                                 : this.formatDate(item.updated)
                             }
-                            { hasHSPReadPermissions &&
+                            { permissions.hspRead &&
                                 (item.type === 'system' || item.type === 'historical-system-profile')
                                 ? <HistoricalProfilesPopover
                                     system={ item }
@@ -190,6 +190,7 @@ ComparisonHeader.propTypes = {
     fetchCompare: PropTypes.func,
     hasHSPReadPermissions: PropTypes.bool,
     masterList: PropTypes.array,
+    permissions: PropTypes.object,
     referenceId: PropTypes.string,
     removeSystem: PropTypes.func,
     stateSort: PropTypes.string,

--- a/src/SmartComponents/DriftPage/DriftTable/ComparisonHeader/__tests__/ComparisonHeader.tests.js
+++ b/src/SmartComponents/DriftPage/DriftTable/ComparisonHeader/__tests__/ComparisonHeader.tests.js
@@ -14,6 +14,9 @@ describe('ComparisonHeader', () => {
             fetchCompare: jest.fn(),
             hasHSPReadPermissions: true,
             masterList: [],
+            permissions: {
+                hspRead: true
+            },
             referenceId: undefined,
             isFirstReference: true,
             removeSystem: jest.fn(),
@@ -161,7 +164,7 @@ describe('ComparisonHeader', () => {
 
     it('should not render HistoricalProfilesPopover with no hspRead permissions', () => {
         props.masterList = fixtures.masterListAll;
-        props.hasHSPReadPermissions = false;
+        props.permissions.hspRead = false;
         const wrapper = shallow(
             <ComparisonHeader { ...props }/>
         );

--- a/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
+++ b/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
@@ -538,7 +538,7 @@ export class DriftTable extends Component {
     }
 
     renderTable(compareData, loading) {
-        const { factSort, hasHSPReadPermissions, referenceId, selectedBaselineIds, selectedHSPIds,
+        const { factSort, permissions, referenceId, selectedBaselineIds, selectedHSPIds,
             selectHistoricProfiles, setHistory, stateSort, toggleFactSort, toggleStateSort } = this.props;
 
         return (
@@ -552,7 +552,7 @@ export class DriftTable extends Component {
                             <ComparisonHeader
                                 factSort={ factSort }
                                 fetchCompare={ this.fetchCompare }
-                                hasHSPReadPermissions={ hasHSPReadPermissions }
+                                permissions={ permissions }
                                 masterList={ this.masterList }
                                 referenceId={ referenceId }
                                 removeSystem={ this.removeSystem }
@@ -577,8 +577,7 @@ export class DriftTable extends Component {
     }
 
     render() {
-        const { emptyState, filteredCompareData, systems, baselines, hasBaselinesReadPermissions, hasBaselinesWritePermissions,
-            hasHSPReadPermissions, hasInventoryReadPermissions, historicalProfiles, loading } = this.props;
+        const { emptyState, filteredCompareData, systems, baselines, historicalProfiles, loading, permissions } = this.props;
 
         this.masterList = this.formatEntities(systems, baselines, historicalProfiles);
 
@@ -588,10 +587,7 @@ export class DriftTable extends Component {
                     selectedSystemIds={ systems.map(system => system.id) }
                     confirmModal={ this.fetchCompare }
                     referenceId={ this.props.referenceId }
-                    hasInventoryReadPermissions={ hasInventoryReadPermissions }
-                    hasBaselinesReadPermissions={ hasBaselinesReadPermissions }
-                    hasBaselinesWritePermissions={ hasBaselinesWritePermissions }
-                    hasHSPReadPermissions={ hasHSPReadPermissions }
+                    permissions={ permissions }
                 />
                 { !emptyState
                     ? this.renderTable(filteredCompareData, loading)
@@ -654,9 +650,7 @@ DriftTable.propTypes = {
     isFirstReference: PropTypes.bool,
     setIsFirstReference: PropTypes.func,
     clearComparison: PropTypes.func,
-    hasInventoryReadPermissions: PropTypes.bool,
-    hasBaselinesReadPermissions: PropTypes.bool,
-    hasBaselinesWritePermissions: PropTypes.bool,
+    permissions: PropTypes.object,
     stateFilters: PropTypes.array,
     addStateFilter: PropTypes.func,
     handleFactFilter: PropTypes.func,

--- a/src/SmartComponents/DriftPage/DriftTable/__tests__/DriftTable.tests.js
+++ b/src/SmartComponents/DriftPage/DriftTable/__tests__/DriftTable.tests.js
@@ -32,7 +32,9 @@ describe('DriftTable', () => {
             stateSort: DESC,
             loading: false,
             isFirstReference: true,
-            hasHSPReadPermissions: true,
+            permissions: {
+                hspRead: true
+            },
             stateFilters: stateFilterFixtures.allStatesTrue,
             toggleFactSort: jest.fn(),
             toggleStateSort: jest.fn(),
@@ -196,7 +198,9 @@ describe('ConnectedDriftTable', () => {
             systems: [],
             baselines: [],
             historicalProfiles: [],
-            hasHSPReadPermissions: true,
+            permissions: {
+                hspRead: true
+            },
             updateReferenceId: jest.fn()
         };
     });

--- a/src/SmartComponents/DriftPage/DriftTable/__tests__/__snapshots__/DriftTable.tests.js.snap
+++ b/src/SmartComponents/DriftPage/DriftTable/__tests__/__snapshots__/DriftTable.tests.js.snap
@@ -51,15 +51,18 @@ exports[`ConnectedDriftTable should render correctly 1`] = `
       <withRouter(Connect(DriftTable))
         baselines={Array []}
         error={Object {}}
-        hasHSPReadPermissions={true}
         historicalProfiles={Array []}
+        permissions={
+          Object {
+            "hspRead": true,
+          }
+        }
         systems={Array []}
         updateReferenceId={[MockFunction]}
       >
         <Connect(DriftTable)
           baselines={Array []}
           error={Object {}}
-          hasHSPReadPermissions={true}
           historicalProfiles={Array []}
           history={
             Object {
@@ -107,6 +110,11 @@ exports[`ConnectedDriftTable should render correctly 1`] = `
               "url": "/",
             }
           }
+          permissions={
+            Object {
+              "hspRead": true,
+            }
+          }
           systems={Array []}
           updateReferenceId={[MockFunction]}
         >
@@ -119,7 +127,6 @@ exports[`ConnectedDriftTable should render correctly 1`] = `
             expandedRows={Array []}
             fetchCompare={[Function]}
             fullCompareData={Array []}
-            hasHSPReadPermissions={true}
             historicalProfiles={Array []}
             history={
               Object {
@@ -168,6 +175,11 @@ exports[`ConnectedDriftTable should render correctly 1`] = `
                 "url": "/",
               }
             }
+            permissions={
+              Object {
+                "hspRead": true,
+              }
+            }
             selectHistoricProfiles={[Function]}
             setSelectedBaselines={[Function]}
             systems={Array []}
@@ -177,7 +189,11 @@ exports[`ConnectedDriftTable should render correctly 1`] = `
           >
             <Connect(AddSystemModal)
               confirmModal={[Function]}
-              hasHSPReadPermissions={true}
+              permissions={
+                Object {
+                  "hspRead": true,
+                }
+              }
               selectedSystemIds={Array []}
             >
               <AddSystemModal
@@ -187,7 +203,11 @@ exports[`ConnectedDriftTable should render correctly 1`] = `
                 handleBaselineSelection={[Function]}
                 handleHSPSelection={[Function]}
                 handleSystemSelection={[Function]}
-                hasHSPReadPermissions={true}
+                permissions={
+                  Object {
+                    "hspRead": true,
+                  }
+                }
                 selectActiveTab={[Function]}
                 selectBaseline={[Function]}
                 selectEntity={[Function]}
@@ -295,8 +315,12 @@ exports[`ConnectedDriftTable should render correctly 1`] = `
                 <thead>
                   <ComparisonHeader
                     fetchCompare={[Function]}
-                    hasHSPReadPermissions={true}
                     masterList={Array []}
+                    permissions={
+                      Object {
+                        "hspRead": true,
+                      }
+                    }
                     removeSystem={[Function]}
                     selectHistoricProfiles={[Function]}
                     systemIds={Array []}
@@ -453,15 +477,18 @@ exports[`ConnectedDriftTable should render loading rows 1`] = `
       <withRouter(Connect(DriftTable))
         baselines={Array []}
         error={Object {}}
-        hasHSPReadPermissions={true}
         historicalProfiles={Array []}
+        permissions={
+          Object {
+            "hspRead": true,
+          }
+        }
         systems={Array []}
         updateReferenceId={[MockFunction]}
       >
         <Connect(DriftTable)
           baselines={Array []}
           error={Object {}}
-          hasHSPReadPermissions={true}
           historicalProfiles={Array []}
           history={
             Object {
@@ -509,6 +536,11 @@ exports[`ConnectedDriftTable should render loading rows 1`] = `
               "url": "/",
             }
           }
+          permissions={
+            Object {
+              "hspRead": true,
+            }
+          }
           systems={Array []}
           updateReferenceId={[MockFunction]}
         >
@@ -521,7 +553,6 @@ exports[`ConnectedDriftTable should render loading rows 1`] = `
             expandedRows={Array []}
             fetchCompare={[Function]}
             fullCompareData={Array []}
-            hasHSPReadPermissions={true}
             historicalProfiles={Array []}
             history={
               Object {
@@ -570,6 +601,11 @@ exports[`ConnectedDriftTable should render loading rows 1`] = `
                 "url": "/",
               }
             }
+            permissions={
+              Object {
+                "hspRead": true,
+              }
+            }
             selectHistoricProfiles={[Function]}
             setSelectedBaselines={[Function]}
             systems={Array []}
@@ -579,7 +615,11 @@ exports[`ConnectedDriftTable should render loading rows 1`] = `
           >
             <Connect(AddSystemModal)
               confirmModal={[Function]}
-              hasHSPReadPermissions={true}
+              permissions={
+                Object {
+                  "hspRead": true,
+                }
+              }
               selectedSystemIds={Array []}
             >
               <AddSystemModal
@@ -589,7 +629,11 @@ exports[`ConnectedDriftTable should render loading rows 1`] = `
                 handleBaselineSelection={[Function]}
                 handleHSPSelection={[Function]}
                 handleSystemSelection={[Function]}
-                hasHSPReadPermissions={true}
+                permissions={
+                  Object {
+                    "hspRead": true,
+                  }
+                }
                 selectActiveTab={[Function]}
                 selectBaseline={[Function]}
                 selectEntity={[Function]}
@@ -697,8 +741,12 @@ exports[`ConnectedDriftTable should render loading rows 1`] = `
                 <thead>
                   <ComparisonHeader
                     fetchCompare={[Function]}
-                    hasHSPReadPermissions={true}
                     masterList={Array []}
+                    permissions={
+                      Object {
+                        "hspRead": true,
+                      }
+                    }
                     removeSystem={[Function]}
                     selectHistoricProfiles={[Function]}
                     systemIds={Array []}
@@ -1250,7 +1298,6 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
             },
           ]
         }
-        hasHSPReadPermissions={true}
         historicalProfiles={
           Array [
             Object {
@@ -1268,6 +1315,11 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
               "updated": "2019-01-15T15:25:16.304899Z",
             },
           ]
+        }
+        permissions={
+          Object {
+            "hspRead": true,
+          }
         }
         systems={
           Array [
@@ -1304,7 +1356,6 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
               },
             ]
           }
-          hasHSPReadPermissions={true}
           historicalProfiles={
             Array [
               Object {
@@ -1367,6 +1418,11 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
               "params": Object {},
               "path": "/",
               "url": "/",
+            }
+          }
+          permissions={
+            Object {
+              "hspRead": true,
             }
           }
           systems={
@@ -1892,7 +1948,6 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
                 },
               ]
             }
-            hasHSPReadPermissions={true}
             historicalProfiles={
               Array [
                 Object {
@@ -1958,6 +2013,11 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
                 "url": "/",
               }
             }
+            permissions={
+              Object {
+                "hspRead": true,
+              }
+            }
             selectHistoricProfiles={[Function]}
             setSelectedBaselines={[Function]}
             systems={
@@ -1982,7 +2042,11 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
           >
             <Connect(AddSystemModal)
               confirmModal={[Function]}
-              hasHSPReadPermissions={true}
+              permissions={
+                Object {
+                  "hspRead": true,
+                }
+              }
               selectedSystemIds={
                 Array [
                   "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
@@ -1997,7 +2061,11 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
                 handleBaselineSelection={[Function]}
                 handleHSPSelection={[Function]}
                 handleSystemSelection={[Function]}
-                hasHSPReadPermissions={true}
+                permissions={
+                  Object {
+                    "hspRead": true,
+                  }
+                }
                 selectActiveTab={[Function]}
                 selectBaseline={[Function]}
                 selectEntity={[Function]}
@@ -2110,7 +2178,6 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
                 <thead>
                   <ComparisonHeader
                     fetchCompare={[Function]}
-                    hasHSPReadPermissions={true}
                     masterList={
                       Array [
                         Object {
@@ -2152,6 +2219,11 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
                           "type": "system",
                         },
                       ]
+                    }
+                    permissions={
+                      Object {
+                        "hspRead": true,
+                      }
                     }
                     removeSystem={[Function]}
                     selectHistoricProfiles={[Function]}
@@ -7483,7 +7555,6 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
             },
           ]
         }
-        hasHSPReadPermissions={true}
         historicalProfiles={
           Array [
             Object {
@@ -7501,6 +7572,11 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
               "updated": "2019-01-15T15:25:16.304899Z",
             },
           ]
+        }
+        permissions={
+          Object {
+            "hspRead": true,
+          }
         }
         systems={
           Array [
@@ -7537,7 +7613,6 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
               },
             ]
           }
-          hasHSPReadPermissions={true}
           historicalProfiles={
             Array [
               Object {
@@ -7600,6 +7675,11 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
               "params": Object {},
               "path": "/",
               "url": "/",
+            }
+          }
+          permissions={
+            Object {
+              "hspRead": true,
             }
           }
           systems={
@@ -7736,7 +7816,6 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                 },
               ]
             }
-            hasHSPReadPermissions={true}
             historicalProfiles={
               Array [
                 Object {
@@ -7802,6 +7881,11 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                 "url": "/",
               }
             }
+            permissions={
+              Object {
+                "hspRead": true,
+              }
+            }
             selectHistoricProfiles={[Function]}
             setSelectedBaselines={[Function]}
             systems={
@@ -7826,7 +7910,11 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
           >
             <Connect(AddSystemModal)
               confirmModal={[Function]}
-              hasHSPReadPermissions={true}
+              permissions={
+                Object {
+                  "hspRead": true,
+                }
+              }
               selectedSystemIds={
                 Array [
                   "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
@@ -7841,7 +7929,11 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                 handleBaselineSelection={[Function]}
                 handleHSPSelection={[Function]}
                 handleSystemSelection={[Function]}
-                hasHSPReadPermissions={true}
+                permissions={
+                  Object {
+                    "hspRead": true,
+                  }
+                }
                 selectActiveTab={[Function]}
                 selectBaseline={[Function]}
                 selectEntity={[Function]}
@@ -7954,7 +8046,6 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                 <thead>
                   <ComparisonHeader
                     fetchCompare={[Function]}
-                    hasHSPReadPermissions={true}
                     masterList={
                       Array [
                         Object {
@@ -7996,6 +8087,11 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                           "type": "system",
                         },
                       ]
+                    }
+                    permissions={
+                      Object {
+                        "hspRead": true,
+                      }
                     }
                     removeSystem={[Function]}
                     selectHistoricProfiles={[Function]}
@@ -11878,7 +11974,11 @@ exports[`DriftTable should render correctly 1`] = `
 <Fragment>
   <Connect(AddSystemModal)
     confirmModal={[Function]}
-    hasHSPReadPermissions={true}
+    permissions={
+      Object {
+        "hspRead": true,
+      }
+    }
     selectedSystemIds={Array []}
   />
   <div
@@ -11893,8 +11993,12 @@ exports[`DriftTable should render correctly 1`] = `
         <ComparisonHeader
           factSort="asc"
           fetchCompare={[Function]}
-          hasHSPReadPermissions={true}
           masterList={Array []}
+          permissions={
+            Object {
+              "hspRead": true,
+            }
+          }
           removeSystem={[Function]}
           selectHistoricProfiles={[MockFunction]}
           setHistory={[MockFunction]}

--- a/src/SmartComponents/DriftPage/__tests__/__snapshots__/DriftPage.tests.js.snap
+++ b/src/SmartComponents/DriftPage/__tests__/__snapshots__/DriftPage.tests.js.snap
@@ -3150,6 +3150,11 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
                               handleSystemSelection={[Function]}
                               historicalProfiles={Array []}
                               isFirstReference={true}
+                              permissions={
+                                Object {
+                                  "compareRead": true,
+                                }
+                              }
                               selectedBaselineIds={Array []}
                               selectedHSPIds={Array []}
                               setHistory={[Function]}
@@ -3233,6 +3238,11 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
                                     "params": Object {},
                                     "path": "/",
                                     "url": "/",
+                                  }
+                                }
+                                permissions={
+                                  Object {
+                                    "compareRead": true,
                                   }
                                 }
                                 selectedBaselineIds={Array []}
@@ -3326,6 +3336,11 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
                                       "url": "/",
                                     }
                                   }
+                                  permissions={
+                                    Object {
+                                      "compareRead": true,
+                                    }
+                                  }
                                   selectHistoricProfiles={[Function]}
                                   selectedBaselineIds={Array []}
                                   selectedHSPIds={Array []}
@@ -3358,6 +3373,11 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
                                 >
                                   <Connect(AddSystemModal)
                                     confirmModal={[Function]}
+                                    permissions={
+                                      Object {
+                                        "compareRead": true,
+                                      }
+                                    }
                                     selectedSystemIds={Array []}
                                   >
                                     <AddSystemModal
@@ -3369,6 +3389,11 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
                                       handleHSPSelection={[Function]}
                                       handleSystemSelection={[Function]}
                                       historicalProfiles={Array []}
+                                      permissions={
+                                        Object {
+                                          "compareRead": true,
+                                        }
+                                      }
                                       selectActiveTab={[Function]}
                                       selectBaseline={[Function]}
                                       selectEntity={[Function]}
@@ -3478,6 +3503,11 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
                                         <ComparisonHeader
                                           fetchCompare={[Function]}
                                           masterList={Array []}
+                                          permissions={
+                                            Object {
+                                              "compareRead": true,
+                                            }
+                                          }
                                           removeSystem={[Function]}
                                           selectHistoricProfiles={[Function]}
                                           selectedBaselineIds={Array []}
@@ -7582,6 +7612,11 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                               handleSystemSelection={[Function]}
                               historicalProfiles={Array []}
                               isFirstReference={true}
+                              permissions={
+                                Object {
+                                  "compareRead": true,
+                                }
+                              }
                               selectedBaselineIds={Array []}
                               selectedHSPIds={Array []}
                               setHistory={[Function]}
@@ -7669,6 +7704,11 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                     "params": Object {},
                                     "path": "/",
                                     "url": "/",
+                                  }
+                                }
+                                permissions={
+                                  Object {
+                                    "compareRead": true,
                                   }
                                 }
                                 selectedBaselineIds={Array []}
@@ -7766,6 +7806,11 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                       "url": "/",
                                     }
                                   }
+                                  permissions={
+                                    Object {
+                                      "compareRead": true,
+                                    }
+                                  }
                                   selectHistoricProfiles={[Function]}
                                   selectedBaselineIds={Array []}
                                   selectedHSPIds={Array []}
@@ -7798,6 +7843,11 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                 >
                                   <Connect(AddSystemModal)
                                     confirmModal={[Function]}
+                                    permissions={
+                                      Object {
+                                        "compareRead": true,
+                                      }
+                                    }
                                     selectedSystemIds={Array []}
                                   >
                                     <AddSystemModal
@@ -7809,6 +7859,11 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                       handleHSPSelection={[Function]}
                                       handleSystemSelection={[Function]}
                                       historicalProfiles={Array []}
+                                      permissions={
+                                        Object {
+                                          "compareRead": true,
+                                        }
+                                      }
                                       selectActiveTab={[Function]}
                                       selectBaseline={[Function]}
                                       selectEntity={[Function]}
@@ -7918,6 +7973,11 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                         <ComparisonHeader
                                           fetchCompare={[Function]}
                                           masterList={Array []}
+                                          permissions={
+                                            Object {
+                                              "compareRead": true,
+                                            }
+                                          }
                                           removeSystem={[Function]}
                                           selectHistoricProfiles={[Function]}
                                           selectedBaselineIds={Array []}

--- a/src/SmartComponents/SystemsTable/NotificationsSystemsTable.js
+++ b/src/SmartComponents/SystemsTable/NotificationsSystemsTable.js
@@ -36,7 +36,8 @@ export const SystemsTable = connect(null, mapDispatchToProps)(({
     hasMultiSelect,
     selectHistoricProfiles,
     updateColumns,
-    hasInventoryReadPermissions,
+    //hasInventoryReadPermissions,
+    permissions,
     selectEntities,
     selectVariant,
     systemNotificationIds,
@@ -99,7 +100,7 @@ export const SystemsTable = connect(null, mapDispatchToProps)(({
     });
 
     return (
-        hasInventoryReadPermissions ? (
+        /*hasInventoryReadPermissions*/ permissions.inventoryRead ? (
             <InventoryTable
                 onLoad={ ({ mergeWithEntities, INVENTORY_ACTION_TYPES, api }) => {
                     getEntities.current = api?.getEntities;
@@ -206,7 +207,8 @@ SystemsTable.propTypes = {
     hasMultiSelect: PropTypes.bool,
     updateColumns: PropTypes.func,
     selectedHSPIds: PropTypes.array,
-    hasInventoryReadPermissions: PropTypes.bool,
+    //hasInventoryReadPermissions: PropTypes.bool,
+    permissions: PropTypes.object,
     entities: PropTypes.object,
     selectEntities: PropTypes.func,
     selectVariant: PropTypes.string,

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -20,7 +20,8 @@ export const SystemsTable = ({
     driftClearFilters,
     entities,
     hasHistoricalDropdown,
-    hasInventoryReadPermissions,
+    //hasInventoryReadPermissions,
+    permissions,
     hasMultiSelect,
     historicalProfiles,
     isAddSystemNotifications,
@@ -55,7 +56,7 @@ export const SystemsTable = ({
     };
 
     return (
-        hasInventoryReadPermissions ? (
+        permissions.inventoryRead ? (
             <InventoryTable
                 onLoad={ ({ mergeWithEntities, INVENTORY_ACTION_TYPES, api }) => {
                     getEntities.current = api?.getEntities;
@@ -153,7 +154,8 @@ SystemsTable.propTypes = {
     historicalProfiles: PropTypes.array,
     hasMultiSelect: PropTypes.bool,
     updateColumns: PropTypes.func,
-    hasInventoryReadPermissions: PropTypes.bool,
+    //hasInventoryReadPermissions: PropTypes.bool,
+    permissions: PropTypes.object,
     entities: PropTypes.object,
     selectEntities: PropTypes.func,
     selectVariant: PropTypes.string,
@@ -163,7 +165,6 @@ SystemsTable.propTypes = {
     selectHistoricProfiles: PropTypes.func,
     selectSystemsToAdd: PropTypes.func,
     selectSingleHSP: PropTypes.func,
-    thething: PropTypes.string,
     deselectHistoricalProfiles: PropTypes.func
 };
 

--- a/src/SmartComponents/SystemsTable/__tests__/SystemsTable.tests.js
+++ b/src/SmartComponents/SystemsTable/__tests__/SystemsTable.tests.js
@@ -44,7 +44,9 @@ describe('ConnectedSystemsTable', () => {
             selectEntities: jest.fn()
         };
         props = {
-            hasInventoryReadPermissions: true
+            permissions: {
+                inventoryRead: true
+            }
         };
 
         global.window.insights = {
@@ -62,6 +64,21 @@ describe('ConnectedSystemsTable', () => {
 
     it('should render correctly', () => {
         const store = mockStore(initialState);
+
+        const wrapper = mount(
+            <MemoryRouter keyLength={ 0 }>
+                <Provider store={ store }>
+                    <ConnectedSystemsTable { ...props } />
+                </Provider>
+            </MemoryRouter>
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('should render correctly with no inventory read permissions', () => {
+        const store = mockStore(initialState);
+        props.permissions.inventoryRead = false;
 
         const wrapper = mount(
             <MemoryRouter keyLength={ 0 }>

--- a/src/SmartComponents/SystemsTable/__tests__/__snapshots__/SystemsTable.tests.js.snap
+++ b/src/SmartComponents/SystemsTable/__tests__/__snapshots__/SystemsTable.tests.js.snap
@@ -49,11 +49,19 @@ exports[`ConnectedSystemsTable should render correctly 1`] = `
       }
     >
       <Connect(SystemsTable)
-        hasInventoryReadPermissions={true}
+        permissions={
+          Object {
+            "inventoryRead": true,
+          }
+        }
       >
         <SystemsTable
           driftClearFilters={[Function]}
-          hasInventoryReadPermissions={true}
+          permissions={
+            Object {
+              "inventoryRead": true,
+            }
+          }
           selectEntities={[Function]}
           selectHistoricProfiles={[Function]}
           selectSingleHSP={[Function]}
@@ -488,6 +496,156 @@ exports[`ConnectedSystemsTable should render correctly 1`] = `
               </Suspense>
             </BaseInvTable>
           </ForwardRef>
+        </SystemsTable>
+      </Connect(SystemsTable)>
+    </Provider>
+  </Router>
+</MemoryRouter>
+`;
+
+exports[`ConnectedSystemsTable should render correctly with no inventory read permissions 1`] = `
+<MemoryRouter
+  keyLength={0}
+>
+  <Router
+    history={
+      Object {
+        "action": "POP",
+        "block": [Function],
+        "canGo": [Function],
+        "createHref": [Function],
+        "entries": Array [
+          Object {
+            "hash": "",
+            "pathname": "/",
+            "search": "",
+            "state": undefined,
+          },
+        ],
+        "go": [Function],
+        "goBack": [Function],
+        "goForward": [Function],
+        "index": 0,
+        "length": 1,
+        "listen": [Function],
+        "location": Object {
+          "hash": "",
+          "pathname": "/",
+          "search": "",
+          "state": undefined,
+        },
+        "push": [Function],
+        "replace": [Function],
+      }
+    }
+  >
+    <Provider
+      store={
+        Object {
+          "clearActions": [Function],
+          "dispatch": [Function],
+          "getActions": [Function],
+          "getState": [Function],
+          "replaceReducer": [Function],
+          "subscribe": [Function],
+        }
+      }
+    >
+      <Connect(SystemsTable)
+        permissions={
+          Object {
+            "inventoryRead": false,
+          }
+        }
+      >
+        <SystemsTable
+          driftClearFilters={[Function]}
+          permissions={
+            Object {
+              "inventoryRead": false,
+            }
+          }
+          selectEntities={[Function]}
+          selectHistoricProfiles={[Function]}
+          selectSingleHSP={[Function]}
+          selectedSystemIds={Array []}
+          setSelectedSystemIds={[Function]}
+          updateColumns={[Function]}
+        >
+          <EmptyStateDisplay
+            color="#6a6e73"
+            icon={[Function]}
+            text={
+              Array [
+                "Contact your organization administrator(s) for more information.",
+              ]
+            }
+            title="You do not have access to the inventory"
+          >
+            <EmptyState
+              variant="large"
+            >
+              <div
+                className="pf-c-empty-state pf-m-lg"
+              >
+                <div
+                  className="pf-c-empty-state__content"
+                >
+                  <EmptyStateIcon
+                    className={null}
+                    color="#6a6e73"
+                    icon={[Function]}
+                  >
+                    <LockIcon
+                      aria-hidden="true"
+                      className="pf-c-empty-state__icon"
+                      color="#6a6e73"
+                      noVerticalAlign={false}
+                      size="sm"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        aria-labelledby={null}
+                        className="pf-c-empty-state__icon"
+                        fill="#6a6e73"
+                        height="1em"
+                        role="img"
+                        style={
+                          Object {
+                            "verticalAlign": "-0.125em",
+                          }
+                        }
+                        viewBox="0 0 448 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M400 224h-24v-72C376 68.2 307.8 0 224 0S72 68.2 72 152v72H48c-26.5 0-48 21.5-48 48v192c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V272c0-26.5-21.5-48-48-48zm-104 0H152v-72c0-39.7 32.3-72 72-72s72 32.3 72 72v72z"
+                        />
+                      </svg>
+                    </LockIcon>
+                  </EmptyStateIcon>
+                  <br />
+                  <Title
+                    headingLevel="h1"
+                    size="lg"
+                  >
+                    <h1
+                      className="pf-c-title pf-m-lg"
+                    >
+                      You do not have access to the inventory
+                    </h1>
+                  </Title>
+                  <EmptyStateBody>
+                    <div
+                      className="pf-c-empty-state__body"
+                    >
+                      Contact your organization administrator(s) for more information.
+                    </div>
+                  </EmptyStateBody>
+                </div>
+              </div>
+            </EmptyState>
+          </EmptyStateDisplay>
         </SystemsTable>
       </Connect(SystemsTable)>
     </Provider>


### PR DESCRIPTION
To test:

- Go to line 29 in `src/App.js` and change to:
```
    const handlePermissionsUpdate = (hasCompareRead, hasBaselinesRead/*, hasBaselinesWrite*/, hasInventoryRead) => {
        setPermissions({
            hasCompareReadPermissions: hasCompareRead,
            hasBaselinesReadPermissions: hasBaselinesRead,
            hasBaselinesWritePermissions: /*hasBaselinesWrite*/false,
            hasInventoryReadPermissions: hasInventoryRead,
            arePermissionsLoaded: true
        });
    };
```
- Go to details for a baseline
- Select `Systems` tab

'Add system' button should be disabled. If you revert the above code then you'll see that the button is now enabled.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
