### PR TITLE
[DRFT-582] Allow facts and categories to share names

### DIFF
--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaseline/EditBaseline.js
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaseline/EditBaseline.js
@@ -163,7 +163,10 @@ class EditBaseline extends Component {
 
         baselinesWrite
             ? row.push(<td
-                className={ expandedRows.includes(fact[FACT_NAME]) ? 'pf-c-table__check nested-fact' : 'pf-c-table__check' }>
+                className={ expandedRows.includes(fact[FACT_NAME]) && Array.isArray(fact[2])
+                    ? 'pf-c-table__check nested-fact'
+                    : 'pf-c-table__check' }
+            >
                 { this.renderCheckbox(fact) }
             </td>)
             : null;

--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaseline/__tests__/helpers.fixtures.js
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaseline/__tests__/helpers.fixtures.js
@@ -23,6 +23,31 @@ const mockBaselineData1 = {
     ]
 };
 
+const mockBaselineDataSameName1 = {
+    account: '12345678',
+    created: '2019-10-17T16:20:06.050710Z',
+    display_name: 'lotr-baseline',
+    fact_count: 3,
+    id: 'jf8alskj-jf74-aje8-ke83-jf84ldjru439k',
+    updated: '2020-02-06T21:48:30.661510Z',
+    baseline_facts: [
+        { name: 'Sauron', value: 'the Dark Lord' },
+        { name: 'Galadriel', value: 'the Elven Queen' },
+        { name: 'The Fellowship of the Ring', value: 'same name as category' },
+        { name: 'The Fellowship of the Ring', values: [
+            { name: 'Frodo', value: 'Baggins' },
+            { name: 'Samwise', value: 'Gamgee' },
+            { name: 'Gandalf', value: 'the Grey' },
+            { name: 'Meriadoc', value: 'Brandybuck' },
+            { name: 'Peregrin', value: 'Took' },
+            { name: 'Gimli', value: 'son of Gloin' },
+            { name: 'Legolas', value: 'Greenleaf' },
+            { name: 'Boromir', value: 'son of Denethor' },
+            { name: 'Aragorn', value: 'son of Arathorn' }
+        ]}
+    ]
+};
+
 const mockBaselineTableData1 = [
     [ 0, 'Sauron', 'the Dark Lord' ],
     [ 1, 'Galadriel', 'the Elven Queen' ],
@@ -246,6 +271,7 @@ const editParentFactAPIBody = {
 
 export default {
     mockBaselineData1,
+    mockBaselineDataSameName1,
     mockBaselineTableData1,
     mockBaselineAPIBody,
     originalAPIBody,

--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaseline/__tests__/helpers.tests.js
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaseline/__tests__/helpers.tests.js
@@ -84,6 +84,23 @@ describe('edit baseline helpers', () => {
         );
     });
 
+    it('buildEditedFactData with same subFact name just returns', () => {
+        const isParent = undefined;
+        const originalFactName = 'old-virus';
+        const factName = 'old-virus';
+        const originalValueName = 'SARS';
+        const factValue = 'SARS';
+        const factData = { name: 'viruses', values: [
+            { name: 'old-virus', value: 'SARS' }
+        ]};
+
+        expect(editBaselineHelpers.buildEditedFactData(isParent, originalFactName, factName, originalValueName, factValue, factData)).toEqual(
+            { name: 'viruses', values: [
+                { name: 'old-virus', value: 'SARS' }
+            ]}
+        );
+    });
+
     it('isAllSelected retuns false', () => {
         editBaselineFixtures.mockBaselineTableData1[0].selected = true;
         editBaselineFixtures.mockBaselineTableData1[1].selected = true;
@@ -158,6 +175,23 @@ describe('edit baseline helpers', () => {
         expect(editBaselineHelpers.makeAddFactPatch(newFactData, originalAPIBody)).toEqual(newAPIBody);
     });
 
+    it('makeAddFactPatch adds fact to category, not fact with same name', () => {
+        let newFactData = { name: 'The Fellowship of the Ring', values: [
+            { name: 'Gollum', value: 'Smeagol' }
+        ]};
+        let originalAPIBody = editBaselineFixtures.mockBaselineDataSameName1;
+        let newAPIBody = {
+            display_name: 'lotr-baseline',
+            facts_patch: [
+                { op: 'add', path: '/3/values/0', value:
+                    { name: 'Gollum', value: 'Smeagol' }
+                }
+            ]
+        };
+
+        expect(editBaselineHelpers.makeAddFactPatch(newFactData, originalAPIBody)).toEqual(newAPIBody);
+    });
+
     it('makeDeleteFactsPatch removes single fact', () => {
         let factsToDelete = editBaselineFixtures.mockBaselineTableData1;
         factsToDelete.forEach(fact => fact.selected = false);
@@ -174,6 +208,42 @@ describe('edit baseline helpers', () => {
         };
 
         expect(editBaselineHelpers.makeDeleteFactsPatch(factsToDelete, originalAPIBody)).toEqual(newAPIBody);
+    });
+
+    it('returns true if categories with same name', () => {
+        let factA = editBaselineFixtures.newParentFact;
+        let factB = editBaselineFixtures.newParentFact;
+        expect(editBaselineHelpers.isSameFact(factA, factB)).toEqual(true);
+    });
+
+    it('returns true if facts with same name', () => {
+        let factA = editBaselineFixtures.newFact;
+        let factB = editBaselineFixtures.newFact;
+        expect(editBaselineHelpers.isSameFact(factA, factB)).toEqual(true);
+    });
+
+    it('returns false if different category', () => {
+        let factA = editBaselineFixtures.newParentFact;
+        let factB = editBaselineFixtures.editParentFact;
+        expect(editBaselineHelpers.isSameFact(factA, factB)).toEqual(false);
+    });
+
+    it('returns false if different fact', () => {
+        let factA = editBaselineFixtures.newFact;
+        let factB = editBaselineFixtures.editFact;
+        expect(editBaselineHelpers.isSameFact(factA, factB)).toEqual(false);
+    });
+
+    it('returns false if category and fact', () => {
+        let factA = editBaselineFixtures.newParentFact;
+        let factB = editBaselineFixtures.newFact;
+        expect(editBaselineHelpers.isSameFact(factA, factB)).toEqual(false);
+    });
+
+    it('returns false if category and fact with same name', () => {
+        let factA = editBaselineFixtures.newParentFact;
+        let factB = { name: 'new_parent_fact', value: 'new_value' };
+        expect(editBaselineHelpers.isSameFact(factA, factB)).toEqual(false);
     });
 });
 /*eslint-enable camelcase*/

--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaseline/helpers.js
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaseline/helpers.js
@@ -63,7 +63,7 @@ function buildEditedFactData(isParent, originalFactName, factName, originalValue
             let newSubFact = { name: factName, value: factValue };
 
             factData.values.forEach(function(subFact) {
-                if (subFact.name === originalSubFact.name && subFact.value === originalSubFact.value) {
+                if (isSameFact(originalSubFact, subFact)) {
                     return;
                 }
 
@@ -84,7 +84,7 @@ function buildDeletedSubFact(factToDelete, fact) {
     let newSubFacts = [];
 
     fact.values.forEach(function(subFact) {
-        if (subFact.name === factToDelete.name && subFact.value === factToDelete.value) {
+        if (isSameFact(subFact, factToDelete)) {
             return;
         }
 
@@ -102,7 +102,7 @@ function makeDeleteFactPatch(factToDelete, originalAPIBody) {
 
     /*eslint-disable camelcase*/
     originalAPIBody.baseline_facts.forEach(function(fact, index) {
-        if (fact.name === factToDelete.name) {
+        if (fact.name === factToDelete.name && fact.value === factToDelete.value) {
             path += index;
         }
     });
@@ -122,13 +122,13 @@ function makeDeleteSubFactPatch(factToDelete, parentFact, originalAPIBody) {
 
     /*eslint-disable camelcase*/
     originalAPIBody.baseline_facts.forEach(function(fact, index) {
-        if (fact.name === parentFact.name) {
+        if (isSameFact(fact, parentFact)) {
             path = `/${index}/values`;
         }
     });
 
     parentFact.values.forEach(function(fact, index) {
-        if (fact.name === factToDelete.name) {
+        if (isSameFact(fact, factToDelete)) {
             path += `/${index}`;
         }
     });
@@ -189,7 +189,7 @@ function makeAddFactPatch(newFactData, originalAPIBody) {
         value = newFactData.values[newFactData.values.length - 1];
 
         for (let i = 0; i < originalAPIBody.baseline_facts.length; i += 1) {
-            if (originalAPIBody.baseline_facts[i].name === newFactData.name) {
+            if (isSameFact(originalAPIBody.baseline_facts[i], newFactData)) {
                 index = i;
             }
         }
@@ -339,6 +339,18 @@ function isCategory(fact) {
     }
 }
 
+function isSameFact(factA, factB) {
+    if (factA.name === factB.name) {
+        if (factA.values === factB.values || factA.value === factB.value) {
+            return true;
+        } else {
+            return false;
+        }
+    } else {
+        return false;
+    }
+}
+
 function baselineSubFacts(fact) {
     return fact[2];
 }
@@ -436,6 +448,7 @@ export default {
     toggleExpandedRow,
     isAllSelected,
     isCategory,
+    isSameFact,
     baselineSubFacts,
     findFactCount,
     findSelected,


### PR DESCRIPTION
Because of a discussion in which we decided that a fact and a category can share the same name, we are updating the system-baseline-backend repo with a PR that allows this to happen. This caused some add, deleting and editing of facts, categories and sub facts to work improperly.

This PR allows things to work as usual with a new feature that allows a category and fact to share a name. Facts still can't share names with other facts and categories can't share names with other categories.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
