### PR TITLE
[DRFT-608] Make filters case-insensitive

### DIFF
--- a/src/SmartComponents/modules/__tests__/helpers-tests.js
+++ b/src/SmartComponents/modules/__tests__/helpers-tests.js
@@ -1,8 +1,8 @@
 import helpers from '../helpers';
 import stateFiltersFixtures from './state-filter.fixtures';
-import { compareReducerPayloadWithCategory, compareReducerPayloadWithMultiFact,
-    sortedPayloadWithMultiFactAscDesc, sortedPayloadWithMultiFactAscAsc } from './reducer.fixtures';
-import { filteredCategory, filteredCategoryAndFact } from './reducer.fact-filter-fixtures';
+import { compareReducerPayloadWithCategory, compareReducerPayloadWithMultiFact, compareReducerPayloadWithUppercase,
+    sortedPayloadWithMultiFactAscDesc, sortedPayloadWithMultiFactAscAsc, compareReducerPayloadWithUpperCaseSubFact } from './reducer.fixtures';
+import { filteredCategory, filteredCategoryAndFact, filteredUpperCaseFact, filteredUpperCaseSubFact } from './reducer.fact-filter-fixtures';
 import { multivalues, comparisonsWithMultivalues, multivaluesWithTooltips, comparisonsWithMultivaluesTooltips } from './multiFact-filter-fixtures';
 
 describe('helpers', () => {
@@ -85,6 +85,18 @@ describe('helpers', () => {
         ).toEqual(filteredCategoryAndFact);
     });
 
+    it('should return uppercase fact name with lowercase fact filter', () => {
+        const data = compareReducerPayloadWithUppercase.facts;
+        const stateFilters = stateFiltersFixtures.allStatesTrue;
+        const factFilter = 'cpus';
+        const referenceId = undefined;
+        const activeFactFilters = [];
+
+        expect(
+            helpers.filterCompareData(data, stateFilters, factFilter, referenceId, activeFactFilters)
+        ).toEqual(filteredUpperCaseFact);
+    });
+
     it('should filterComparisons with multivalues with all states true', () => {
         const comparisons = comparisonsWithMultivalues;
         const stateFilters = stateFiltersFixtures.allStatesTrue;
@@ -95,6 +107,18 @@ describe('helpers', () => {
         expect(
             helpers.filterComparisons(comparisons, stateFilters, factFilter, referenceId, activeFactFilters)
         ).toEqual(comparisonsWithMultivaluesTooltips);
+    });
+
+    it('should filterCompareData with upper case sub fact', () => {
+        const data = compareReducerPayloadWithUpperCaseSubFact.facts;
+        const stateFilters = stateFiltersFixtures.allStatesTrue;
+        const factFilter = 'abm';
+        const referenceId = undefined;
+        const activeFactFilters = [];
+
+        expect(
+            helpers.filterCompareData(data, stateFilters, factFilter, referenceId, activeFactFilters)
+        ).toEqual(filteredUpperCaseSubFact);
     });
 
     it('should filterMultiFacts with all states true', () => {

--- a/src/SmartComponents/modules/__tests__/reducer.fact-filter-fixtures.js
+++ b/src/SmartComponents/modules/__tests__/reducer.fact-filter-fixtures.js
@@ -236,4 +236,59 @@ export const filteredCategoryAndFact = ([
         tooltip: 'Different - At least one system fact value in this category differs.'
     }
 ]);
+
+export const filteredUpperCaseFact = ([
+    {
+        name: 'Cpus',
+        state: 'DIFFERENT',
+        systems: [
+            {
+                id: '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9', value: '4'
+            },
+            {
+                id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2', value: '3'
+            }
+        ],
+        tooltip: 'Different - At least one system fact value in this row differs.'
+    }
+]);
+
+export const filteredUpperCaseSubFact = ([
+    {
+        name: 'cpu_flags',
+        state: 'DIFFERENT',
+        tooltip: 'Different - At least one system fact value in this category differs.',
+        comparisons: [
+            {
+                name: 'aBM',
+                state: 'SAME',
+                tooltip: 'Same - All system facts in this row are the same.',
+                systems: [
+                    {
+                        id: '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9', value: 'enabled'
+                    },
+                    {
+                        id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2', value: 'enabled'
+                    },
+                    {
+                        id: '9bbbefcc-8f23-4d97-07f2-142asdl234e9', value: 'enabled'
+                    },
+                    {
+                        id: 'fdmk59dj-fn42-dfjk-alv3-bmn2854mnn29', value: 'enabled'
+                    },
+                    {
+                        id: '9bbbefcc-8f23-4d97-07f2-142asdl234e8',
+                        system_id: '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9',
+                        value: 'enabled'
+                    },
+                    {
+                        id: 'edmk59dj-fn42-dfjk-alv3-bmn2854mnn27',
+                        system_id: '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9',
+                        value: 'enabled'
+                    }
+                ]
+            }
+        ]
+    }
+]);
 /*eslint-enable camelcase*/

--- a/src/SmartComponents/modules/__tests__/reducer.fixtures.js
+++ b/src/SmartComponents/modules/__tests__/reducer.fixtures.js
@@ -345,6 +345,171 @@ export const compareReducerPayloadWithMultiFact = ({
     ]
 });
 
+export const compareReducerPayloadWithUppercase = ({
+    facts: [
+        {
+            name: 'Cpus',
+            state: 'DIFFERENT',
+            systems: [
+                {
+                    id: '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9', value: '4'
+                },
+                {
+                    id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2', value: '3'
+                }
+            ],
+            tooltip: 'Different - At least one system fact value in this row differs.'
+        },
+        {
+            name: 'bios_uuid',
+            state: 'SAME',
+            systems: [
+                {
+                    id: '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9', value: 'FAKE-BIOS'
+                },
+                {
+                    id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2', value: 'FAKE-BIOS'
+                }
+            ]
+        }
+    ],
+    systems: [
+        {
+            display_name: 'sgi-xe500-01.rhts.eng.bos.redhat.com',
+            id: '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9',
+            last_updated: '2019-01-15T14:53:15.886891Z'
+        },
+        {
+            display_name: 'ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com',
+            id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2',
+            last_updated: '2019-01-15T15:25:16.304899Z'
+        }
+    ]
+});
+
+export const compareReducerPayloadWithUpperCaseSubFact = ({
+    facts: [
+        {
+            name: 'cpu_flags',
+            state: 'DIFFERENT',
+            comparisons: [
+                {
+                    name: 'aBM',
+                    state: 'SAME',
+                    systems: [
+                        {
+                            id: '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9', value: 'enabled'
+                        },
+                        {
+                            id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2', value: 'enabled'
+                        },
+                        {
+                            id: '9bbbefcc-8f23-4d97-07f2-142asdl234e9', value: 'enabled'
+                        },
+                        {
+                            id: 'fdmk59dj-fn42-dfjk-alv3-bmn2854mnn29', value: 'enabled'
+                        },
+                        {
+                            id: '9bbbefcc-8f23-4d97-07f2-142asdl234e8',
+                            system_id: '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9',
+                            value: 'enabled'
+                        },
+                        {
+                            id: 'edmk59dj-fn42-dfjk-alv3-bmn2854mnn27',
+                            system_id: '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9',
+                            value: 'enabled'
+                        }
+                    ]
+                },
+                {
+                    name: 'adx',
+                    state: 'INCOMPLETE_DATA',
+                    systems: [
+                        {
+                            id: '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9', value: 'disabled'
+                        },
+                        {
+                            id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2', value: undefined
+                        },
+                        {
+                            id: '9bbbefcc-8f23-4d97-07f2-142asdl234e9', value: 'disabled'
+                        },
+                        {
+                            id: 'fdmk59dj-fn42-dfjk-alv3-bmn2854mnn29', value: undefined
+                        },
+                        {
+                            id: '9bbbefcc-8f23-4d97-07f2-142asdl234e8',
+                            system_id: '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9',
+                            value: 'disabled'
+                        },
+                        {
+                            id: 'edmk59dj-fn42-dfjk-alv3-bmn2854mnn27',
+                            system_id: '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9',
+                            value: 'disabled'
+                        }
+                    ]
+                },
+                {
+                    name: 'abc',
+                    state: 'INCOMPLETE_DATA',
+                    multivalues: [
+                        {
+                            state: 'SAME',
+                            systems: [
+                                { id: '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9', value: 'blah1' },
+                                { id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2', value: 'blah1' },
+                                { id: '9bbbefcc-8f23-4d97-07f2-142asdl234e9', value: 'blah1' },
+                                { id: 'fdmk59dj-fn42-dfjk-alv3-bmn2854mnn29', value: 'blah1' },
+                                {
+                                    id: '9bbbefcc-8f23-4d97-07f2-142asdl234e8',
+                                    system_id: '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9',
+                                    value: 'blah1'
+                                },
+                                {
+                                    id: 'edmk59dj-fn42-dfjk-alv3-bmn2854mnn27',
+                                    system_id: '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9',
+                                    value: 'blah1'
+                                }
+                            ]
+                        },
+                        {
+                            state: 'INCOMPLETE_DATA',
+                            systems: [
+                                { id: '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9', value: undefined },
+                                { id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2', value: 'blah2' },
+                                { id: '9bbbefcc-8f23-4d97-07f2-142asdl234e9', value: 'blah2' },
+                                { id: 'fdmk59dj-fn42-dfjk-alv3-bmn2854mnn29', value: 'blah2' },
+                                {
+                                    id: '9bbbefcc-8f23-4d97-07f2-142asdl234e8',
+                                    system_id: '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9',
+                                    value: undefined
+                                },
+                                {
+                                    id: 'edmk59dj-fn42-dfjk-alv3-bmn2854mnn27',
+                                    system_id: '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9',
+                                    value: undefined
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    systems: [
+        {
+            display_name: 'sgi-xe500-01.rhts.eng.bos.redhat.com',
+            id: '9c79efcc-8f9a-47c7-b0f2-142ff52e89e9',
+            last_updated: '2019-01-15T14:53:15.886891Z'
+        },
+        {
+            display_name: 'ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com',
+            id: 'f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2',
+            last_updated: '2019-01-15T15:25:16.304899Z'
+        }
+    ]
+});
+
 export const sortedPayloadWithMultiFactAscDesc = ([
     {
         name: 'cpu_flags',

--- a/src/SmartComponents/modules/helpers.js
+++ b/src/SmartComponents/modules/helpers.js
@@ -84,10 +84,11 @@ function filterCompareData(data, stateFilters, factFilter, referenceId, activeFa
     }
 
     for (let i = 0; i < data.length; i += 1) {
+        let lowerCaseFactName = data[i].name.toLowerCase();
         isStateSelected = getStateSelected(data[i].state, stateFilters);
 
         if (data[i].comparisons) {
-            if (data[i].name === factFilter || activeFactFilters?.includes(data[i].name)) {
+            if (lowerCaseFactName === factFilter || activeFactFilters?.includes(lowerCaseFactName)) {
                 setTooltip(data[i], stateFilters, referenceId);
                 filteredComparisons = filterComparisons(data[i].comparisons, stateFilters, '', referenceId, []);
                 filteredFacts.push({
@@ -112,7 +113,7 @@ function filterCompareData(data, stateFilters, factFilter, referenceId, activeFa
                 });
             }
         } else {
-            if (isStateSelected && filterFact(data[i].name, factFilter, activeFactFilters)) {
+            if (isStateSelected && filterFact(lowerCaseFactName, factFilter, activeFactFilters)) {
                 setTooltip(data[i], stateFilters, referenceId);
                 filteredFacts.push(data[i]);
             }
@@ -129,9 +130,10 @@ function filterComparisons(comparisons, stateFilters, factFilter, referenceId, a
     let isStateSelected;
 
     for (let i = 0; i < comparisons.length; i++) {
+        let lowerCaseFactName = comparisons[i].name.toLowerCase();
         if (comparisons[i].multivalues) {
             filteredMultivalueItems = filterMultiFacts(comparisons[i].multivalues, stateFilters, referenceId);
-            if (filteredMultivalueItems.length && filterFact(comparisons[i].name, factFilter, activeFactFilters)) {
+            if (filteredMultivalueItems.length && filterFact(lowerCaseFactName, factFilter, activeFactFilters)) {
                 setTooltip(comparisons[i], stateFilters, referenceId);
                 filteredComparisons.push({
                     name: comparisons[i].name,
@@ -142,7 +144,7 @@ function filterComparisons(comparisons, stateFilters, factFilter, referenceId, a
             }
         } else {
             isStateSelected = getStateSelected(comparisons[i].state, stateFilters);
-            if (isStateSelected && filterFact(comparisons[i].name, factFilter, activeFactFilters)) {
+            if (isStateSelected && filterFact(lowerCaseFactName, factFilter, activeFactFilters)) {
                 setTooltip(comparisons[i], stateFilters, referenceId);
                 filteredComparisons.push(comparisons[i]);
             }

--- a/src/SmartComponents/modules/reducers.js
+++ b/src/SmartComponents/modules/reducers.js
@@ -54,6 +54,7 @@ export function compareReducer(state = initialState, action) {
     let newActiveFactFilters = [];
     let index;
     let newFactFilter;
+    let lowerCaseFilter;
 
     switch (action.type) {
         case types.CLEAR_COMPARISON:
@@ -168,14 +169,16 @@ export function compareReducer(state = initialState, action) {
                 totalFacts: filteredFacts.length
             };
         case `${types.FILTER_BY_FACT}`:
+            lowerCaseFilter = action.payload.toLowerCase();
+
             filteredFacts = reducerHelpers.filterCompareData(
-                state.fullCompareData, state.stateFilters, action.payload, state.referenceId, state.activeFactFilters
+                state.fullCompareData, state.stateFilters, lowerCaseFilter, state.referenceId, state.activeFactFilters
             );
             sortedFacts = reducerHelpers.sortData(filteredFacts, state.factSort, state.stateSort);
             paginatedFacts = reducerHelpers.paginateData(sortedFacts, 1, state.perPage);
             return {
                 ...state,
-                factFilter: action.payload,
+                factFilter: lowerCaseFilter,
                 page: 1,
                 filteredCompareData: paginatedFacts,
                 sortedFilteredFacts: sortedFacts,


### PR DESCRIPTION
To repro:

- Create a comparison
- Use the fact name filter to filter on a fact name, but use uppercase letters instead of lowercase letters.

This should cause the fact you were trying to filter to not show up when you think it should. Now, filters are case-insensitive, so no matter if you use upper or lowercase in the filter or in the fact name, the fact name will show up.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
