### PR TITLE
[DRFT-246] Make baselines filter empty state 2 lines

### DIFF
--- a/src/SmartComponents/AddSystemModal/__tests__/__snapshots__/AddSystemModal.tests.js.snap
+++ b/src/SmartComponents/AddSystemModal/__tests__/__snapshots__/AddSystemModal.tests.js.snap
@@ -10124,7 +10124,9 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                             class="pf-c-empty-state__body"
                                           >
                                             This filter criteria matches no baselines.
-Try changing your filter settings.
+                                            <br />
+                                            Try changing your filter settings.
+                                            <br />
                                           </div>
                                         </div>
                                       </div>
@@ -14877,7 +14879,9 @@ Try changing your filter settings.
                                                                                                         className="pf-c-empty-state__body"
                                                                                                       >
                                                                                                         This filter criteria matches no baselines.
-Try changing your filter settings.
+                                                                                                        <br />
+                                                                                                        Try changing your filter settings.
+                                                                                                        <br />
                                                                                                       </div>
                                                                                                     </EmptyStateBody>
                                                                                                   </div>
@@ -16631,7 +16635,9 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                             class="pf-c-empty-state__body"
                                           >
                                             This filter criteria matches no baselines.
-Try changing your filter settings.
+                                            <br />
+                                            Try changing your filter settings.
+                                            <br />
                                           </div>
                                         </div>
                                       </div>
@@ -21328,7 +21334,9 @@ Try changing your filter settings.
                                                                                                         className="pf-c-empty-state__body"
                                                                                                       >
                                                                                                         This filter criteria matches no baselines.
-Try changing your filter settings.
+                                                                                                        <br />
+                                                                                                        Try changing your filter settings.
+                                                                                                        <br />
                                                                                                       </div>
                                                                                                     </EmptyStateBody>
                                                                                                   </div>
@@ -22665,6 +22673,7 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                   class="pf-c-empty-state__body"
                                 >
                                   Contact your organization administrator(s) for more information.
+                                  <br />
                                 </div>
                               </div>
                             </div>
@@ -23096,7 +23105,9 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                             class="pf-c-empty-state__body"
                                           >
                                             This filter criteria matches no baselines.
-Try changing your filter settings.
+                                            <br />
+                                            Try changing your filter settings.
+                                            <br />
                                           </div>
                                         </div>
                                       </div>
@@ -24248,6 +24259,7 @@ Try changing your filter settings.
                                                         className="pf-c-empty-state__body"
                                                       >
                                                         Contact your organization administrator(s) for more information.
+                                                        <br />
                                                       </div>
                                                     </EmptyStateBody>
                                                   </div>
@@ -27416,7 +27428,9 @@ Try changing your filter settings.
                                                                                                         className="pf-c-empty-state__body"
                                                                                                       >
                                                                                                         This filter criteria matches no baselines.
-Try changing your filter settings.
+                                                                                                        <br />
+                                                                                                        Try changing your filter settings.
+                                                                                                        <br />
                                                                                                       </div>
                                                                                                     </EmptyStateBody>
                                                                                                   </div>

--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/SystemNotification/__tests__/__snapshots__/SystemNotification.tests.js.snap
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/SystemNotification/__tests__/__snapshots__/SystemNotification.tests.js.snap
@@ -408,6 +408,7 @@ exports[`ConnectedSystemNotification should render correctly 1`] = `
                               className="pf-c-empty-state__body"
                             >
                               Contact your organization administrator(s) for more information.
+                              <br />
                             </div>
                           </EmptyStateBody>
                         </div>

--- a/src/SmartComponents/BaselinesPage/__tests__/__snapshots__/BaselinesPage.tests.js.snap
+++ b/src/SmartComponents/BaselinesPage/__tests__/__snapshots__/BaselinesPage.tests.js.snap
@@ -4499,7 +4499,9 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                                                                                             className="pf-c-empty-state__body"
                                                                                           >
                                                                                             This filter criteria matches no baselines.
-Try changing your filter settings.
+                                                                                            <br />
+                                                                                            Try changing your filter settings.
+                                                                                            <br />
                                                                                           </div>
                                                                                         </EmptyStateBody>
                                                                                       </div>
@@ -5882,7 +5884,9 @@ exports[`ConnectedBaselinesPage should render empty state 1`] = `
                               className="pf-c-empty-state__body"
                             >
                               You currently have no baselines displayed.
-Create a baseline to use in your Comparison analysis.
+                              <br />
+                              Create a baseline to use in your Comparison analysis.
+                              <br />
                             </div>
                           </EmptyStateBody>
                           <withRouter(Connect(CreateBaselineButton))

--- a/src/SmartComponents/BaselinesTable/__tests__/__snapshots__/BaselinesTable.tests.js.snap
+++ b/src/SmartComponents/BaselinesTable/__tests__/__snapshots__/BaselinesTable.tests.js.snap
@@ -47160,7 +47160,9 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                                                       className="pf-c-empty-state__body"
                                                                     >
                                                                       This filter criteria matches no baselines.
-Try changing your filter settings.
+                                                                      <br />
+                                                                      Try changing your filter settings.
+                                                                      <br />
                                                                     </div>
                                                                   </EmptyStateBody>
                                                                 </div>

--- a/src/SmartComponents/EmptyStateDisplay/EmptyStateDisplay.js
+++ b/src/SmartComponents/EmptyStateDisplay/EmptyStateDisplay.js
@@ -15,6 +15,7 @@ export class EmptyStateDisplay extends Component {
     render() {
         const { button, color, error, icon, isSmall, text, title } = this.props;
 
+        /*eslint-disable react/jsx-key*/
         return (
             <EmptyState variant={ isSmall ? EmptyStateVariant.small : EmptyStateVariant.large }>
                 { icon
@@ -33,12 +34,19 @@ export class EmptyStateDisplay extends Component {
                     { title }
                 </Title>
                 <EmptyStateBody>
-                    { text ? text.join('\n') : null }
+                    { text ? text.map(line =>
+                        <React.Fragment>
+                            { line }
+                            <br />
+                        </React.Fragment>)
+                        : null
+                    }
                     { error ? error : null }
                 </EmptyStateBody>
                 { button }
             </EmptyState>
         );
+        /*eslint-enable react/jsx-key*/
     }
 }
 

--- a/src/SmartComponents/SystemsTable/__tests__/__snapshots__/SystemsTable.tests.js.snap
+++ b/src/SmartComponents/SystemsTable/__tests__/__snapshots__/SystemsTable.tests.js.snap
@@ -664,6 +664,7 @@ exports[`ConnectedSystemsTable should render correctly with no inventory read pe
                       className="pf-c-empty-state__body"
                     >
                       Contact your organization administrator(s) for more information.
+                      <br />
                     </div>
                   </EmptyStateBody>
                 </div>


### PR DESCRIPTION
To repro:
Go to baselines page
Filter so nothing matches

You'll see that the line doesn't break at the sentence change. With this change, the line will break after the first period.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
