### PR TITLE
[DRFT-590] 'X' icon in hsp selection should be gray

### DIFF
--- a/src/SmartComponents/helpers.js
+++ b/src/SmartComponents/helpers.js
@@ -70,7 +70,7 @@ function buildSystemsTableWithSelectedHSP (rows, selectedHSP, deselectHistorical
                         moment.utc(selectedHSP.captured_date).format('DD MMM YYYY, HH:mm UTC')
                     }
                     <CloseIcon
-                        className='pointer active-blue margin-left-5-px'
+                        className='pointer not-active margin-left-5-px'
                         onClick={ () => deselectHistoricalProfiles() }
                     />
                 </div>


### PR DESCRIPTION
To reproduce:
Go to baselines list
Click "Create baseline"
Select "Copy an existing system or historical profile"
Select an hsp from a system that has an hsp

The blue 'X' icon should appear next to the time stamp for the hsp underneath the name of the system to which it belongs. This PR changes that icon to gray when the cursor is not hovering over it and black when it is.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
