### PR TITLE
[DRFT-571] Remove padding on inventory table toolbar

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -396,3 +396,9 @@
   display: flex;
   align-items: center;
 }
+
+.inventory-toolbar-no-padding {
+  .ins-c-inventory__table--toolbar .pf-c-toolbar__content {
+    padding-left: 0;
+  }
+}

--- a/src/SmartComponents/AddSystemModal/__tests__/__snapshots__/AddSystemModal.tests.js.snap
+++ b/src/SmartComponents/AddSystemModal/__tests__/__snapshots__/AddSystemModal.tests.js.snap
@@ -9711,23 +9711,27 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                             tabindex="0"
                           >
                             <div
-                              class="pf-l-bullseye pf-u-p-lg"
+                              class="inventory-toolbar-no-padding"
                             >
-                              <span
-                                aria-valuetext="Loading..."
-                                class="pf-c-spinner pf-m-xl"
-                                role="progressbar"
+                              <div
+                                class="pf-l-bullseye pf-u-p-lg"
                               >
                                 <span
-                                  class="pf-c-spinner__clipper"
-                                />
-                                <span
-                                  class="pf-c-spinner__lead-ball"
-                                />
-                                <span
-                                  class="pf-c-spinner__tail-ball"
-                                />
-                              </span>
+                                  aria-valuetext="Loading..."
+                                  class="pf-c-spinner pf-m-xl"
+                                  role="progressbar"
+                                >
+                                  <span
+                                    class="pf-c-spinner__clipper"
+                                  />
+                                  <span
+                                    class="pf-c-spinner__lead-ball"
+                                  />
+                                  <span
+                                    class="pf-c-spinner__tail-ball"
+                                  />
+                                </span>
+                              </div>
                             </div>
                           </section>
                           <section
@@ -11389,93 +11393,10 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                               ]
                                             }
                                           >
-                                            <ForwardRef
-                                              bulkSelect={
-                                                Object {
-                                                  "checked": false,
-                                                  "count": 0,
-                                                  "isDisabled": false,
-                                                  "items": Array [
-                                                    Object {
-                                                      "onClick": [Function],
-                                                      "title": "Select none (0)",
-                                                    },
-                                                    Object {
-                                                      "onClick": [Function],
-                                                      "title": "Select page (0)",
-                                                    },
-                                                    Object {
-                                                      "onClick": [Function],
-                                                      "title": "Deselect page (0)",
-                                                    },
-                                                  ],
-                                                  "onSelect": [Function],
-                                                }
-                                              }
-                                              columns={
-                                                Array [
-                                                  Object {
-                                                    "key": "display_name",
-                                                    "props": Object {
-                                                      "width": 20,
-                                                    },
-                                                    "title": "Name",
-                                                  },
-                                                  Object {
-                                                    "key": "tags",
-                                                    "props": Object {
-                                                      "isStatic": true,
-                                                      "width": 10,
-                                                    },
-                                                    "title": "Tags",
-                                                  },
-                                                  Object {
-                                                    "key": "updated",
-                                                    "props": Object {
-                                                      "width": 10,
-                                                    },
-                                                    "title": "Last seen",
-                                                  },
-                                                  Object {
-                                                    "key": "historical_profiles",
-                                                    "props": Object {
-                                                      "isStatic": true,
-                                                      "width": 10,
-                                                    },
-                                                    "title": "Historical profiles",
-                                                  },
-                                                ]
-                                              }
-                                              customFilters={
-                                                Object {
-                                                  "filter": Object {
-                                                    "system_profile": Object {},
-                                                  },
-                                                  "tags": Array [],
-                                                }
-                                              }
-                                              fallback={
-                                                <Bullseye
-                                                  className="pf-u-p-lg"
-                                                >
-                                                  <Spinner
-                                                    size="xl"
-                                                  />
-                                                </Bullseye>
-                                              }
-                                              getEntities={[Function]}
-                                              noDetail={true}
-                                              onLoad={[Function]}
-                                              showTags={true}
-                                              tableProps={
-                                                Object {
-                                                  "canSelectAll": false,
-                                                  "ouiaId": "systems-table",
-                                                  "selectVariant": "checkbox",
-                                                }
-                                              }
+                                            <div
+                                              className="inventory-toolbar-no-padding"
                                             >
-                                              <BaseInvTable
+                                              <ForwardRef
                                                 bulkSelect={
                                                   Object {
                                                     "checked": false,
@@ -11550,7 +11471,6 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                                   </Bullseye>
                                                 }
                                                 getEntities={[Function]}
-                                                innerRef={null}
                                                 noDetail={true}
                                                 onLoad={[Function]}
                                                 showTags={true}
@@ -11562,7 +11482,71 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                                   }
                                                 }
                                               >
-                                                <Suspense
+                                                <BaseInvTable
+                                                  bulkSelect={
+                                                    Object {
+                                                      "checked": false,
+                                                      "count": 0,
+                                                      "isDisabled": false,
+                                                      "items": Array [
+                                                        Object {
+                                                          "onClick": [Function],
+                                                          "title": "Select none (0)",
+                                                        },
+                                                        Object {
+                                                          "onClick": [Function],
+                                                          "title": "Select page (0)",
+                                                        },
+                                                        Object {
+                                                          "onClick": [Function],
+                                                          "title": "Deselect page (0)",
+                                                        },
+                                                      ],
+                                                      "onSelect": [Function],
+                                                    }
+                                                  }
+                                                  columns={
+                                                    Array [
+                                                      Object {
+                                                        "key": "display_name",
+                                                        "props": Object {
+                                                          "width": 20,
+                                                        },
+                                                        "title": "Name",
+                                                      },
+                                                      Object {
+                                                        "key": "tags",
+                                                        "props": Object {
+                                                          "isStatic": true,
+                                                          "width": 10,
+                                                        },
+                                                        "title": "Tags",
+                                                      },
+                                                      Object {
+                                                        "key": "updated",
+                                                        "props": Object {
+                                                          "width": 10,
+                                                        },
+                                                        "title": "Last seen",
+                                                      },
+                                                      Object {
+                                                        "key": "historical_profiles",
+                                                        "props": Object {
+                                                          "isStatic": true,
+                                                          "width": 10,
+                                                        },
+                                                        "title": "Historical profiles",
+                                                      },
+                                                    ]
+                                                  }
+                                                  customFilters={
+                                                    Object {
+                                                      "filter": Object {
+                                                        "system_profile": Object {},
+                                                      },
+                                                      "tags": Array [],
+                                                    }
+                                                  }
                                                   fallback={
                                                     <Bullseye
                                                       className="pf-u-p-lg"
@@ -11572,163 +11556,20 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                                       />
                                                     </Bullseye>
                                                   }
+                                                  getEntities={[Function]}
+                                                  innerRef={null}
+                                                  noDetail={true}
+                                                  onLoad={[Function]}
+                                                  showTags={true}
+                                                  tableProps={
+                                                    Object {
+                                                      "canSelectAll": false,
+                                                      "ouiaId": "systems-table",
+                                                      "selectVariant": "checkbox",
+                                                    }
+                                                  }
                                                 >
