### PR TITLE
[DRFT-469] Fix errors with basket items not being added or removed

### DIFF
--- a/src/SmartComponents/AddSystemModal/AddSystemModal.js
+++ b/src/SmartComponents/AddSystemModal/AddSystemModal.js
@@ -131,7 +131,9 @@ export class AddSystemModal extends Component {
         if (comparedContent.length === 0) {
             return basketContent;
         } else {
-            return basketContent.filter(item => comparedContent.some(({ id }) => id !== item.id));
+            return basketContent.filter(basketItem => (
+                comparedContent.findIndex(comparedItem => (basketItem.id === comparedItem.id)) === -1
+            ));
         }
     }
 

--- a/src/SmartComponents/AddSystemModal/__tests__/AddSystemModal.tests.js
+++ b/src/SmartComponents/AddSystemModal/__tests__/AddSystemModal.tests.js
@@ -252,6 +252,40 @@ describe('AddSystemModal', () => {
         wrapper.instance().setSelectedContent();
         expect(props.handleSystemSelection).toHaveBeenCalledWith(modalFixtures.systemContent3, false);
     });
+
+    it('should return basket content if no items in comparedContent', () => {
+        let basketContent = modalFixtures.systemContent1;
+        const wrapper = shallow(
+            <AddSystemModal
+                { ...props }
+            />
+        );
+
+        expect(wrapper.instance().findNotInComparison(basketContent, [])).toEqual(basketContent);
+    });
+
+    it('should return empty if no items in basketContent', () => {
+        let comparedContent = modalFixtures.systems2;
+        const wrapper = shallow(
+            <AddSystemModal
+                { ...props }
+            />
+        );
+
+        expect(wrapper.instance().findNotInComparison([], comparedContent)).toEqual([]);
+    });
+
+    it('should return systems to be removed', () => {
+        let basketContent = modalFixtures.systemContent1;
+        let comparedContent = modalFixtures.systems3;
+        const wrapper = shallow(
+            <AddSystemModal
+                { ...props }
+            />
+        );
+
+        expect(wrapper.instance().findNotInComparison(basketContent, comparedContent)).toEqual(modalFixtures.systemContent2);
+    });
 });
 
 describe('ConnectedAddSystemModal', () => {

--- a/src/SmartComponents/AddSystemModal/redux/__tests__/addSystemModalReducer.fixtures.js
+++ b/src/SmartComponents/AddSystemModal/redux/__tests__/addSystemModalReducer.fixtures.js
@@ -34,6 +34,15 @@ const systems1 = ([
     { id: '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9' }
 ]);
 
+const systems2 = ([
+    { id: '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9' },
+    { id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2' }
+]);
+
+const systems3 = ([
+    { id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2' }
+]);
+
 const baselineContent1 = ([
     { id: 'abcd1234', icon: <BlueprintIcon />, name: 'baseline1' }
 ]);
@@ -115,6 +124,8 @@ export default {
     systemContent2,
     systemContent3,
     systems1,
+    systems2,
+    systems3,
     baselineContent1,
     baselineContent2,
     baselineContent3,


### PR DESCRIPTION
There are 2 issues.

First, baseline selections are being properly saved. To repro:
add two baselines to comparison
open the add system modal

You should see that the 2 baselines are in the systems basket, but aren't selected in the table.

Second, reference gets removed from comparison with the following actions:
add two baselines to comparison
then add another system or baseline to comparison

Because the baseline selections are empty after second entry into add system modal, the reference id is not present in the comparison.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
