### PR TITLE
[DRFT-262] Fix bulk select in add system modal

### DIFF
--- a/src/SmartComponents/AddSystemModal/__tests__/AddSystemModal.tests.js
+++ b/src/SmartComponents/AddSystemModal/__tests__/AddSystemModal.tests.js
@@ -45,7 +45,9 @@ describe('AddSystemModal', () => {
             toggleAddSystemModal: jest.fn(),
             handleBaselineSelection: jest.fn(),
             handleHSPSelection: jest.fn(),
-            handleSystemSelection: jest.fn()
+            handleSystemSelection: jest.fn(),
+            selectHistoricProfiles: jest.fn(),
+            selectBaseline: jest.fn()
         };
     });
 
@@ -139,12 +141,14 @@ describe('AddSystemModal', () => {
             />
         );
 
+        let prevProps = props;
+
         wrapper.setProps({
             baselines: baselinesPayload,
             systems: systemsPayload,
             historicalProfiles: historicalProfilesPayload
         });
-        wrapper.instance().componentDidUpdate();
+        wrapper.instance().componentDidUpdate(prevProps);
         expect(props.handleSystemSelection).toHaveBeenCalledWith(modalFixtures.systemContent1, true);
         expect(props.handleBaselineSelection).toHaveBeenCalledWith(modalFixtures.baselineContent3, true);
         expect(props.handleHSPSelection).toHaveBeenCalledWith(modalFixtures.hspContent1);
@@ -178,6 +182,9 @@ describe('AddSystemModal', () => {
         );
 
         wrapper.instance().cancelSelection();
+        expect(props.handleSystemSelection).toHaveBeenCalled();
+        expect(props.handleBaselineSelection).toHaveBeenCalled();
+        expect(props.selectHistoricProfiles).toHaveBeenCalled();
         expect(props.toggleAddSystemModal).toHaveBeenCalled();
     });
 
@@ -228,6 +235,23 @@ describe('AddSystemModal', () => {
         wrapper.instance().systemContentSelect(modalFixtures.data3);
         expect(props.handleSystemSelection).toHaveBeenCalledWith([ modalFixtures.systemContent1[0] ], modalFixtures.data3.selected);
     });