-                                                  <ForwardRef
-                                                    ErrorComponent={
-                                                      <UNDEFINED
-                                                        bulkSelect={
-                                                          Object {
-                                                            "checked": false,
-                                                            "count": 0,
-                                                            "isDisabled": false,
-                                                            "items": Array [
-                                                              Object {
-                                                                "onClick": [Function],
-                                                                "title": "Select none (0)",
-                                                              },
-                                                              Object {
-                                                                "onClick": [Function],
-                                                                "title": "Select page (0)",
-                                                              },
-                                                              Object {
-                                                                "onClick": [Function],
-                                                                "title": "Deselect page (0)",
-                                                              },
-                                                            ],
-                                                            "onSelect": [Function],
-                                                          }
-                                                        }
-                                                        columns={
-                                                          Array [
-                                                            Object {
-                                                              "key": "display_name",
-                                                              "props": Object {
-                                                                "width": 20,
-                                                              },
-                                                              "title": "Name",
-                                                            },
-                                                            Object {
-                                                              "key": "tags",
-                                                              "props": Object {
-                                                                "isStatic": true,
-                                                                "width": 10,
-                                                              },
-                                                              "title": "Tags",
-                                                            },
-                                                            Object {
-                                                              "key": "updated",
-                                                              "props": Object {
-                                                                "width": 10,
-                                                              },
-                                                              "title": "Last seen",
-                                                            },
-                                                            Object {
-                                                              "key": "historical_profiles",
-                                                              "props": Object {
-                                                                "isStatic": true,
-                                                                "width": 10,
-                                                              },
-                                                              "title": "Historical profiles",
-                                                            },
-                                                          ]
-                                                        }
-                                                        component="InventoryTable"
-                                                        customFilters={
-                                                          Object {
-                                                            "filter": Object {
-                                                              "system_profile": Object {},
-                                                            },
-                                                            "tags": Array [],
-                                                          }
-                                                        }
-                                                        fallback={
-                                                          <Bullseye
-                                                            className="pf-u-p-lg"
-                                                          >
-                                                            <Spinner
-                                                              size="xl"
-                                                            />
-                                                          </Bullseye>
-                                                        }
-                                                        getEntities={[Function]}
-                                                        innerRef={null}
-                                                        noDetail={true}
-                                                        onLoad={[Function]}
-                                                        showTags={true}
-                                                        tableProps={
-                                                          Object {
-                                                            "canSelectAll": false,
-                                                            "ouiaId": "systems-table",
-                                                            "selectVariant": "checkbox",
-                                                          }
-                                                        }
-                                                      />
-                                                    }
-                                                    appName="chrome"
-                                                    bulkSelect={
-                                                      Object {
-                                                        "checked": false,
-                                                        "count": 0,
-                                                        "isDisabled": false,
-                                                        "items": Array [
-                                                          Object {
-                                                            "onClick": [Function],
-                                                            "title": "Select none (0)",
-                                                          },
-                                                          Object {
-                                                            "onClick": [Function],
-                                                            "title": "Select page (0)",
-                                                          },
-                                                          Object {
-                                                            "onClick": [Function],
-                                                            "title": "Deselect page (0)",
-                                                          },
-                                                        ],
-                                                        "onSelect": [Function],
-                                                      }
-                                                    }
-                                                    columns={
-                                                      Array [
-                                                        Object {
-                                                          "key": "display_name",
-                                                          "props": Object {
-                                                            "width": 20,
-                                                          },
-                                                          "title": "Name",
-                                                        },
-                                                        Object {
-                                                          "key": "tags",
-                                                          "props": Object {
-                                                            "isStatic": true,
-                                                            "width": 10,
-                                                          },
-                                                          "title": "Tags",
-                                                        },
-                                                        Object {
-                                                          "key": "updated",
-                                                          "props": Object {
-                                                            "width": 10,
-                                                          },
-                                                          "title": "Last seen",
-                                                        },
-                                                        Object {
-                                                          "key": "historical_profiles",
-                                                          "props": Object {
-                                                            "isStatic": true,
-                                                            "width": 10,
-                                                          },
-                                                          "title": "Historical profiles",
-                                                        },
-                                                      ]
-                                                    }
-                                                    customFilters={
-                                                      Object {
-                                                        "filter": Object {
-                                                          "system_profile": Object {},
-                                                        },
-                                                        "tags": Array [],
-                                                      }
-                                                    }
+                                                  <Suspense
                                                     fallback={
                                                       <Bullseye
                                                         className="pf-u-p-lg"
@@ -11738,62 +11579,8 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                                         />
                                                       </Bullseye>
                                                     }
-                                                    getEntities={[Function]}
-                                                    history={
-                                                      Object {
-                                                        "action": "POP",
-                                                        "block": [Function],
-                                                        "canGo": [Function],
-                                                        "createHref": [Function],
-                                                        "entries": Array [
-                                                          Object {
-                                                            "hash": "",
-                                                            "pathname": "/",
-                                                            "search": "",
-                                                            "state": undefined,
-                                                          },
-                                                        ],
-                                                        "go": [Function],
-                                                        "goBack": [Function],
-                                                        "goForward": [Function],
-                                                        "index": 0,
-                                                        "length": 1,
-                                                        "listen": [Function],
-                                                        "location": Object {
-                                                          "hash": "",
-                                                          "pathname": "/",
-                                                          "search": "",
-                                                          "state": undefined,
-                                                        },
-                                                        "push": [Function],
-                                                        "replace": [Function],
-                                                      }
-                                                    }
-                                                    innerRef={null}
-                                                    module="./InventoryTable"
-                                                    noDetail={true}
-                                                    onLoad={[Function]}
-                                                    scope="chrome"
-                                                    showTags={true}
-                                                    store={
-                                                      Object {
-                                                        "clearActions": [Function],
-                                                        "dispatch": [Function],
-                                                        "getActions": [Function],
-                                                        "getState": [Function],
-                                                        "replaceReducer": [Function],
-                                                        "subscribe": [Function],
-                                                      }
-                                                    }
-                                                    tableProps={
-                                                      Object {
-                                                        "canSelectAll": false,
-                                                        "ouiaId": "systems-table",
-                                                        "selectVariant": "checkbox",
-                                                      }
-                                                    }
                                                   >
-                                                    <BaseScalprumComponent
+                                                    <ForwardRef
                                                       ErrorComponent={
                                                         <UNDEFINED
                                                           bulkSelect={
@@ -12013,7 +11800,98 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                                         }
                                                       }
                                                     >
-                                                      <AsyncInventory
+                                                      <BaseScalprumComponent
+                                                        ErrorComponent={
+                                                          <UNDEFINED
+                                                            bulkSelect={
+                                                              Object {
+                                                                "checked": false,
+                                                                "count": 0,
+                                                                "isDisabled": false,
+                                                                "items": Array [
+                                                                  Object {
+                                                                    "onClick": [Function],
+                                                                    "title": "Select none (0)",
+                                                                  },
+                                                                  Object {
+                                                                    "onClick": [Function],
+                                                                    "title": "Select page (0)",
+                                                                  },
+                                                                  Object {
+                                                                    "onClick": [Function],
+                                                                    "title": "Deselect page (0)",
+                                                                  },
+                                                                ],
+                                                                "onSelect": [Function],
+                                                              }
+                                                            }
+                                                            columns={
+                                                              Array [
+                                                                Object {
+                                                                  "key": "display_name",
+                                                                  "props": Object {
+                                                                    "width": 20,
+                                                                  },
+                                                                  "title": "Name",
+                                                                },
+                                                                Object {
+                                                                  "key": "tags",
+                                                                  "props": Object {
+                                                                    "isStatic": true,
+                                                                    "width": 10,
+                                                                  },
+                                                                  "title": "Tags",
+                                                                },
+                                                                Object {
+                                                                  "key": "updated",
+                                                                  "props": Object {
+                                                                    "width": 10,
+                                                                  },
+                                                                  "title": "Last seen",
+                                                                },
+                                                                Object {
+                                                                  "key": "historical_profiles",
+                                                                  "props": Object {
+                                                                    "isStatic": true,
+                                                                    "width": 10,
+                                                                  },
+                                                                  "title": "Historical profiles",
+                                                                },
+                                                              ]
+                                                            }
+                                                            component="InventoryTable"
+                                                            customFilters={
+                                                              Object {
+                                                                "filter": Object {
+                                                                  "system_profile": Object {},
+                                                                },
+                                                                "tags": Array [],
+                                                              }
+                                                            }
+                                                            fallback={
+                                                              <Bullseye
+                                                                className="pf-u-p-lg"
+                                                              >
+                                                                <Spinner
+                                                                  size="xl"
+                                                                />
+                                                              </Bullseye>
+                                                            }
+                                                            getEntities={[Function]}
+                                                            innerRef={null}
+                                                            noDetail={true}
+                                                            onLoad={[Function]}
+                                                            showTags={true}
+                                                            tableProps={
+                                                              Object {
+                                                                "canSelectAll": false,
+                                                                "ouiaId": "systems-table",
+                                                                "selectVariant": "checkbox",
+                                                              }
+                                                            }
+                                                          />
+                                                        }
+                                                        appName="chrome"
                                                         bulkSelect={
                                                           Object {
                                                             "checked": false,
@@ -12070,7 +11948,6 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                                             },
                                                           ]
                                                         }
