### PR TITLE
[DRFT-539] Add scrollbar to top of comparison table

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -247,9 +247,20 @@
   color: #6a6a73;
 }
 
+.second-scroll-wrapper {
+  margin-left: 24px;
+  margin-right: 24px;
+  overflow-x: scroll;
+  overflow-y: hidden;
+}
+
+.second-scroll {
+  height: 12px;
+}
+
 .drift-table-wrapper {
-  overflow: auto;
-  height: 100%;
+  overflow-x: scroll;
+  overflow-y: hidden;
   min-height: 500px;
   margin-left: 24px;
   margin-right: 24px;

--- a/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
+++ b/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
@@ -34,8 +34,24 @@ export class DriftTable extends Component {
         this.setReferenceId();
         this.setFilters();
         this.setSort();
+        this.topScroller = React.createRef();
+        this.bottomScroller = React.createRef();
+        this.doubleScroll = this.doubleScroll.bind(this);
         this.fetchCompare = this.fetchCompare.bind(this);
         this.removeSystem = this.removeSystem.bind(this);
+    }
+
+    doubleScroll() {
+        let wrapper1 = this.topScroller.current;
+        let wrapper2 = this.bottomScroller.current;
+
+        wrapper1.onscroll = function() {
+            wrapper2.scrollLeft = wrapper1.scrollLeft;
+        };
+
+        wrapper2.onscroll = function() {
+            wrapper1.scrollLeft = wrapper2.scrollLeft;
+        };
     }
 
     async componentDidMount() {
@@ -540,10 +556,21 @@ export class DriftTable extends Component {
     renderTable(compareData, loading) {
         const { factSort, permissions, referenceId, selectedBaselineIds, selectedHSPIds,
             selectHistoricProfiles, setHistory, stateSort, toggleFactSort, toggleStateSort } = this.props;
+        let scrollWidth = '';
+
+        if (this.bottomScroller.current) {
+            scrollWidth = this.bottomScroller.current.scrollWidth;
+        }
 
         return (
             <React.Fragment>
-                <div className="drift-table-wrapper">
+                <div className='second-scroll-wrapper' onScroll={ this.doubleScroll } ref={ this.topScroller }>
+                    <div
+                        className='second-scroll'
+                        style={{ width: scrollWidth }}
+                    ></div>
+                </div>
+                <div className="drift-table-wrapper" onScroll={ this.doubleScroll } ref={ this.bottomScroller }>
                     <table
                         className="pf-c-table pf-m-compact drift-table"
                         data-ouia-component-type='PF4/Table'

--- a/src/SmartComponents/DriftPage/DriftTable/__tests__/__snapshots__/DriftTable.tests.js.snap
+++ b/src/SmartComponents/DriftPage/DriftTable/__tests__/__snapshots__/DriftTable.tests.js.snap
@@ -304,7 +304,21 @@ exports[`ConnectedDriftTable should render correctly 1`] = `
               </AddSystemModal>
             </Connect(AddSystemModal)>
             <div
+              className="second-scroll-wrapper"
+              onScroll={[Function]}
+            >
+              <div
+                className="second-scroll"
+                style={
+                  Object {
+                    "width": "",
+                  }
+                }
+              />
+            </div>
+            <div
               className="drift-table-wrapper"
+              onScroll={[Function]}
             >
               <table
                 className="pf-c-table pf-m-compact drift-table"
@@ -729,7 +743,21 @@ exports[`ConnectedDriftTable should render loading rows 1`] = `
               </AddSystemModal>
             </Connect(AddSystemModal)>
             <div
+              className="second-scroll-wrapper"
+              onScroll={[Function]}
+            >
+              <div
+                className="second-scroll"
+                style={
+                  Object {
+                    "width": "",
+                  }
+                }
+              />
+            </div>
+            <div
               className="drift-table-wrapper"
+              onScroll={[Function]}
             >
               <table
                 className="pf-c-table pf-m-compact drift-table"
@@ -2165,7 +2193,21 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
               </AddSystemModal>
             </Connect(AddSystemModal)>
             <div
+              className="second-scroll-wrapper"
+              onScroll={[Function]}
+            >
+              <div
+                className="second-scroll"
+                style={
+                  Object {
+                    "width": "",
+                  }
+                }
+              />
+            </div>
+            <div
               className="drift-table-wrapper"
+              onScroll={[Function]}
             >
               <table
                 className="pf-c-table pf-m-compact drift-table"
@@ -7985,7 +8027,21 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
               </AddSystemModal>
             </Connect(AddSystemModal)>
             <div
+              className="second-scroll-wrapper"
+              onScroll={[Function]}
+            >
+              <div
+                className="second-scroll"
+                style={
+                  Object {
+                    "width": "",
+                  }
+                }
+              />
+            </div>
+            <div
               className="drift-table-wrapper"
+              onScroll={[Function]}
             >
               <table
                 className="pf-c-table pf-m-compact drift-table"
@@ -11902,7 +11958,21 @@ exports[`DriftTable should render correctly 1`] = `
     selectedSystemIds={Array []}
   />
   <div
+    className="second-scroll-wrapper"
+    onScroll={[Function]}
+  >
+    <div
+      className="second-scroll"
+      style={
+        Object {
+          "width": "",
+        }
+      }
+    />
+  </div>
+  <div
     className="drift-table-wrapper"
+    onScroll={[Function]}
   >
     <table
       className="pf-c-table pf-m-compact drift-table"

--- a/src/SmartComponents/DriftPage/__tests__/__snapshots__/DriftPage.tests.js.snap
+++ b/src/SmartComponents/DriftPage/__tests__/__snapshots__/DriftPage.tests.js.snap
@@ -3582,7 +3582,21 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
                                   </AddSystemModal>
                                 </Connect(AddSystemModal)>
                                 <div
+                                  className="second-scroll-wrapper"
+                                  onScroll={[Function]}
+                                >
+                                  <div
+                                    className="second-scroll"
+                                    style={
+                                      Object {
+                                        "width": "",
+                                      }
+                                    }
+                                  />
+                                </div>
+                                <div
                                   className="drift-table-wrapper"
+                                  onScroll={[Function]}
                                 >
                                   <table
                                     className="pf-c-table pf-m-compact drift-table"
@@ -8184,7 +8198,21 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                   </AddSystemModal>
                                 </Connect(AddSystemModal)>
                                 <div
+                                  className="second-scroll-wrapper"
+                                  onScroll={[Function]}
+                                >
+                                  <div
+                                    className="second-scroll"
+                                    style={
+                                      Object {
+                                        "width": "",
+                                      }
+                                    }
+                                  />
+                                </div>
+                                <div
                                   className="drift-table-wrapper"
+                                  onScroll={[Function]}
                                 >
                                   <table
                                     className="pf-c-table pf-m-compact drift-table"


### PR DESCRIPTION
The only horizontal scrollbar on the comparison table is located at the bottom of the table, therefore scrolling is not optimal when a user has to scroll all the way to the bottom to scroll horizontally. This PR adds a scrollbar to the top so a user can scroll horizontally from the top or the bottom of the page.

This PR does not fully fix the issue as the end goal is to make the top scrollbar sticky at the top of the page so you can scroll horizontally even if you are in the middle of the page where neither scrollbar is visible. Because we are also attempting to make the header row of the table sticky, we are going to implement the stickiness with that PR.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
