### PR TITLE
[DRFT-608] Fix case-sensitivity in active fact filters

### DIFF
--- a/src/SmartComponents/modules/__tests__/helpers-tests.js
+++ b/src/SmartComponents/modules/__tests__/helpers-tests.js
@@ -121,6 +121,18 @@ describe('helpers', () => {
         ).toEqual(filteredUpperCaseSubFact);
     });
 
+    it('should filterCompareData with upper case activeFactFilter', () => {
+        const data = compareReducerPayloadWithUppercase.facts;
+        const stateFilters = stateFiltersFixtures.allStatesTrue;
+        const factFilter = '';
+        const referenceId = undefined;
+        const activeFactFilters = [ 'CPU' ];
+
+        expect(
+            helpers.filterCompareData(data, stateFilters, factFilter, referenceId, activeFactFilters)
+        ).toEqual(filteredUpperCaseFact);
+    });
+
     it('should filterMultiFacts with all states true', () => {
         const multivalueItems = multivalues;
         const stateFilters = stateFiltersFixtures.allStatesTrue;

--- a/src/SmartComponents/modules/__tests__/reducer-test.js
+++ b/src/SmartComponents/modules/__tests__/reducer-test.js
@@ -910,6 +910,34 @@ describe('compare reducer', () => {
         });
     });
 
+    it('should handle HANDLE_FACT_FILTER uppercase active filters, all states different', () => {
+        expect(
+            compareReducer({
+                page: 1,
+                perPage: 50,
+                fullCompareData: compareReducerPayloadWithCategory.facts,
+                systems: compareReducerPayloadWithCategory.systems,
+                factFilter: 'BIOS',
+                activeFactFilters: [],
+                stateFilters: stateFilters.allStatesFalse },
+            {
+                payload: 'BIOS',
+                type: `${types.HANDLE_FACT_FILTER}`
+            })
+        ).toEqual({
+            fullCompareData: compareReducerPayloadWithCategory.facts,
+            factFilter: '',
+            activeFactFilters: [ 'BIOS' ],
+            filteredCompareData: [],
+            sortedFilteredFacts: [],
+            systems: activeFactFilteredStateOne.systems,
+            page: 1,
+            perPage: 50,
+            stateFilters: stateFilters.allStatesFalse,
+            totalFacts: 0
+        });
+    });
+
     it('should handle CLEAR_ALL_FACT_FILTERS', () => {
         expect(
             compareReducer({

--- a/src/SmartComponents/modules/helpers.js
+++ b/src/SmartComponents/modules/helpers.js
@@ -78,6 +78,8 @@ function filterCompareData(data, stateFilters, factFilter, referenceId, activeFa
     let filteredFacts = [];
     let filteredComparisons = [];
     let isStateSelected;
+    let lowerCaseFactFilter = factFilter.toLowerCase();
+    let lowerCaseActiveFilters = activeFactFilters?.map(filter => filter.toLowerCase());
 
     if (data === null || !data.length) {
         return [];
@@ -88,7 +90,7 @@ function filterCompareData(data, stateFilters, factFilter, referenceId, activeFa
         isStateSelected = getStateSelected(data[i].state, stateFilters);
 
         if (data[i].comparisons) {
-            if (lowerCaseFactName === factFilter || activeFactFilters?.includes(lowerCaseFactName)) {
+            if (lowerCaseFactName === lowerCaseFactFilter || lowerCaseActiveFilters?.includes(lowerCaseFactName)) {
                 setTooltip(data[i], stateFilters, referenceId);
                 filteredComparisons = filterComparisons(data[i].comparisons, stateFilters, '', referenceId, []);
                 filteredFacts.push({
@@ -101,7 +103,7 @@ function filterCompareData(data, stateFilters, factFilter, referenceId, activeFa
                 continue;
             }
 
-            filteredComparisons = filterComparisons(data[i].comparisons, stateFilters, factFilter, referenceId, activeFactFilters);
+            filteredComparisons = filterComparisons(data[i].comparisons, stateFilters, lowerCaseFactFilter, referenceId, lowerCaseActiveFilters);
 
             if (filteredComparisons.length) {
                 setTooltip(data[i], stateFilters, referenceId);
@@ -113,7 +115,7 @@ function filterCompareData(data, stateFilters, factFilter, referenceId, activeFa
                 });
             }
         } else {
-            if (isStateSelected && filterFact(lowerCaseFactName, factFilter, activeFactFilters)) {
+            if (isStateSelected && filterFact(lowerCaseFactName, lowerCaseFactFilter, lowerCaseActiveFilters)) {
                 setTooltip(data[i], stateFilters, referenceId);
                 filteredFacts.push(data[i]);
             }

--- a/src/SmartComponents/modules/reducers.js
+++ b/src/SmartComponents/modules/reducers.js
@@ -54,7 +54,6 @@ export function compareReducer(state = initialState, action) {
     let newActiveFactFilters = [];
     let index;
     let newFactFilter;
-    let lowerCaseFilter;
 
     switch (action.type) {
         case types.CLEAR_COMPARISON:
@@ -169,16 +168,14 @@ export function compareReducer(state = initialState, action) {
                 totalFacts: filteredFacts.length
             };
         case `${types.FILTER_BY_FACT}`:
-            lowerCaseFilter = action.payload.toLowerCase();
-
             filteredFacts = reducerHelpers.filterCompareData(
-                state.fullCompareData, state.stateFilters, lowerCaseFilter, state.referenceId, state.activeFactFilters
+                state.fullCompareData, state.stateFilters, action.payload, state.referenceId, state.activeFactFilters
             );
             sortedFacts = reducerHelpers.sortData(filteredFacts, state.factSort, state.stateSort);
             paginatedFacts = reducerHelpers.paginateData(sortedFacts, 1, state.perPage);
             return {
                 ...state,
-                factFilter: lowerCaseFilter,
+                factFilter: action.payload,
                 page: 1,
                 filteredCompareData: paginatedFacts,
                 sortedFilteredFacts: sortedFacts,


### PR DESCRIPTION
To repro:
If my filter has all lower case, it will match as I type it through hitting return.  If my filter has any upper case, it will match as I type, but no longer after I hit return.

Before, the app didn't properly handle case-insensitivity with active fact filters (pressing enter after a filter is added). Now, if a fact is added to active fact filters, it properly handles it.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