-                                                        component="InventoryTable"
                                                         customFilters={
                                                           Object {
                                                             "filter": Object {
@@ -12079,16 +11956,147 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                                             "tags": Array [],
                                                           }
                                                         }
-                                                        error={[TypeError: Cannot read property 'appsMetaData' of undefined]}
-                                                        errorInfo={
+                                                        fallback={
+                                                          <Bullseye
+                                                            className="pf-u-p-lg"
+                                                          >
+                                                            <Spinner
+                                                              size="xl"
+                                                            />
+                                                          </Bullseye>
+                                                        }
+                                                        getEntities={[Function]}
+                                                        history={
                                                           Object {
-                                                            "componentStack": "
+                                                            "action": "POP",
+                                                            "block": [Function],
+                                                            "canGo": [Function],
+                                                            "createHref": [Function],
+                                                            "entries": Array [
+                                                              Object {
+                                                                "hash": "",
+                                                                "pathname": "/",
+                                                                "search": "",
+                                                                "state": undefined,
+                                                              },
+                                                            ],
+                                                            "go": [Function],
+                                                            "goBack": [Function],
+                                                            "goForward": [Function],
+                                                            "index": 0,
+                                                            "length": 1,
+                                                            "listen": [Function],
+                                                            "location": Object {
+                                                              "hash": "",
+                                                              "pathname": "/",
+                                                              "search": "",
+                                                              "state": undefined,
+                                                            },
+                                                            "push": [Function],
+                                                            "replace": [Function],
+                                                          }
+                                                        }
+                                                        innerRef={null}
+                                                        module="./InventoryTable"
+                                                        noDetail={true}
+                                                        onLoad={[Function]}
+                                                        scope="chrome"
+                                                        showTags={true}
+                                                        store={
+                                                          Object {
+                                                            "clearActions": [Function],
+                                                            "dispatch": [Function],
+                                                            "getActions": [Function],
+                                                            "getState": [Function],
+                                                            "replaceReducer": [Function],
+                                                            "subscribe": [Function],
+                                                          }
+                                                        }
+                                                        tableProps={
+                                                          Object {
+                                                            "canSelectAll": false,
+                                                            "ouiaId": "systems-table",
+                                                            "selectVariant": "checkbox",
+                                                          }
+                                                        }
+                                                      >
+                                                        <AsyncInventory
+                                                          bulkSelect={
+                                                            Object {
+                                                              "checked": false,
+                                                              "count": 0,
+                                                              "isDisabled": false,
+                                                              "items": Array [
+                                                                Object {
+                                                                  "onClick": [Function],
+                                                                  "title": "Select none (0)",
+                                                                },
+                                                                Object {
+                                                                  "onClick": [Function],
+                                                                  "title": "Select page (0)",
+                                                                },
+                                                                Object {
+                                                                  "onClick": [Function],
+                                                                  "title": "Deselect page (0)",
+                                                                },
+                                                              ],
+                                                              "onSelect": [Function],
+                                                            }
+                                                          }
+                                                          columns={
+                                                            Array [
+                                                              Object {
+                                                                "key": "display_name",
+                                                                "props": Object {
+                                                                  "width": 20,
+                                                                },
+                                                                "title": "Name",
+                                                              },
+                                                              Object {
+                                                                "key": "tags",
+                                                                "props": Object {
+                                                                  "isStatic": true,
+                                                                  "width": 10,
+                                                                },
+                                                                "title": "Tags",
+                                                              },
+                                                              Object {
+                                                                "key": "updated",
+                                                                "props": Object {
+                                                                  "width": 10,
+                                                                },
+                                                                "title": "Last seen",
+                                                              },
+                                                              Object {
+                                                                "key": "historical_profiles",
+                                                                "props": Object {
+                                                                  "isStatic": true,
+                                                                  "width": 10,
+                                                                },
+                                                                "title": "Historical profiles",
+                                                              },
+                                                            ]
+                                                          }
+                                                          component="InventoryTable"
+                                                          customFilters={
+                                                            Object {
+                                                              "filter": Object {
+                                                                "system_profile": Object {},
+                                                              },
+                                                              "tags": Array [],
+                                                            }
+                                                          }
+                                                          error={[TypeError: Cannot read property 'appsMetaData' of undefined]}
+                                                          errorInfo={
+                                                            Object {
+                                                              "componentStack": "
     in LoadModule (created by BaseScalprumComponent)
     in BaseScalprumComponent (created by ForwardRef)
     in ForwardRef (created by BaseInvTable)
     in Suspense (created by BaseInvTable)
     in BaseInvTable (created by ForwardRef)
     in ForwardRef (created by SystemsTable)
+    in div (created by SystemsTable)
     in SystemsTable (created by Connect(SystemsTable))
     in Connect(SystemsTable) (created by AddSystemModal)
     in section (created by Context.Consumer)
@@ -12111,64 +12119,65 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
     in Router (created by MemoryRouter)
     in MemoryRouter (created by WrapperComponent)
     in WrapperComponent",
+                                                            }
                                                           }
-                                                        }
-                                                        fallback={
+                                                          fallback={
+                                                            <Bullseye
+                                                              className="pf-u-p-lg"
+                                                            >
+                                                              <Spinner
+                                                                size="xl"
+                                                              />
+                                                            </Bullseye>
+                                                          }
+                                                          getEntities={[Function]}
+                                                          hasError={true}
+                                                          innerRef={null}
+                                                          noDetail={true}
+                                                          onLoad={[Function]}
+                                                          showTags={true}
+                                                          tableProps={
+                                                            Object {
+                                                              "canSelectAll": false,
+                                                              "ouiaId": "systems-table",
+                                                              "selectVariant": "checkbox",
+                                                            }
+                                                          }
+                                                        >
                                                           <Bullseye
                                                             className="pf-u-p-lg"
                                                           >
-                                                            <Spinner
-                                                              size="xl"
-                                                            />
-                                                          </Bullseye>
-                                                        }
-                                                        getEntities={[Function]}
-                                                        hasError={true}
-                                                        innerRef={null}
-                                                        noDetail={true}
-                                                        onLoad={[Function]}
-                                                        showTags={true}
-                                                        tableProps={
-                                                          Object {
-                                                            "canSelectAll": false,
-                                                            "ouiaId": "systems-table",
-                                                            "selectVariant": "checkbox",
-                                                          }
-                                                        }
-                                                      >
-                                                        <Bullseye
-                                                          className="pf-u-p-lg"
-                                                        >
-                                                          <div
-                                                            className="pf-l-bullseye pf-u-p-lg"
-                                                          >
-                                                            <Spinner
-                                                              size="xl"
+                                                            <div
+                                                              className="pf-l-bullseye pf-u-p-lg"
                                                             >
-                                                              <span
-                                                                aria-valuetext="Loading..."
-                                                                className="pf-c-spinner pf-m-xl"
-                                                                role="progressbar"
+                                                              <Spinner
+                                                                size="xl"
                                                               >
                                                                 <span
-                                                                  className="pf-c-spinner__clipper"
-                                                                />
-                                                                <span
-                                                                  className="pf-c-spinner__lead-ball"
-                                                                />
-                                                                <span
-                                                                  className="pf-c-spinner__tail-ball"
-                                                                />
-                                                              </span>
-                                                            </Spinner>
-                                                          </div>
-                                                        </Bullseye>
-                                                      </AsyncInventory>
-                                                    </BaseScalprumComponent>
-                                                  </ForwardRef>
-                                                </Suspense>
-                                              </BaseInvTable>
-                                            </ForwardRef>
+                                                                  aria-valuetext="Loading..."
+                                                                  className="pf-c-spinner pf-m-xl"
+                                                                  role="progressbar"
+                                                                >
+                                                                  <span
+                                                                    className="pf-c-spinner__clipper"
+                                                                  />
+                                                                  <span
+                                                                    className="pf-c-spinner__lead-ball"
+                                                                  />
+                                                                  <span
+                                                                    className="pf-c-spinner__tail-ball"
+                                                                  />
+                                                                </span>
+                                                              </Spinner>
+                                                            </div>
+                                                          </Bullseye>
+                                                        </AsyncInventory>
+                                                      </BaseScalprumComponent>
+                                                    </ForwardRef>
+                                                  </Suspense>
+                                                </BaseInvTable>
+                                              </ForwardRef>
+                                            </div>
                                           </SystemsTable>
                                         </Connect(SystemsTable)>
                                       </section>
@@ -16741,23 +16750,27 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                             tabindex="0"
                           >
                             <div
-                              class="pf-l-bullseye pf-u-p-lg"
+                              class="inventory-toolbar-no-padding"
                             >
-                              <span
-                                aria-valuetext="Loading..."
-                                class="pf-c-spinner pf-m-xl"
-                                role="progressbar"
+                              <div
+                                class="pf-l-bullseye pf-u-p-lg"
                               >
                                 <span
-                                  class="pf-c-spinner__clipper"
-                                />
-                                <span
-                                  class="pf-c-spinner__lead-ball"
-                                />
-                                <span
-                                  class="pf-c-spinner__tail-ball"
-                                />
-                              </span>
+                                  aria-valuetext="Loading..."
+                                  class="pf-c-spinner pf-m-xl"
+                                  role="progressbar"
+                                >
+                                  <span
+                                    class="pf-c-spinner__clipper"
+                                  />
+                                  <span
+                                    class="pf-c-spinner__lead-ball"
+                                  />
+                                  <span
+                                    class="pf-c-spinner__tail-ball"
+                                  />
+                                </span>
+                              </div>
                             </div>
                           </section>
                           <section
@@ -18420,93 +18433,10 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                               ]
                                             }
                                           >
