### PR TITLE
[DRFT-765] Update create baseline modal text for HSPs

### DIFF
--- a/src/SmartComponents/BaselinesPage/CreateBaselineModal/CreateBaselineModal.js
+++ b/src/SmartComponents/BaselinesPage/CreateBaselineModal/CreateBaselineModal.js
@@ -193,7 +193,7 @@ export class CreateBaselineModal extends Component {
                 id='copy system'
                 ouiaId='create-baseline-copy-system-radio'
                 name='baseline-create-options'
-                label='Copy an existing system'
+                label='Copy an existing system or historical profile'
                 value='copySystemChecked'
                 onChange={ this.handleChecked }
             />
@@ -227,7 +227,7 @@ export class CreateBaselineModal extends Component {
         const { entities, permissions } = this.props;
 
         return (<React.Fragment>
-            <b>Select system to copy from</b>
+            <b>Select system or historical profile to copy from</b>
             <br></br>
             <SystemsTable
                 createBaselineModal={ true }

--- a/src/SmartComponents/BaselinesPage/CreateBaselineModal/__tests__/__snapshots__/CreateBaselineModal.tests.js.snap
+++ b/src/SmartComponents/BaselinesPage/CreateBaselineModal/__tests__/__snapshots__/CreateBaselineModal.tests.js.snap
@@ -320,7 +320,7 @@ exports[`ConnectedCreateBaselineModal should render correctly 1`] = `
                                 class="pf-c-radio__label"
                                 for="copy system"
                               >
-                                Copy an existing system
+                                Copy an existing system or historical profile
                               </label>
                             </div>
                             <div
@@ -662,7 +662,7 @@ exports[`ConnectedCreateBaselineModal should render correctly 1`] = `
                                     isChecked={false}
                                     isDisabled={false}
                                     isValid={true}
-                                    label="Copy an existing system"
+                                    label="Copy an existing system or historical profile"
                                     name="baseline-create-options"
                                     onChange={[Function]}
                                     ouiaId="create-baseline-copy-system-radio"
@@ -689,7 +689,7 @@ exports[`ConnectedCreateBaselineModal should render correctly 1`] = `
                                         className="pf-c-radio__label"
                                         htmlFor="copy system"
                                       >
-                                        Copy an existing system
+                                        Copy an existing system or historical profile
                                       </label>
                                     </div>
                                   </Radio>
@@ -933,7 +933,7 @@ exports[`CreateBaselineModal should render correctly 1`] = `
     isChecked={false}
     isDisabled={false}
     isValid={true}
-    label="Copy an existing system"
+    label="Copy an existing system or historical profile"
     name="baseline-create-options"
     onChange={[Function]}
     ouiaId="create-baseline-copy-system-radio"


### PR DESCRIPTION
Before, if you wanted to copy an hsp as a baseline, there were no clear indications of what to select. The radio button in the create baseline modal read, "Copy an exisiting system"; and the text at the top of the table, after you selected that checkbox read, "Select system to copy from".

This PR updates the text like so, respectively:
"Copy an existing system or historical profile"
"Select system or historical profile to copy from"

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
