### PR TITLE
[DRFT-596] Update incomplete data icon to #6A6E73

### DIFF
--- a/src/SmartComponents/DriftPage/DriftTable/__tests__/__snapshots__/DriftTable.tests.js.snap
+++ b/src/SmartComponents/DriftPage/DriftTable/__tests__/__snapshots__/DriftTable.tests.js.snap
@@ -6752,7 +6752,7 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
                             }
                             trigger={
                               <QuestionCircleIcon
-                                color="#151515"
+                                color="#6A6E73"
                                 height="16px"
                                 noVerticalAlign={false}
                                 size="sm"
@@ -6765,7 +6765,7 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
                               onFoundRef={[Function]}
                             >
                               <QuestionCircleIcon
-                                color="#151515"
+                                color="#6A6E73"
                                 height="16px"
                                 noVerticalAlign={false}
                                 size="sm"
@@ -6774,7 +6774,7 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
                                 <svg
                                   aria-hidden={true}
                                   aria-labelledby={null}
-                                  fill="#151515"
+                                  fill="#6A6E73"
                                   height="16px"
                                   role="img"
                                   style={
@@ -7003,7 +7003,7 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
                             }
                             trigger={
                               <QuestionCircleIcon
-                                color="#151515"
+                                color="#6A6E73"
                                 height="16px"
                                 noVerticalAlign={false}
                                 size="sm"
@@ -7016,7 +7016,7 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
                               onFoundRef={[Function]}
                             >
                               <QuestionCircleIcon
-                                color="#151515"
+                                color="#6A6E73"
                                 height="16px"
                                 noVerticalAlign={false}
                                 size="sm"
@@ -7025,7 +7025,7 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
                                 <svg
                                   aria-hidden={true}
                                   aria-labelledby={null}
-                                  fill="#151515"
+                                  fill="#6A6E73"
                                   height="16px"
                                   role="img"
                                   style={
@@ -7361,7 +7361,7 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
                             }
                             trigger={
                               <QuestionCircleIcon
-                                color="#151515"
+                                color="#6A6E73"
                                 height="16px"
                                 noVerticalAlign={false}
                                 size="sm"
@@ -7374,7 +7374,7 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
                               onFoundRef={[Function]}
                             >
                               <QuestionCircleIcon
-                                color="#151515"
+                                color="#6A6E73"
                                 height="16px"
                                 noVerticalAlign={false}
                                 size="sm"
@@ -7383,7 +7383,7 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
                                 <svg
                                   aria-hidden={true}
                                   aria-labelledby={null}
-                                  fill="#151515"
+                                  fill="#6A6E73"
                                   height="16px"
                                   role="img"
                                   style={

--- a/src/SmartComponents/StateIcon/StateIcon.js
+++ b/src/SmartComponents/StateIcon/StateIcon.js
@@ -16,7 +16,7 @@ class StateIcon extends Component {
         } else if (this.props.fact.state === 'DIFFERENT') {
             iconClass = <ExclamationCircleIcon color='#C9190B' height='16px' width='16px'/>;
         } else {
-            iconClass = <QuestionCircleIcon color='#151515' height='16px' width='16px'/>;
+            iconClass = <QuestionCircleIcon color='#6A6E73' height='16px' width='16px'/>;
         }
 
         return iconClass;


### PR DESCRIPTION
To reproduce:
Create a comparison that includes a state of incomplete data

The incomplete data icon should be black. This PR updates the color so it's #6A6E73

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