-                                            <ForwardRef
-                                              bulkSelect={
-                                                Object {
-                                                  "checked": false,
-                                                  "count": 0,
-                                                  "isDisabled": false,
-                                                  "items": Array [
-                                                    Object {
-                                                      "onClick": [Function],
-                                                      "title": "Select none (0)",
-                                                    },
-                                                    Object {
-                                                      "onClick": [Function],
-                                                      "title": "Select page (0)",
-                                                    },
-                                                    Object {
-                                                      "onClick": [Function],
-                                                      "title": "Deselect page (0)",
-                                                    },
-                                                  ],
-                                                  "onSelect": [Function],
-                                                }
-                                              }
-                                              columns={
-                                                Array [
-                                                  Object {
-                                                    "key": "display_name",
-                                                    "props": Object {
-                                                      "width": 20,
-                                                    },
-                                                    "title": "Name",
-                                                  },
-                                                  Object {
-                                                    "key": "tags",
-                                                    "props": Object {
-                                                      "isStatic": true,
-                                                      "width": 10,
-                                                    },
-                                                    "title": "Tags",
-                                                  },
-                                                  Object {
-                                                    "key": "updated",
-                                                    "props": Object {
-                                                      "width": 10,
-                                                    },
-                                                    "title": "Last seen",
-                                                  },
-                                                  Object {
-                                                    "key": "historical_profiles",
-                                                    "props": Object {
-                                                      "isStatic": true,
-                                                      "width": 10,
-                                                    },
-                                                    "title": "Historical profiles",
-                                                  },
-                                                ]
-                                              }
-                                              customFilters={
-                                                Object {
-                                                  "filter": Object {
-                                                    "system_profile": Object {},
-                                                  },
-                                                  "tags": Array [],
-                                                }
-                                              }
-                                              fallback={
-                                                <Bullseye
-                                                  className="pf-u-p-lg"
-                                                >
-                                                  <Spinner
-                                                    size="xl"
-                                                  />
-                                                </Bullseye>
-                                              }
-                                              getEntities={[Function]}
-                                              noDetail={true}
-                                              onLoad={[Function]}
-                                              showTags={true}
-                                              tableProps={
-                                                Object {
-                                                  "canSelectAll": false,
-                                                  "ouiaId": "systems-table",
-                                                  "selectVariant": "checkbox",
-                                                }
-                                              }
+                                            <div
+                                              className="inventory-toolbar-no-padding"
                                             >
-                                              <BaseInvTable
+                                              <ForwardRef
                                                 bulkSelect={
                                                   Object {
                                                     "checked": false,
@@ -18581,7 +18511,6 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                                   </Bullseye>
                                                 }
                                                 getEntities={[Function]}
-                                                innerRef={null}
                                                 noDetail={true}
                                                 onLoad={[Function]}
                                                 showTags={true}
@@ -18593,7 +18522,71 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                                   }
                                                 }
                                               >
-                                                <Suspense
+                                                <BaseInvTable
+                                                  bulkSelect={
+                                                    Object {
+                                                      "checked": false,
+                                                      "count": 0,
+                                                      "isDisabled": false,
+                                                      "items": Array [
+                                                        Object {
+                                                          "onClick": [Function],
+                                                          "title": "Select none (0)",
+                                                        },
+                                                        Object {
+                                                          "onClick": [Function],
+                                                          "title": "Select page (0)",
+                                                        },
+                                                        Object {
+                                                          "onClick": [Function],
+                                                          "title": "Deselect page (0)",
+                                                        },
+                                                      ],
+                                                      "onSelect": [Function],
+                                                    }
+                                                  }
+                                                  columns={
+                                                    Array [
+                                                      Object {
+                                                        "key": "display_name",
+                                                        "props": Object {
+                                                          "width": 20,
+                                                        },
+                                                        "title": "Name",
+                                                      },
+                                                      Object {
+                                                        "key": "tags",
+                                                        "props": Object {
+                                                          "isStatic": true,
+                                                          "width": 10,
+                                                        },
+                                                        "title": "Tags",
+                                                      },
+                                                      Object {
+                                                        "key": "updated",
+                                                        "props": Object {
+                                                          "width": 10,
+                                                        },
+                                                        "title": "Last seen",
+                                                      },
+                                                      Object {
+                                                        "key": "historical_profiles",
+                                                        "props": Object {
+                                                          "isStatic": true,
+                                                          "width": 10,
+                                                        },
+                                                        "title": "Historical profiles",
+                                                      },
+                                                    ]
+                                                  }
+                                                  customFilters={
+                                                    Object {
+                                                      "filter": Object {
+                                                        "system_profile": Object {},
+                                                      },
+                                                      "tags": Array [],
+                                                    }
+                                                  }
                                                   fallback={
                                                     <Bullseye
                                                       className="pf-u-p-lg"
@@ -18603,163 +18596,20 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                                       />
                                                     </Bullseye>
                                                   }
+                                                  getEntities={[Function]}
+                                                  innerRef={null}
+                                                  noDetail={true}
+                                                  onLoad={[Function]}
+                                                  showTags={true}
+                                                  tableProps={
+                                                    Object {
+                                                      "canSelectAll": false,
+                                                      "ouiaId": "systems-table",
+                                                      "selectVariant": "checkbox",
+                                                    }
+                                                  }
                                                 >
