### PR TITLE
[DRFT-578] Edit baseline fact error should be sentence case

### DIFF
--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/redux/reducers.js
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/redux/reducers.js
@@ -80,11 +80,11 @@ export function editBaselineReducer(state = initialState, action) {
             response = action.payload.response;
 
             if (response.data === '') {
-                errorObject = { detail: response.statusText, status: response.status };
+                errorObject = { detail: helpers.makeSentenceCase(response.statusText), status: response.status };
             } else if (response.data.message) {
-                errorObject = { detail: response.data.message, status: response.status };
+                errorObject = { detail: helpers.makeSentenceCase(response.data.message), status: response.status };
             } else {
-                errorObject = { detail: response.data.detail, status: response.status };
+                errorObject = { detail: helpers.makeSentenceCase(response.data.detail), status: response.status };
             }
 
             return {

--- a/src/SmartComponents/helpers.js
+++ b/src/SmartComponents/helpers.js
@@ -114,10 +114,15 @@ function downloadCSV(baselineData) {
     link.dispatchEvent(new MouseEvent(`click`, { bubbles: true, cancelable: true, view: window }));
 }
 
+function makeSentenceCase(message) {
+    return message.charAt(0).toUpperCase() + message.slice(1);
+}
+
 export default {
     findSelectedOnPage,
     findCheckedValue,
     paginateData,
     buildSystemsTableWithSelectedHSP,
-    downloadCSV
+    downloadCSV,
+    makeSentenceCase
 };


### PR DESCRIPTION
Before, if there was an error in the edit fact modal, the error would be in all lowercase. Now the error is properly in sentence case.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
