### PR TITLE
[DRFT-575] Make create baseline modal error sentence case

### DIFF
--- a/src/SmartComponents/BaselinesPage/CreateBaselineModal/redux/__tests__/reducer.fixtures.js
+++ b/src/SmartComponents/BaselinesPage/CreateBaselineModal/redux/__tests__/reducer.fixtures.js
@@ -21,7 +21,7 @@ const baselineData = ({
 const errorStatusText = ({
     response: {
         data: '',
-        statusText: 'error',
+        statusText: 'Error',
         status: 400
     }
 });
@@ -29,7 +29,7 @@ const errorStatusText = ({
 const errorDataMessage = ({
     response: {
         data: {
-            message: 'error'
+            message: 'Error'
         },
         status: 400
     }
@@ -38,7 +38,7 @@ const errorDataMessage = ({
 const errorDataDetail = ({
     response: {
         data: {
-            detail: 'error'
+            detail: 'Error'
         },
         status: 400
     }

--- a/src/SmartComponents/BaselinesPage/CreateBaselineModal/redux/reducers.js
+++ b/src/SmartComponents/BaselinesPage/CreateBaselineModal/redux/reducers.js
@@ -1,4 +1,5 @@
 import types from './types';
+import helpers from '../../../helpers';
 
 const initialState = {
     createBaselineModalOpened: false,
@@ -35,11 +36,11 @@ export function createBaselineModalReducer(state = initialState, action) {
             response = action.payload.response;
 
             if (response.data === '') {
-                errorObject = { detail: response.statusText, status: response.status };
+                errorObject = { detail: helpers.makeSentenceCase(response.statusText), status: response.status };
             } else if (response.data.message) {
-                errorObject = { detail: response.data.message, status: response.status };
+                errorObject = { detail: helpers.makeSentenceCase(response.data.message), status: response.status };
             } else {
-                errorObject = { detail: response.data.detail, status: response.status };
+                errorObject = { detail: helpers.makeSentenceCase(response.data.detail), status: response.status };
             }
 
             return {

--- a/src/SmartComponents/__tests__/helpers.tests.js
+++ b/src/SmartComponents/__tests__/helpers.tests.js
@@ -4,6 +4,11 @@ import helpers from '../helpers';
 
 /*eslint-disable camelcase*/
 describe('helpers', () => {
+    it('should make string sentence case', () => {
+        let string = 'this is a sentence.';
+        expect(helpers.makeSentenceCase(string)).toEqual('This is a sentence.');
+    });
+
     it.skip('buildSystemsTableWithSelectedHSP returns selected HSP', () => {
         const rows = [
             { display_name: 'system1', id: 'abcd1234' },

--- a/src/SmartComponents/helpers.js
+++ b/src/SmartComponents/helpers.js
@@ -114,10 +114,15 @@ function downloadCSV(baselineData) {
     link.dispatchEvent(new MouseEvent(`click`, { bubbles: true, cancelable: true, view: window }));
 }
 
+function makeSentenceCase(message) {
+    return message.charAt(0).toUpperCase() + message.slice(1);
+}
+
 export default {
     findSelectedOnPage,
     findCheckedValue,
     paginateData,
     buildSystemsTableWithSelectedHSP,
-    downloadCSV
+    downloadCSV,
+    makeSentenceCase
 };


### PR DESCRIPTION
Before, the error text in the create baseline modal was all lowercase. Now, there is a function that makes any single sentence, sentence case, correctly capitalizing the first letter of a string.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