-                                                  <ForwardRef
-                                                    ErrorComponent={
-                                                      <UNDEFINED
-                                                        bulkSelect={
-                                                          Object {
-                                                            "checked": false,
-                                                            "count": 0,
-                                                            "isDisabled": false,
-                                                            "items": Array [
-                                                              Object {
-                                                                "onClick": [Function],
-                                                                "title": "Select none (0)",
-                                                              },
-                                                              Object {
-                                                                "onClick": [Function],
-                                                                "title": "Select page (0)",
-                                                              },
-                                                              Object {
-                                                                "onClick": [Function],
-                                                                "title": "Deselect page (0)",
-                                                              },
-                                                            ],
-                                                            "onSelect": [Function],
-                                                          }
-                                                        }
-                                                        columns={
-                                                          Array [
-                                                            Object {
-                                                              "key": "display_name",
-                                                              "props": Object {
-                                                                "width": 20,
-                                                              },
-                                                              "title": "Name",
-                                                            },
-                                                            Object {
-                                                              "key": "tags",
-                                                              "props": Object {
-                                                                "isStatic": true,
-                                                                "width": 10,
-                                                              },
-                                                              "title": "Tags",
-                                                            },
-                                                            Object {
-                                                              "key": "updated",
-                                                              "props": Object {
-                                                                "width": 10,
-                                                              },
-                                                              "title": "Last seen",
-                                                            },
-                                                            Object {
-                                                              "key": "historical_profiles",
-                                                              "props": Object {
-                                                                "isStatic": true,
-                                                                "width": 10,
-                                                              },
-                                                              "title": "Historical profiles",
-                                                            },
-                                                          ]
-                                                        }
-                                                        component="InventoryTable"
-                                                        customFilters={
-                                                          Object {
-                                                            "filter": Object {
-                                                              "system_profile": Object {},
-                                                            },
-                                                            "tags": Array [],
-                                                          }
-                                                        }
-                                                        fallback={
-                                                          <Bullseye
-                                                            className="pf-u-p-lg"
-                                                          >
-                                                            <Spinner
-                                                              size="xl"
-                                                            />
-                                                          </Bullseye>
-                                                        }
-                                                        getEntities={[Function]}
-                                                        innerRef={null}
-                                                        noDetail={true}
-                                                        onLoad={[Function]}
-                                                        showTags={true}
-                                                        tableProps={
-                                                          Object {
-                                                            "canSelectAll": false,
-                                                            "ouiaId": "systems-table",
-                                                            "selectVariant": "checkbox",
-                                                          }
-                                                        }
-                                                      />
-                                                    }
-                                                    appName="chrome"
-                                                    bulkSelect={
-                                                      Object {
-                                                        "checked": false,
-                                                        "count": 0,
-                                                        "isDisabled": false,
-                                                        "items": Array [
-                                                          Object {
-                                                            "onClick": [Function],
-                                                            "title": "Select none (0)",
-                                                          },
-                                                          Object {
-                                                            "onClick": [Function],
-                                                            "title": "Select page (0)",
-                                                          },
-                                                          Object {
-                                                            "onClick": [Function],
-                                                            "title": "Deselect page (0)",
-                                                          },
-                                                        ],
-                                                        "onSelect": [Function],
-                                                      }
-                                                    }
-                                                    columns={
-                                                      Array [
-                                                        Object {
-                                                          "key": "display_name",
-                                                          "props": Object {
-                                                            "width": 20,
-                                                          },
-                                                          "title": "Name",
-                                                        },
-                                                        Object {
-                                                          "key": "tags",
-                                                          "props": Object {
-                                                            "isStatic": true,
-                                                            "width": 10,
-                                                          },
-                                                          "title": "Tags",
-                                                        },
-                                                        Object {
-                                                          "key": "updated",
-                                                          "props": Object {
-                                                            "width": 10,
-                                                          },
-                                                          "title": "Last seen",
-                                                        },
-                                                        Object {
-                                                          "key": "historical_profiles",
-                                                          "props": Object {
-                                                            "isStatic": true,
-                                                            "width": 10,
-                                                          },
-                                                          "title": "Historical profiles",
-                                                        },
-                                                      ]
-                                                    }
-                                                    customFilters={
-                                                      Object {
-                                                        "filter": Object {
-                                                          "system_profile": Object {},
-                                                        },
-                                                        "tags": Array [],
-                                                      }
-                                                    }
+                                                  <Suspense
                                                     fallback={
                                                       <Bullseye
                                                         className="pf-u-p-lg"
@@ -18769,62 +18619,8 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                                         />
                                                       </Bullseye>
                                                     }
-                                                    getEntities={[Function]}
-                                                    history={
-                                                      Object {
-                                                        "action": "POP",
-                                                        "block": [Function],
-                                                        "canGo": [Function],
-                                                        "createHref": [Function],
-                                                        "entries": Array [
-                                                          Object {
-                                                            "hash": "",
-                                                            "pathname": "/",
-                                                            "search": "",
-                                                            "state": undefined,
-                                                          },
-                                                        ],
-                                                        "go": [Function],
-                                                        "goBack": [Function],
-                                                        "goForward": [Function],
-                                                        "index": 0,
-                                                        "length": 1,
-                                                        "listen": [Function],
-                                                        "location": Object {
-                                                          "hash": "",
-                                                          "pathname": "/",
-                                                          "search": "",
-                                                          "state": undefined,
-                                                        },
-                                                        "push": [Function],
-                                                        "replace": [Function],
-                                                      }
-                                                    }
-                                                    innerRef={null}
-                                                    module="./InventoryTable"
-                                                    noDetail={true}
-                                                    onLoad={[Function]}
-                                                    scope="chrome"
-                                                    showTags={true}
-                                                    store={
-                                                      Object {
-                                                        "clearActions": [Function],
-                                                        "dispatch": [Function],
-                                                        "getActions": [Function],
-                                                        "getState": [Function],
-                                                        "replaceReducer": [Function],
-                                                        "subscribe": [Function],
-                                                      }
-                                                    }
-                                                    tableProps={
-                                                      Object {
-                                                        "canSelectAll": false,
-                                                        "ouiaId": "systems-table",
-                                                        "selectVariant": "checkbox",
-                                                      }
-                                                    }
                                                   >
-                                                    <BaseScalprumComponent
+                                                    <ForwardRef
                                                       ErrorComponent={
                                                         <UNDEFINED
                                                           bulkSelect={
@@ -19043,38 +18839,259 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                                           "selectVariant": "checkbox",
                                                         }
                                                       }
-                                                    />
-                                                  </ForwardRef>
-                                                  <Bullseye
-                                                    className="pf-u-p-lg"
-                                                  >
-                                                    <div
-                                                      className="pf-l-bullseye pf-u-p-lg"
                                                     >