+
+    it('should remove contents from basket that are not compared', () => {
+        props.baselines = modalFixtures.baselines1;
+        props.historicalProfiles = modalFixtures.historicalProfiles1;
+        props.systems = modalFixtures.systems1;
+        props.selectedBaselineContent = modalFixtures.baselineContent2;
+        props.selectedHSPContent = modalFixtures.hspContent3;
+        props.selectedSystemContent = modalFixtures.systemContent1;
+        const wrapper = shallow(
+            <AddSystemModal
+                { ...props }
+            />
+        );
+
+        wrapper.instance().setSelectedContent();
+        expect(props.handleSystemSelection).toHaveBeenCalledWith(modalFixtures.systemContent3, false);
+    });
 });
 
 describe('ConnectedAddSystemModal', () => {
@@ -265,7 +289,8 @@ describe('ConnectedAddSystemModal', () => {
                 selectedHSPIds: []
             },
             entities: {
-                selectedSystemIds: []
+                selectedSystemIds: [],
+                rows: modalFixtures.rows
             },
             addSystemModalActions: {
                 toggleAddSystemModal: jest.fn()

--- a/src/SmartComponents/AddSystemModal/__tests__/__snapshots__/AddSystemModal.tests.js.snap
+++ b/src/SmartComponents/AddSystemModal/__tests__/__snapshots__/AddSystemModal.tests.js.snap
@@ -64,6 +64,8 @@ exports[`AddSystemModal should render correctly 1`] = `
             handleBaselineSelection={[MockFunction]}
             handleHSPSelection={[MockFunction]}
             isVisible={false}
+            selectBaseline={[MockFunction]}
+            selectHistoricProfiles={[MockFunction]}
             selectedBaselineContent={Array []}
             selectedHSPContent={Array []}
             selectedSystemContent={Array []}
@@ -9385,6 +9387,16 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
           disableSystemTable={[Function]}
           entities={
             Object {
+              "rows": Array [
+                Object {
+                  "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
+                  "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+                },
+                Object {
+                  "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
+                  "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
+                },
+              ],
               "selectedSystemIds": Array [],
             }
           }
@@ -10612,6 +10624,16 @@ Try changing your filter settings.
                                                 <SelectedBasket
                                                   entities={
                                                     Object {
+                                                      "rows": Array [
+                                                        Object {
+                                                          "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
+                                                          "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+                                                        },
+                                                        Object {
+                                                          "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
+                                                          "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
+                                                        },
+                                                      ],
                                                       "selectedSystemIds": Array [],
                                                     }
                                                   }
@@ -10640,6 +10662,16 @@ Try changing your filter settings.
                                                           <SelectedTable
                                                             entities={
                                                               Object {
+                                                                "rows": Array [
+                                                                  Object {
+                                                                    "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
+                                                                    "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+                                                                  },
+                                                                  Object {
+                                                                    "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
+                                                                    "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
+                                                                  },
+                                                                ],
                                                                 "selectedSystemIds": Array [],
                                                               }
                                                             }
@@ -10735,6 +10767,16 @@ Try changing your filter settings.
                                                                   <SelectedTable
                                                                     entities={
                                                                       Object {
+                                                                        "rows": Array [
+                                                                          Object {
+                                                                            "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
+                                                                            "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+                                                                          },
+                                                                          Object {
+                                                                            "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
+                                                                            "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
+                                                                          },
+                                                                        ],
                                                                         "selectedSystemIds": Array [],
                                                                       }
                                                                     }
@@ -11018,6 +11060,16 @@ Try changing your filter settings.
                                         <Memo(Connect(SystemsTable))
                                           entities={
                                             Object {
+                                              "rows": Array [
+                                                Object {
+                                                  "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
+                                                  "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+                                                },
+                                                Object {
+                                                  "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
+                                                  "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
+                                                },
+                                              ],
                                               "selectedSystemIds": Array [],
                                             }
                                           }
@@ -11051,6 +11103,16 @@ Try changing your filter settings.
                                           <Memo(Connect(SystemsTable))
                                             entities={
                                               Object {
+                                                "rows": Array [
+                                                  Object {
+                                                    "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
+                                                    "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+                                                  },
+                                                  Object {
+                                                    "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
+                                                    "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
+                                                  },
+                                                ],
                                                 "selectedSystemIds": Array [],
                                               }
                                             }
@@ -11085,6 +11147,16 @@ Try changing your filter settings.
                                         <Connect(SystemsTable)
                                           entities={
                                             Object {
+                                              "rows": Array [
+                                                Object {
+                                                  "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
+                                                  "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+                                                },
+                                                Object {
+                                                  "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
+                                                  "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
+                                                },
+                                              ],
                                               "selectedSystemIds": Array [],
                                             }
                                           }
@@ -11105,6 +11177,16 @@ Try changing your filter settings.
                                             driftClearFilters={[Function]}
                                             entities={
                                               Object {
+                                                "rows": Array [
+                                                  Object {
+                                                    "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
+                                                    "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+                                                  },
+                                                  Object {
+                                                    "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
+                                                    "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
+                                                  },
+                                                ],
                                                 "selectedSystemIds": Array [],
                                               }
                                             }
@@ -11140,6 +11222,10 @@ Try changing your filter settings.
                                                     Object {
                                                       "onClick": [Function],
                                                       "title": "Select page (0)",
+                                                    },
+                                                    Object {
+                                                      "onClick": [Function],
+                                                      "title": "Deselect page (0)",
                                                     },
                                                   ],
                                                   "onSelect": [Function],
@@ -11188,6 +11274,10 @@ Try changing your filter settings.
                                                       Object {
                                                         "onClick": [Function],
                                                         "title": "Select page (0)",
+                                                      },
+                                                      Object {
+                                                        "onClick": [Function],
+                                                        "title": "Deselect page (0)",
                                                       },
                                                     ],
                                                     "onSelect": [Function],
@@ -11251,6 +11341,10 @@ Try changing your filter settings.
                                                                 "onClick": [Function],
                                                                 "title": "Select page (0)",
                                                               },
+                                                              Object {
+                                                                "onClick": [Function],
+                                                                "title": "Deselect page (0)",
+                                                              },
                                                             ],
                                                             "onSelect": [Function],
                                                           }
@@ -11301,6 +11395,10 @@ Try changing your filter settings.
                                                           Object {
                                                             "onClick": [Function],
                                                             "title": "Select page (0)",
+                                                          },
+                                                          Object {
+                                                            "onClick": [Function],
+                                                            "title": "Deselect page (0)",
                                                           },
                                                         ],
                                                         "onSelect": [Function],
@@ -11395,6 +11493,10 @@ Try changing your filter settings.
                                                                   "onClick": [Function],
                                                                   "title": "Select page (0)",
                                                                 },
+                                                                Object {
+                                                                  "onClick": [Function],
+                                                                  "title": "Deselect page (0)",
+                                                                },
                                                               ],
                                                               "onSelect": [Function],
                                                             }
@@ -11445,6 +11547,10 @@ Try changing your filter settings.
                                                             Object {
                                                               "onClick": [Function],
                                                               "title": "Select page (0)",
+                                                            },
+                                                            Object {
+                                                              "onClick": [Function],
+                                                              "title": "Deselect page (0)",
                                                             },
                                                           ],
                                                           "onSelect": [Function],
@@ -11536,6 +11642,10 @@ Try changing your filter settings.
                                                               Object {
                                                                 "onClick": [Function],
                                                                 "title": "Select page (0)",
+                                                              },
+                                                              Object {
+                                                                "onClick": [Function],
+                                                                "title": "Deselect page (0)",
                                                               },
                                                             ],
                                                             "onSelect": [Function],
@@ -15772,6 +15882,16 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
           disableSystemTable={[Function]}
           entities={
             Object {
+              "rows": Array [
+                Object {
+                  "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
+                  "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+                },
+                Object {
+                  "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
+                  "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
+                },
+              ],
               "selectedSystemIds": Array [],
             }
           }
@@ -16999,6 +17119,16 @@ Try changing your filter settings.
                                                 <SelectedBasket
                                                   entities={
                                                     Object {
+                                                      "rows": Array [
+                                                        Object {
+                                                          "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
+                                                          "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+                                                        },
+                                                        Object {
+                                                          "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
+                                                          "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
+                                                        },
+                                                      ],
                                                       "selectedSystemIds": Array [],
                                                     }
                                                   }
@@ -17027,6 +17157,16 @@ Try changing your filter settings.
                                                           <SelectedTable
                                                             entities={
                                                               Object {
+                                                                "rows": Array [
+                                                                  Object {
+                                                                    "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
+                                                                    "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+                                                                  },
+                                                                  Object {
+                                                                    "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
+                                                                    "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
+                                                                  },
+                                                                ],
                                                                 "selectedSystemIds": Array [],
                                                               }
                                                             }
@@ -17122,6 +17262,16 @@ Try changing your filter settings.
                                                                   <SelectedTable
                                                                     entities={
                                                                       Object {
+                                                                        "rows": Array [
+                                                                          Object {
+                                                                            "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
+                                                                            "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+                                                                          },
+                                                                          Object {
+                                                                            "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
+                                                                            "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
+                                                                          },
+                                                                        ],
                                                                         "selectedSystemIds": Array [],
                                                                       }
                                                                     }
@@ -17405,6 +17555,16 @@ Try changing your filter settings.
                                         <Memo(Connect(SystemsTable))
                                           entities={
                                             Object {
+                                              "rows": Array [
+                                                Object {
+                                                  "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
+                                                  "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+                                                },
+                                                Object {
+                                                  "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
+                                                  "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
+                                                },
+                                              ],
                                               "selectedSystemIds": Array [],
                                             }
                                           }
@@ -17438,6 +17598,16 @@ Try changing your filter settings.
                                           <Memo(Connect(SystemsTable))
                                             entities={
                                               Object {
+                                                "rows": Array [
+                                                  Object {
+                                                    "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
+                                                    "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+                                                  },
+                                                  Object {
+                                                    "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
+                                                    "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
+                                                  },
+                                                ],
                                                 "selectedSystemIds": Array [],
                                               }
                                             }
@@ -17472,6 +17642,16 @@ Try changing your filter settings.
                                         <Connect(SystemsTable)
                                           entities={
                                             Object {
+                                              "rows": Array [
+                                                Object {
+                                                  "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
+                                                  "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+                                                },
+                                                Object {
+                                                  "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
+                                                  "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
+                                                },
+                                              ],
                                               "selectedSystemIds": Array [],
                                             }
                                           }
@@ -17492,6 +17672,16 @@ Try changing your filter settings.
                                             driftClearFilters={[Function]}
                                             entities={
                                               Object {
+                                                "rows": Array [
+                                                  Object {
+                                                    "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
+                                                    "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+                                                  },
+                                                  Object {
+                                                    "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
+                                                    "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
+                                                  },
+                                                ],
                                                 "selectedSystemIds": Array [],
                                               }
                                             }
@@ -17527,6 +17717,10 @@ Try changing your filter settings.
                                                     Object {
                                                       "onClick": [Function],
                                                       "title": "Select page (0)",
+                                                    },
+                                                    Object {
+                                                      "onClick": [Function],
+                                                      "title": "Deselect page (0)",
                                                     },
                                                   ],
                                                   "onSelect": [Function],
@@ -17575,6 +17769,10 @@ Try changing your filter settings.
                                                       Object {
                                                         "onClick": [Function],
                                                         "title": "Select page (0)",
+                                                      },
+                                                      Object {
+                                                        "onClick": [Function],
+                                                        "title": "Deselect page (0)",
                                                       },
                                                     ],
                                                     "onSelect": [Function],
@@ -17638,6 +17836,10 @@ Try changing your filter settings.
                                                                 "onClick": [Function],
                                                                 "title": "Select page (0)",
                                                               },
+                                                              Object {
+                                                                "onClick": [Function],
+                                                                "title": "Deselect page (0)",
+                                                              },
                                                             ],
                                                             "onSelect": [Function],
                                                           }
@@ -17688,6 +17890,10 @@ Try changing your filter settings.
                                                           Object {
                                                             "onClick": [Function],
                                                             "title": "Select page (0)",
+                                                          },
+                                                          Object {
+                                                            "onClick": [Function],
+                                                            "title": "Deselect page (0)",
                                                           },
                                                         ],
                                                         "onSelect": [Function],
@@ -17782,6 +17988,10 @@ Try changing your filter settings.
                                                                   "onClick": [Function],
                                                                   "title": "Select page (0)",
                                                                 },
+                                                                Object {
+                                                                  "onClick": [Function],
+                                                                  "title": "Deselect page (0)",
+                                                                },
                                                               ],
                                                               "onSelect": [Function],
                                                             }
@@ -17832,6 +18042,10 @@ Try changing your filter settings.
                                                             Object {
                                                               "onClick": [Function],
                                                               "title": "Select page (0)",
+                                                            },
+                                                            Object {
+                                                              "onClick": [Function],
+                                                              "title": "Deselect page (0)",
                                                             },
                                                           ],
                                                           "onSelect": [Function],
@@ -22107,6 +22321,16 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
           disableSystemTable={[Function]}
           entities={
             Object {
+              "rows": Array [
+                Object {
+                  "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
+                  "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+                },
+                Object {
+                  "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
+                  "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
+                },
+              ],
               "selectedSystemIds": Array [],
             }
           }
@@ -23348,6 +23572,16 @@ Try changing your filter settings.
                                                 <SelectedBasket
                                                   entities={
                                                     Object {
+                                                      "rows": Array [
+                                                        Object {
+                                                          "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
+                                                          "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+                                                        },
+                                                        Object {
+                                                          "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
+                                                          "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
+                                                        },
+                                                      ],
                                                       "selectedSystemIds": Array [],
                                                     }
                                                   }
@@ -23376,6 +23610,16 @@ Try changing your filter settings.
                                                           <SelectedTable
                                                             entities={
                                                               Object {
+                                                                "rows": Array [
+                                                                  Object {
+                                                                    "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
+                                                                    "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+                                                                  },
+                                                                  Object {
+                                                                    "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
+                                                                    "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
+                                                                  },
+                                                                ],
                                                                 "selectedSystemIds": Array [],
                                                               }
                                                             }
@@ -23471,6 +23715,16 @@ Try changing your filter settings.
                                                                   <SelectedTable
                                                                     entities={
                                                                       Object {
+                                                                        "rows": Array [
+                                                                          Object {
+                                                                            "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
+                                                                            "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+                                                                          },
+                                                                          Object {
+                                                                            "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
+                                                                            "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
+                                                                          },
+                                                                        ],
                                                                         "selectedSystemIds": Array [],
                                                                       }
                                                                     }
@@ -23754,6 +24008,16 @@ Try changing your filter settings.
                                         <Memo(Connect(SystemsTable))
                                           entities={
                                             Object {
+                                              "rows": Array [
+                                                Object {
+                                                  "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
+                                                  "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+                                                },
+                                                Object {
+                                                  "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
+                                                  "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
+                                                },
+                                              ],
                                               "selectedSystemIds": Array [],
                                             }
                                           }
@@ -23787,6 +24051,16 @@ Try changing your filter settings.
                                           <Memo(Connect(SystemsTable))
                                             entities={
                                               Object {
+                                                "rows": Array [
+                                                  Object {
+                                                    "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
+                                                    "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+                                                  },
+                                                  Object {
+                                                    "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
+                                                    "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
+                                                  },
+                                                ],
                                                 "selectedSystemIds": Array [],
                                               }
                                             }
@@ -23821,6 +24095,16 @@ Try changing your filter settings.
                                         <Connect(SystemsTable)
                                           entities={
                                             Object {
+                                              "rows": Array [
+                                                Object {
+                                                  "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
+                                                  "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+                                                },
+                                                Object {
+                                                  "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
+                                                  "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
+                                                },
+                                              ],
                                               "selectedSystemIds": Array [],
                                             }
                                           }
@@ -23841,6 +24125,16 @@ Try changing your filter settings.
                                             driftClearFilters={[Function]}
                                             entities={
                                               Object {
+                                                "rows": Array [
+                                                  Object {
+                                                    "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
+                                                    "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
+                                                  },
+                                                  Object {
+                                                    "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
+                                                    "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
+                                                  },
+                                                ],
                                                 "selectedSystemIds": Array [],
                                               }
                                             }

--- a/src/SmartComponents/AddSystemModal/redux/__tests__/addSystemModalReducer.fixtures.js
+++ b/src/SmartComponents/AddSystemModal/redux/__tests__/addSystemModalReducer.fixtures.js
@@ -22,6 +22,18 @@ const systemContent2 = ([
     }
 ]);
 
+const systemContent3 = ([
+    {
+        id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2',
+        icon: <ServerIcon />,
+        name: 'ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com'
+    }
+]);
+
+const systems1 = ([
+    { id: '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9' }
+]);
+
 const baselineContent1 = ([
     { id: 'abcd1234', icon: <BlueprintIcon />, name: 'baseline1' }
 ]);
@@ -44,6 +56,10 @@ const baselineContent3 = ([
     }
 ]);
 
+const baselines1 = ([
+    { id: 'fdmk59dj-fn42-dfjk-alv3-bmn2854mnn29' }
+]);
+
 const hspContent1 = ({
     system_name: 'system1',
     captured_date: '2019-01-15T14:53:15.886891Z',
@@ -57,6 +73,25 @@ const hspContent2 = ({
     id: 'edmk59dj-fn42-dfjk-alv3-bmn2854mnn27',
     system_id: '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9'
 });
+
+const hspContent3 = ([
+    {
+        system_name: 'system1',
+        captured_date: '2019-01-15T14:53:15.886891Z',
+        id: '9bbbefcc-8f23-4d97-07f2-142asdl234e8',
+        system_id: '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9'
+    },
+    {
+        system_name: 'system1',
+        captured_date: '2019-01-15T15:25:16.304899Z',
+        id: 'edmk59dj-fn42-dfjk-alv3-bmn2854mnn27',
+        system_id: '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9'
+    }
+]);
+
+const historicalProfiles1 = ([
+    { id: 'edmk59dj-fn42-dfjk-alv3-bmn2854mnn27' }
+]);
 
 const data1 = ({
     id: '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9', selected: true
@@ -78,11 +113,16 @@ const rows = ([
 export default {
     systemContent1,
     systemContent2,
+    systemContent3,
+    systems1,
     baselineContent1,
     baselineContent2,
     baselineContent3,
+    baselines1,
     hspContent1,
     hspContent2,
+    hspContent3,
+    historicalProfiles1,
     data1,
     data2,
     data3,

--- a/src/SmartComponents/AddSystemModal/redux/helpers.js
+++ b/src/SmartComponents/AddSystemModal/redux/helpers.js
@@ -20,9 +20,12 @@ function makeSelections(content, isSelected, selectedContent) {
         }
     } else {
         newSelectedContent = [ ...selectedContent ];
+        let selectedContentIds = selectedContent.map(selectedItem => selectedItem.id);
 
         content.forEach(function(item) {
-            newSelectedContent.push(item);
+            if (!selectedContentIds.includes(item.id)) {
+                newSelectedContent.push(item);
+            }
         });
     }
 

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -20,7 +20,6 @@ export const SystemsTable = ({
     driftClearFilters,
     entities,
     hasHistoricalDropdown,
-    //hasInventoryReadPermissions,
     permissions,
     hasMultiSelect,
     historicalProfiles,
@@ -43,6 +42,11 @@ export const SystemsTable = ({
         switch (event) {
             case 'none': {
                 toSelect = { id: 0, selected: false, bulk: true };
+                break;
+            }
+
+            case 'deselect-page': {
+                toSelect = { id: 0, selected: false };
                 break;
             }
 
@@ -115,7 +119,7 @@ export const SystemsTable = ({
                     } }
                 bulkSelect={ onSelect && !isAddSystemNotifications && {
                     isDisabled: !hasMultiSelect,
-                    count: entities && entities.selectedSystemIds ? entities.selectedSystemIds.length : 0,
+                    count: entities?.selectedSystemIds?.length,
                     items: [{
                         title: `Select none (0)`,
                         onClick: () => {
@@ -126,9 +130,18 @@ export const SystemsTable = ({
                         onClick: () => {
                             onSelect('page');
                         }
+                    }, {
+                        title: `Deselect page (${ entities?.count || 0 })`,
+                        onClick: () => {
+                            onSelect('deselect-page');
+                        }
                     }],
-                    onSelect: (value) => {
-                        value ? onSelect('page') : onSelect('none');
+                    onSelect: () => {
+                        if (entities?.rows.length === entities?.selectedSystems?.length) {
+                            onSelect('deselect-page');
+                        } else {
+                            onSelect('page');
+                        }
                     },
                     checked: entities && entities.selectedSystemIds
                         ? helpers.findCheckedValue(entities?.total, entities?.selectedSystemIds.length)
@@ -154,7 +167,6 @@ SystemsTable.propTypes = {
     historicalProfiles: PropTypes.array,
     hasMultiSelect: PropTypes.bool,
     updateColumns: PropTypes.func,
-    //hasInventoryReadPermissions: PropTypes.bool,
     permissions: PropTypes.object,
     entities: PropTypes.object,
     selectEntities: PropTypes.func,

--- a/src/SmartComponents/SystemsTable/__tests__/__snapshots__/SystemsTable.tests.js.snap
+++ b/src/SmartComponents/SystemsTable/__tests__/__snapshots__/SystemsTable.tests.js.snap
@@ -73,7 +73,7 @@ exports[`ConnectedSystemsTable should render correctly 1`] = `
             bulkSelect={
               Object {
                 "checked": null,
-                "count": 0,
+                "count": undefined,
                 "isDisabled": true,
                 "items": Array [
                   Object {
@@ -83,6 +83,10 @@ exports[`ConnectedSystemsTable should render correctly 1`] = `
                   Object {
                     "onClick": [Function],
                     "title": "Select page (0)",
+                  },
+                  Object {
+                    "onClick": [Function],
+                    "title": "Deselect page (0)",
                   },
                 ],
                 "onSelect": [Function],
@@ -121,7 +125,7 @@ exports[`ConnectedSystemsTable should render correctly 1`] = `
               bulkSelect={
                 Object {
                   "checked": null,
-                  "count": 0,
+                  "count": undefined,
                   "isDisabled": true,
                   "items": Array [
                     Object {
@@ -131,6 +135,10 @@ exports[`ConnectedSystemsTable should render correctly 1`] = `
                     Object {
                       "onClick": [Function],
                       "title": "Select page (0)",
+                    },
+                    Object {
+                      "onClick": [Function],
+                      "title": "Deselect page (0)",
                     },
                   ],
                   "onSelect": [Function],
@@ -183,7 +191,7 @@ exports[`ConnectedSystemsTable should render correctly 1`] = `
                       bulkSelect={
                         Object {
                           "checked": null,
-                          "count": 0,
+                          "count": undefined,
                           "isDisabled": true,
                           "items": Array [
                             Object {
@@ -193,6 +201,10 @@ exports[`ConnectedSystemsTable should render correctly 1`] = `
                             Object {
                               "onClick": [Function],
                               "title": "Select page (0)",
+                            },
+                            Object {
+                              "onClick": [Function],
+                              "title": "Deselect page (0)",
                             },
                           ],
                           "onSelect": [Function],
@@ -234,7 +246,7 @@ exports[`ConnectedSystemsTable should render correctly 1`] = `
                   bulkSelect={
                     Object {
                       "checked": null,
-                      "count": 0,
+                      "count": undefined,
                       "isDisabled": true,
                       "items": Array [
                         Object {
@@ -244,6 +256,10 @@ exports[`ConnectedSystemsTable should render correctly 1`] = `
                         Object {
                           "onClick": [Function],
                           "title": "Select page (0)",
+                        },
+                        Object {
+                          "onClick": [Function],
+                          "title": "Deselect page (0)",
                         },
                       ],
                       "onSelect": [Function],
@@ -327,7 +343,7 @@ exports[`ConnectedSystemsTable should render correctly 1`] = `
                         bulkSelect={
                           Object {
                             "checked": null,
-                            "count": 0,
+                            "count": undefined,
                             "isDisabled": true,
                             "items": Array [
                               Object {
@@ -337,6 +353,10 @@ exports[`ConnectedSystemsTable should render correctly 1`] = `
                               Object {
                                 "onClick": [Function],
                                 "title": "Select page (0)",
+                              },
+                              Object {
+                                "onClick": [Function],
+                                "title": "Deselect page (0)",
                               },
                             ],
                             "onSelect": [Function],
@@ -378,7 +398,7 @@ exports[`ConnectedSystemsTable should render correctly 1`] = `
                     bulkSelect={
                       Object {
                         "checked": null,
-                        "count": 0,
+                        "count": undefined,
                         "isDisabled": true,
                         "items": Array [
                           Object {
@@ -388,6 +408,10 @@ exports[`ConnectedSystemsTable should render correctly 1`] = `
                           Object {
                             "onClick": [Function],
                             "title": "Select page (0)",
+                          },
+                          Object {
+                            "onClick": [Function],
+                            "title": "Deselect page (0)",
                           },
                         ],
                         "onSelect": [Function],

--- a/src/SmartComponents/helpers.js
+++ b/src/SmartComponents/helpers.js
@@ -1,8 +1,24 @@
 import React from 'react';
-import { CloseIcon, HistoryIcon } from '@patternfly/react-icons';
+import { CloseIcon, HistoryIcon, ServerIcon } from '@patternfly/react-icons';
 import moment from 'moment';
 import baselinesTableHelpers from './BaselinesTable/redux/helpers';
 import editBaselineHelpers from './BaselinesPage/EditBaselinePage/EditBaseline/helpers';
+
+function findSelectedOnPage(rows, selectedSystemIds) {
+    let selectedSystems = [];
+
+    rows.forEach(function(row) {
+        if (selectedSystemIds.includes(row.id)) {
+            row.selected = true;
+        }
+
+        if (row.selected) {
+            selectedSystems.push({ id: row.id, name: row.display_name, icon: <ServerIcon /> });
+        }
+    });
+
+    return selectedSystems;
+}
 
 function findCheckedValue(total, selected) {
     if (selected === total && total > 0) {
@@ -91,6 +107,7 @@ function downloadCSV(baselineData) {
 }
 
 export default {
+    findSelectedOnPage,
     findCheckedValue,
     paginateData,
     buildSystemsTableWithSelectedHSP,

--- a/src/store/__tests__/reducer-test.js
+++ b/src/store/__tests__/reducer-test.js
@@ -34,7 +34,8 @@ describe('compare reducer', () => {
         ).toEqual({
             rows: fixtures.results,
             columns: fixtures.columns,
-            selectedSystemIds: []
+            selectedSystemIds: [],
+            selectedSystems: []
         });
     });
 
@@ -61,7 +62,8 @@ describe('compare reducer', () => {
         ).toEqual({
             rows: fixtures.results,
             columns: fixtures.columnsWithHSP,
-            selectedSystemIds: []
+            selectedSystemIds: [],
+            selectedSystems: []
         });
     });
 
@@ -88,7 +90,8 @@ describe('compare reducer', () => {
         ).toEqual({
             rows: fixtures.results,
             columns: fixtures.columns,
-            selectedSystemIds: []
+            selectedSystemIds: [],
+            selectedSystems: []
         });
     });
 

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -4,7 +4,6 @@ import { mergeArraysByKey } from '@redhat-cloud-services/frontend-components-uti
 import { applyReducerHash } from '@redhat-cloud-services/frontend-components-utilities/files/ReducerRegistry';
 import HistoricalProfilesPopover from '../SmartComponents/HistoricalProfilesPopover/HistoricalProfilesPopover';
 import SystemKebab from '../SmartComponents/BaselinesPage/EditBaselinePage/SystemNotification/SystemKebab/SystemKebab';
-import { ServerIcon } from '@patternfly/react-icons';
 
 import types from '../SmartComponents/modules/types';
 import helpers from '../SmartComponents/helpers';
@@ -146,7 +145,8 @@ function selectedReducer(
                 columns: newColumns,
                 rows: state.selectedHSP && !hasMultiSelect
                     ? helpers.buildSystemsTableWithSelectedHSP(rows, state.selectedHSP, deselectHistoricalProfiles)
-                    : rows
+                    : rows,
+                selectedSystems: helpers.findSelectedOnPage(rows, state.selectedSystemIds)
             };
         },
         [types.DRIFT_CLEAR_ALL_FILTERS]: (state) => ({
@@ -224,15 +224,7 @@ function selectedReducer(
             }
 
             if (newRows.length === 0) {
-                state.rows.forEach(function(row) {
-                    if (selectedSystemIds.includes(row.id)) {
-                        row.selected = true;
-                    }
-
-                    if (row.selected) {
-                        selectedSystems.push({ id: row.id, name: row.display_name, icon: <ServerIcon /> });
-                    }
-                });
+                selectedSystems = helpers.findSelectedOnPage(state.rows, selectedSystemIds);
             }
 
             return {


### PR DESCRIPTION
To test:

- Navigate to Add to comparison modal
- Click Bulk Selector to select all
- click the Bulk Selector again

The full set of systems on page is added every time we click, making the basket contain duplicates. If we then remove a system from basket, also it's duplicate is removed.

This PR makes sure that when a system, baseline or historical profile is selected, but not compared, and you back out of the add system modal screen, those items are removed from the basket and all selections in the table, when you return to the add system modal, are removed.

This PR also ensures that the bulk selector properly adds and removes systems to the selected basket in the top right corner of the add system modal.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