-                                                      <Spinner
-                                                        size="xl"
+                                                      <BaseScalprumComponent
+                                                        ErrorComponent={
+                                                          <UNDEFINED
+                                                            bulkSelect={
+                                                              Object {
+                                                                "checked": false,
+                                                                "count": 0,
+                                                                "isDisabled": false,
+                                                                "items": Array [
+                                                                  Object {
+                                                                    "onClick": [Function],
+                                                                    "title": "Select none (0)",
+                                                                  },
+                                                                  Object {
+                                                                    "onClick": [Function],
+                                                                    "title": "Select page (0)",
+                                                                  },
+                                                                  Object {
+                                                                    "onClick": [Function],
+                                                                    "title": "Deselect page (0)",
+                                                                  },
+                                                                ],
+                                                                "onSelect": [Function],
+                                                              }
+                                                            }
+                                                            columns={
+                                                              Array [
+                                                                Object {
+                                                                  "key": "display_name",
+                                                                  "props": Object {
+                                                                    "width": 20,
+                                                                  },
+                                                                  "title": "Name",
+                                                                },
+                                                                Object {
+                                                                  "key": "tags",
+                                                                  "props": Object {
+                                                                    "isStatic": true,
+                                                                    "width": 10,
+                                                                  },
+                                                                  "title": "Tags",
+                                                                },
+                                                                Object {
+                                                                  "key": "updated",
+                                                                  "props": Object {
+                                                                    "width": 10,
+                                                                  },
+                                                                  "title": "Last seen",
+                                                                },
+                                                                Object {
+                                                                  "key": "historical_profiles",
+                                                                  "props": Object {
+                                                                    "isStatic": true,
+                                                                    "width": 10,
+                                                                  },
+                                                                  "title": "Historical profiles",
+                                                                },
+                                                              ]
+                                                            }
+                                                            component="InventoryTable"
+                                                            customFilters={
+                                                              Object {
+                                                                "filter": Object {
+                                                                  "system_profile": Object {},
+                                                                },
+                                                                "tags": Array [],
+                                                              }
+                                                            }
+                                                            fallback={
+                                                              <Bullseye
+                                                                className="pf-u-p-lg"
+                                                              >
+                                                                <Spinner
+                                                                  size="xl"
+                                                                />
+                                                              </Bullseye>
+                                                            }
+                                                            getEntities={[Function]}
+                                                            innerRef={null}
+                                                            noDetail={true}
+                                                            onLoad={[Function]}
+                                                            showTags={true}
+                                                            tableProps={
+                                                              Object {
+                                                                "canSelectAll": false,
+                                                                "ouiaId": "systems-table",
+                                                                "selectVariant": "checkbox",
+                                                              }
+                                                            }
+                                                          />
+                                                        }
+                                                        appName="chrome"
+                                                        bulkSelect={
+                                                          Object {
+                                                            "checked": false,
+                                                            "count": 0,
+                                                            "isDisabled": false,
+                                                            "items": Array [
+                                                              Object {
+                                                                "onClick": [Function],
+                                                                "title": "Select none (0)",
+                                                              },
+                                                              Object {
+                                                                "onClick": [Function],
+                                                                "title": "Select page (0)",
+                                                              },
+                                                              Object {
+                                                                "onClick": [Function],
+                                                                "title": "Deselect page (0)",
+                                                              },
+                                                            ],
+                                                            "onSelect": [Function],
+                                                          }
+                                                        }
+                                                        columns={
+                                                          Array [
+                                                            Object {
+                                                              "key": "display_name",
+                                                              "props": Object {
+                                                                "width": 20,
+                                                              },
+                                                              "title": "Name",
+                                                            },
+                                                            Object {
+                                                              "key": "tags",
+                                                              "props": Object {
+                                                                "isStatic": true,
+                                                                "width": 10,
+                                                              },
+                                                              "title": "Tags",
+                                                            },
+                                                            Object {
+                                                              "key": "updated",
+                                                              "props": Object {
+                                                                "width": 10,
+                                                              },
+                                                              "title": "Last seen",
+                                                            },
+                                                            Object {
+                                                              "key": "historical_profiles",
+                                                              "props": Object {
+                                                                "isStatic": true,
+                                                                "width": 10,
+                                                              },
+                                                              "title": "Historical profiles",
+                                                            },
+                                                          ]
+                                                        }
+                                                        customFilters={
+                                                          Object {
+                                                            "filter": Object {
+                                                              "system_profile": Object {},
+                                                            },
+                                                            "tags": Array [],
+                                                          }
+                                                        }
+                                                        fallback={
+                                                          <Bullseye
+                                                            className="pf-u-p-lg"
+                                                          >
+                                                            <Spinner
+                                                              size="xl"
+                                                            />
+                                                          </Bullseye>
+                                                        }
+                                                        getEntities={[Function]}
+                                                        history={
+                                                          Object {
+                                                            "action": "POP",
+                                                            "block": [Function],
+                                                            "canGo": [Function],
+                                                            "createHref": [Function],
+                                                            "entries": Array [
+                                                              Object {
+                                                                "hash": "",
+                                                                "pathname": "/",
+                                                                "search": "",
+                                                                "state": undefined,
+                                                              },
+                                                            ],
+                                                            "go": [Function],
+                                                            "goBack": [Function],
+                                                            "goForward": [Function],
+                                                            "index": 0,
+                                                            "length": 1,
+                                                            "listen": [Function],
+                                                            "location": Object {
+                                                              "hash": "",
+                                                              "pathname": "/",
+                                                              "search": "",
+                                                              "state": undefined,
+                                                            },
+                                                            "push": [Function],
+                                                            "replace": [Function],
+                                                          }
+                                                        }
+                                                        innerRef={null}
+                                                        module="./InventoryTable"
+                                                        noDetail={true}
+                                                        onLoad={[Function]}
+                                                        scope="chrome"
+                                                        showTags={true}
+                                                        store={
+                                                          Object {
+                                                            "clearActions": [Function],
+                                                            "dispatch": [Function],
+                                                            "getActions": [Function],
+                                                            "getState": [Function],
+                                                            "replaceReducer": [Function],
+                                                            "subscribe": [Function],
+                                                          }
+                                                        }
+                                                        tableProps={
+                                                          Object {
+                                                            "canSelectAll": false,
+                                                            "ouiaId": "systems-table",
+                                                            "selectVariant": "checkbox",
+                                                          }
+                                                        }
+                                                      />
+                                                    </ForwardRef>
+                                                    <Bullseye
+                                                      className="pf-u-p-lg"
+                                                    >
+                                                      <div
+                                                        className="pf-l-bullseye pf-u-p-lg"
                                                       >
-                                                        <span
-                                                          aria-valuetext="Loading..."
-                                                          className="pf-c-spinner pf-m-xl"
-                                                          role="progressbar"
+                                                        <Spinner
+                                                          size="xl"
                                                         >
                                                           <span
-                                                            className="pf-c-spinner__clipper"
-                                                          />
-                                                          <span
-                                                            className="pf-c-spinner__lead-ball"
-                                                          />
-                                                          <span
-                                                            className="pf-c-spinner__tail-ball"
-                                                          />
-                                                        </span>
-                                                      </Spinner>
-                                                    </div>
-                                                  </Bullseye>
-                                                </Suspense>
-                                              </BaseInvTable>
-                                            </ForwardRef>
+                                                            aria-valuetext="Loading..."
+                                                            className="pf-c-spinner pf-m-xl"
+                                                            role="progressbar"
+                                                          >
+                                                            <span
+                                                              className="pf-c-spinner__clipper"
+                                                            />
+                                                            <span
+                                                              className="pf-c-spinner__lead-ball"
+                                                            />
+                                                            <span
+                                                              className="pf-c-spinner__tail-ball"
+                                                            />
+                                                          </span>
+                                                        </Spinner>
+                                                      </div>
+                                                    </Bullseye>
+                                                  </Suspense>
+                                                </BaseInvTable>
+                                              </ForwardRef>
+                                            </div>
                                           </SystemsTable>
                                         </Connect(SystemsTable)>
                                       </section>

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -61,94 +61,96 @@ export const SystemsTable = ({
 
     return (
         permissions.inventoryRead ? (
-            <InventoryTable
-                columns={ systemColumns }
-                onLoad={ ({ mergeWithEntities, INVENTORY_ACTION_TYPES, api }) => {
-                    getEntities.current = api?.getEntities;
-                    driftClearFilters();
-                    getRegistry().register(mergeWithEntities(
-                        selectedReducer(
-                            INVENTORY_ACTION_TYPES, baselineId, createBaselineModal, historicalProfiles,
-                            hasMultiSelect, deselectHistoricalProfiles, isAddSystemNotifications,
-                            selectHistoricProfiles, systemNotificationIds, selectSystemsToAdd
-                        )
-                    ));
-                    createBaselineModal ? setSelectedSystemIds([]) : setSelectedSystemIds(selectedSystemIds);
-                } }
-                showTags
-                noDetail
-                customFilters={{
-                    tags: tagsFilter,
-                    filter: {
-                        system_profile: {
-                            ...workloadsFilter?.SAP?.isSelected && { sap_system: true },
-                            ...sidsFilter?.length > 0 && { sap_sids: sidsFilter }
-                        }
-                    }
-                }}
-                tableProps={{
-                    canSelectAll: false,
-                    selectVariant,
-                    ouiaId: 'systems-table'
-                }}
-                getEntities={ systemNotificationIds && !isAddSystemNotifications
-                    ? async (_items, config) => {
-                        const currIds = (systemNotificationIds || [])
-                        .slice((config.page - 1) * config.per_page, config.page * config.per_page);
-                        const data = await getEntities.current?.(
-                            currIds,
-                            {
-                                hasItems: true
-                            },
-                            true
-                        );
-
-                        return {
-                            ...data,
-                            results: data.results.map((system) => ({
-                                ...system,
-                                ...currIds.find(({ uuid }) => uuid === system.id) || {}
-                            })),
-                            total: (systemNotificationIds || []).length,
-                            page: config.page,
-                            per_page: config.per_page
-                        };
-                    }
-                    : async (_items, config) => {
-                        const data = await getEntities.current?.([], config, true);
-                        return { ...data };
+            <div className='inventory-toolbar-no-padding'>
+                <InventoryTable
+                    columns={ systemColumns }
+                    onLoad={ ({ mergeWithEntities, INVENTORY_ACTION_TYPES, api }) => {
+                        getEntities.current = api?.getEntities;
+                        driftClearFilters();
+                        getRegistry().register(mergeWithEntities(
+                            selectedReducer(
+                                INVENTORY_ACTION_TYPES, baselineId, createBaselineModal, historicalProfiles,
+                                hasMultiSelect, deselectHistoricalProfiles, isAddSystemNotifications,
+                                selectHistoricProfiles, systemNotificationIds, selectSystemsToAdd
+                            )
+                        ));
+                        createBaselineModal ? setSelectedSystemIds([]) : setSelectedSystemIds(selectedSystemIds);
                     } }
-                bulkSelect={ onSelect && !isAddSystemNotifications && {
-                    isDisabled: !hasMultiSelect,
-                    count: entities?.selectedSystemIds?.length,
-                    items: [{
-                        title: `Select none (0)`,
-                        onClick: () => {
-                            onSelect('none');
+                    showTags
+                    noDetail
+                    customFilters={{
+                        tags: tagsFilter,
+                        filter: {
+                            system_profile: {
+                                ...workloadsFilter?.SAP?.isSelected && { sap_system: true },
+                                ...sidsFilter?.length > 0 && { sap_sids: sidsFilter }
+                            }
                         }
-                    }, {
-                        title: `Select page (${ entities?.count || 0 })`,
-                        onClick: () => {
-                            onSelect('page');
+                    }}
+                    tableProps={{
+                        canSelectAll: false,
+                        selectVariant,
+                        ouiaId: 'systems-table'
+                    }}
+                    getEntities={ systemNotificationIds && !isAddSystemNotifications
+                        ? async (_items, config) => {
+                            const currIds = (systemNotificationIds || [])
+                            .slice((config.page - 1) * config.per_page, config.page * config.per_page);
+                            const data = await getEntities.current?.(
+                                currIds,
+                                {
+                                    hasItems: true
+                                },
+                                true
+                            );
+
+                            return {
+                                ...data,
+                                results: data.results.map((system) => ({
+                                    ...system,
+                                    ...currIds.find(({ uuid }) => uuid === system.id) || {}
+                                })),
+                                total: (systemNotificationIds || []).length,
+                                page: config.page,
+                                per_page: config.per_page
+                            };
                         }
-                    }, {
-                        title: `Deselect page (${ entities?.count || 0 })`,
-                        onClick: () => {
-                            onSelect('deselect-page');
-                        }
-                    }],
-                    onSelect: () => {
-                        if (entities?.rows.length === entities?.selectedSystems?.length) {
-                            onSelect('deselect-page');
-                        } else {
-                            onSelect('page');
-                        }
-                    },
-                    checked: entities && entities.selectedSystemIds
-                        ? helpers.findCheckedValue(entities?.total, entities?.selectedSystemIds.length)
-                        : null
-                } }
-            />
+                        : async (_items, config) => {
+                            const data = await getEntities.current?.([], config, true);
+                            return { ...data };
+                        } }
+                    bulkSelect={ onSelect && !isAddSystemNotifications && {
+                        isDisabled: !hasMultiSelect,
+                        count: entities?.selectedSystemIds?.length,
+                        items: [{
+                            title: `Select none (0)`,
+                            onClick: () => {
+                                onSelect('none');
+                            }
+                        }, {
+                            title: `Select page (${ entities?.count || 0 })`,
+                            onClick: () => {
+                                onSelect('page');
+                            }
+                        }, {
+                            title: `Deselect page (${ entities?.count || 0 })`,
+                            onClick: () => {
+                                onSelect('deselect-page');
+                            }
+                        }],
+                        onSelect: () => {
+                            if (entities?.rows.length === entities?.selectedSystems?.length) {
+                                onSelect('deselect-page');
+                            } else {
+                                onSelect('page');
+                            }
+                        },
+                        checked: entities && entities.selectedSystemIds
+                            ? helpers.findCheckedValue(entities?.total, entities?.selectedSystemIds.length)
+                            : null
+                    } }
+                />
+            </div>
         )
             : <EmptyStateDisplay
                 icon={ LockIcon }

--- a/src/SmartComponents/SystemsTable/__tests__/__snapshots__/SystemsTable.tests.js.snap
+++ b/src/SmartComponents/SystemsTable/__tests__/__snapshots__/SystemsTable.tests.js.snap
@@ -68,59 +68,10 @@ exports[`ConnectedSystemsTable should render correctly 1`] = `
           selectedSystemIds={Array []}
           setSelectedSystemIds={[Function]}
         >
-          <ForwardRef
-            bulkSelect={
-              Object {
-                "checked": null,
-                "count": undefined,
-                "isDisabled": true,
-                "items": Array [
-                  Object {
-                    "onClick": [Function],
-                    "title": "Select none (0)",
-                  },
-                  Object {
-                    "onClick": [Function],
-                    "title": "Select page (0)",
-                  },
-                  Object {
-                    "onClick": [Function],
-                    "title": "Deselect page (0)",
-                  },
-                ],
-                "onSelect": [Function],
-              }
-            }
-            customFilters={
-              Object {
-                "filter": Object {
-                  "system_profile": Object {},
-                },
-                "tags": undefined,
-              }
-            }
-            fallback={
-              <Bullseye
-                className="pf-u-p-lg"
-              >
-                <Spinner
-                  size="xl"
-                />
-              </Bullseye>
-            }
-            getEntities={[Function]}
-            noDetail={true}
-            onLoad={[Function]}
-            showTags={true}
-            tableProps={
-              Object {
-                "canSelectAll": false,
-                "ouiaId": "systems-table",
-                "selectVariant": undefined,
-              }
-            }
+          <div
+            className="inventory-toolbar-no-padding"
           >
-            <BaseInvTable
+            <ForwardRef
               bulkSelect={
                 Object {
                   "checked": null,
@@ -161,7 +112,6 @@ exports[`ConnectedSystemsTable should render correctly 1`] = `
                 </Bullseye>
               }
               getEntities={[Function]}
-              innerRef={null}
               noDetail={true}
               onLoad={[Function]}
               showTags={true}
@@ -173,7 +123,37 @@ exports[`ConnectedSystemsTable should render correctly 1`] = `
                 }
               }
             >
-              <Suspense
+              <BaseInvTable
+                bulkSelect={
+                  Object {
+                    "checked": null,
+                    "count": undefined,
+                    "isDisabled": true,
+                    "items": Array [
+                      Object {
+                        "onClick": [Function],
+                        "title": "Select none (0)",
+                      },
+                      Object {
+                        "onClick": [Function],
+                        "title": "Select page (0)",
+                      },
+                      Object {
+                        "onClick": [Function],
+                        "title": "Deselect page (0)",
+                      },
+                    ],
+                    "onSelect": [Function],
+                  }
+                }
+                customFilters={
+                  Object {
+                    "filter": Object {
+                      "system_profile": Object {},
+                    },
+                    "tags": undefined,
+                  }
+                }
                 fallback={
                   <Bullseye
                     className="pf-u-p-lg"
@@ -183,95 +163,20 @@ exports[`ConnectedSystemsTable should render correctly 1`] = `
                     />
                   </Bullseye>
                 }
+                getEntities={[Function]}
+                innerRef={null}
+                noDetail={true}
+                onLoad={[Function]}
+                showTags={true}
+                tableProps={
+                  Object {
+                    "canSelectAll": false,
+                    "ouiaId": "systems-table",
+                    "selectVariant": undefined,
+                  }
+                }
               >
-                <ForwardRef
-                  ErrorComponent={
-                    <UNDEFINED
-                      bulkSelect={
-                        Object {
-                          "checked": null,
-                          "count": undefined,
-                          "isDisabled": true,
-                          "items": Array [
-                            Object {
-                              "onClick": [Function],
-                              "title": "Select none (0)",
-                            },
-                            Object {
-                              "onClick": [Function],
-                              "title": "Select page (0)",
-                            },
-                            Object {
-                              "onClick": [Function],
-                              "title": "Deselect page (0)",
-                            },
-                          ],
-                          "onSelect": [Function],
-                        }
-                      }
-                      component="InventoryTable"
-                      customFilters={
-                        Object {
-                          "filter": Object {
-                            "system_profile": Object {},
-                          },
-                          "tags": undefined,
-                        }
-                      }
-                      fallback={
-                        <Bullseye
-                          className="pf-u-p-lg"
-                        >
-                          <Spinner
-                            size="xl"
-                          />
-                        </Bullseye>
-                      }
-                      getEntities={[Function]}
-                      innerRef={null}
-                      noDetail={true}
-                      onLoad={[Function]}
-                      showTags={true}
-                      tableProps={
-                        Object {
-                          "canSelectAll": false,
-                          "ouiaId": "systems-table",
-                          "selectVariant": undefined,
-                        }
-                      }
-                    />
-                  }
-                  appName="chrome"
-                  bulkSelect={
-                    Object {
-                      "checked": null,
-                      "count": undefined,
-                      "isDisabled": true,
-                      "items": Array [
-                        Object {
-                          "onClick": [Function],
-                          "title": "Select none (0)",
-                        },
-                        Object {
-                          "onClick": [Function],
-                          "title": "Select page (0)",
-                        },
-                        Object {
-                          "onClick": [Function],
-                          "title": "Deselect page (0)",
-                        },
-                      ],
-                      "onSelect": [Function],
-                    }
-                  }
-                  customFilters={
-                    Object {
-                      "filter": Object {
-                        "system_profile": Object {},
-                      },
-                      "tags": undefined,
-                    }
-                  }
+                <Suspense
                   fallback={
                     <Bullseye
                       className="pf-u-p-lg"
@@ -281,62 +186,8 @@ exports[`ConnectedSystemsTable should render correctly 1`] = `
                       />
                     </Bullseye>
                   }
-                  getEntities={[Function]}
-                  history={
-                    Object {
-                      "action": "POP",
-                      "block": [Function],
-                      "canGo": [Function],
-                      "createHref": [Function],
-                      "entries": Array [
-                        Object {
-                          "hash": "",
-                          "pathname": "/",
-                          "search": "",
-                          "state": undefined,
-                        },
-                      ],
-                      "go": [Function],
-                      "goBack": [Function],
-                      "goForward": [Function],
-                      "index": 0,
-                      "length": 1,
-                      "listen": [Function],
-                      "location": Object {
-                        "hash": "",
-                        "pathname": "/",
-                        "search": "",
-                        "state": undefined,
-                      },
-                      "push": [Function],
-                      "replace": [Function],
-                    }
-                  }
-                  innerRef={null}
-                  module="./InventoryTable"
-                  noDetail={true}
-                  onLoad={[Function]}
-                  scope="chrome"
-                  showTags={true}
-                  store={
-                    Object {
-                      "clearActions": [Function],
-                      "dispatch": [Function],
-                      "getActions": [Function],
-                      "getState": [Function],
-                      "replaceReducer": [Function],
-                      "subscribe": [Function],
-                    }
-                  }
-                  tableProps={
-                    Object {
-                      "canSelectAll": false,
-                      "ouiaId": "systems-table",
-                      "selectVariant": undefined,
-                    }
-                  }
                 >
-                  <BaseScalprumComponent
+                  <ForwardRef
                     ErrorComponent={
                       <UNDEFINED
                         bulkSelect={
@@ -487,38 +338,191 @@ exports[`ConnectedSystemsTable should render correctly 1`] = `
                         "selectVariant": undefined,
                       }
                     }
-                  />
-                </ForwardRef>
-                <Bullseye
-                  className="pf-u-p-lg"
-                >
-                  <div
-                    className="pf-l-bullseye pf-u-p-lg"
                   >
-                    <Spinner
-                      size="xl"
+                    <BaseScalprumComponent
+                      ErrorComponent={
+                        <UNDEFINED
+                          bulkSelect={
+                            Object {
+                              "checked": null,
+                              "count": undefined,
+                              "isDisabled": true,
+                              "items": Array [
+                                Object {
+                                  "onClick": [Function],
+                                  "title": "Select none (0)",
+                                },
+                                Object {
+                                  "onClick": [Function],
+                                  "title": "Select page (0)",
+                                },
+                                Object {
+                                  "onClick": [Function],
+                                  "title": "Deselect page (0)",
+                                },
+                              ],
+                              "onSelect": [Function],
+                            }
+                          }
+                          component="InventoryTable"
+                          customFilters={
+                            Object {
+                              "filter": Object {
+                                "system_profile": Object {},
+                              },
+                              "tags": undefined,
+                            }
+                          }
+                          fallback={
+                            <Bullseye
+                              className="pf-u-p-lg"
+                            >
+                              <Spinner
+                                size="xl"
+                              />
+                            </Bullseye>
+                          }
+                          getEntities={[Function]}
+                          innerRef={null}
+                          noDetail={true}
+                          onLoad={[Function]}
+                          showTags={true}
+                          tableProps={
+                            Object {
+                              "canSelectAll": false,
+                              "ouiaId": "systems-table",
+                              "selectVariant": undefined,
+                            }
+                          }
+                        />
+                      }
+                      appName="chrome"
+                      bulkSelect={
+                        Object {
+                          "checked": null,
+                          "count": undefined,
+                          "isDisabled": true,
+                          "items": Array [
+                            Object {
+                              "onClick": [Function],
+                              "title": "Select none (0)",
+                            },
+                            Object {
+                              "onClick": [Function],
+                              "title": "Select page (0)",
+                            },
+                            Object {
+                              "onClick": [Function],
+                              "title": "Deselect page (0)",
+                            },
+                          ],
+                          "onSelect": [Function],
+                        }
+                      }
+                      customFilters={
+                        Object {
+                          "filter": Object {
+                            "system_profile": Object {},
+                          },
+                          "tags": undefined,
+                        }
+                      }
+                      fallback={
+                        <Bullseye
+                          className="pf-u-p-lg"
+                        >
+                          <Spinner
+                            size="xl"
+                          />
+                        </Bullseye>
+                      }
+                      getEntities={[Function]}
+                      history={
+                        Object {
+                          "action": "POP",
+                          "block": [Function],
+                          "canGo": [Function],
+                          "createHref": [Function],
+                          "entries": Array [
+                            Object {
+                              "hash": "",
+                              "pathname": "/",
+                              "search": "",
+                              "state": undefined,
+                            },
+                          ],
+                          "go": [Function],
+                          "goBack": [Function],
+                          "goForward": [Function],
+                          "index": 0,
+                          "length": 1,
+                          "listen": [Function],
+                          "location": Object {
+                            "hash": "",
+                            "pathname": "/",
+                            "search": "",
+                            "state": undefined,
+                          },
+                          "push": [Function],
+                          "replace": [Function],
+                        }
+                      }
+                      innerRef={null}
+                      module="./InventoryTable"
+                      noDetail={true}
+                      onLoad={[Function]}
+                      scope="chrome"
+                      showTags={true}
+                      store={
+                        Object {
+                          "clearActions": [Function],
+                          "dispatch": [Function],
+                          "getActions": [Function],
+                          "getState": [Function],
+                          "replaceReducer": [Function],
+                          "subscribe": [Function],
+                        }
+                      }
+                      tableProps={
+                        Object {
+                          "canSelectAll": false,
+                          "ouiaId": "systems-table",
+                          "selectVariant": undefined,
+                        }
+                      }
+                    />
+                  </ForwardRef>
+                  <Bullseye
+                    className="pf-u-p-lg"
+                  >
+                    <div
+                      className="pf-l-bullseye pf-u-p-lg"
                     >
-                      <span
-                        aria-valuetext="Loading..."
-                        className="pf-c-spinner pf-m-xl"
-                        role="progressbar"
+                      <Spinner
+                        size="xl"
                       >
                         <span
-                          className="pf-c-spinner__clipper"
-                        />
-                        <span
-                          className="pf-c-spinner__lead-ball"
-                        />
-                        <span
-                          className="pf-c-spinner__tail-ball"
-                        />
-                      </span>
-                    </Spinner>
-                  </div>
-                </Bullseye>
-              </Suspense>
-            </BaseInvTable>
-          </ForwardRef>
+                          aria-valuetext="Loading..."
+                          className="pf-c-spinner pf-m-xl"
+                          role="progressbar"
+                        >
+                          <span
+                            className="pf-c-spinner__clipper"
+                          />
+                          <span
+                            className="pf-c-spinner__lead-ball"
+                          />
+                          <span
+                            className="pf-c-spinner__tail-ball"
+                          />
+                        </span>
+                      </Spinner>
+                    </div>
+                  </Bullseye>
+                </Suspense>
+              </BaseInvTable>
+            </ForwardRef>
+          </div>
         </SystemsTable>
       </Connect(SystemsTable)>
     </Provider>


### PR DESCRIPTION
Before, the two toolbar rows in the inventory table had a 16px left padding. This PR removes that left padding so the toolbar is left aligned with the tabs in the add system modal.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
