### PR TITLE
[DRFT-596] Left align baselines toolbar

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -67,6 +67,12 @@
   background: #DEF3FF;
 }
 
+.baseline-toolbar {
+  .pf-c-toolbar__content {
+    padding-left: 0;
+  }
+}
+
 .baseline-header {
   overflow: visible;
   border-top: 1px solid #CCC;

--- a/src/SmartComponents/AddSystemModal/AddSystemModal.js
+++ b/src/SmartComponents/AddSystemModal/AddSystemModal.js
@@ -336,6 +336,7 @@ export class AddSystemModal extends Component {
                                 permissions={ permissions }
                                 kebab={ false }
                                 basketIsVisible={ basketIsVisible }
+                                leftAlignToolbar={ true }
                             />
                         </Tab>
                     </Tabs>

--- a/src/SmartComponents/AddSystemModal/__tests__/__snapshots__/AddSystemModal.tests.js.snap
+++ b/src/SmartComponents/AddSystemModal/__tests__/__snapshots__/AddSystemModal.tests.js.snap
@@ -173,6 +173,7 @@ exports[`AddSystemModal should render correctly 1`] = `
           }
           hasMultiSelect={true}
           kebab={false}
+          leftAlignToolbar={true}
           loading={false}
           onBulkSelect={[Function]}
           onSelect={[Function]}
@@ -9744,7 +9745,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                             tabindex="0"
                           >
                             <div
-                              class="pf-c-toolbar drift-toolbar"
+                              class="pf-c-toolbar baseline-toolbar"
                               id="pf-random-id-10"
                             >
                               <div
@@ -12220,6 +12221,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                           }
                                           hasMultiSelect={true}
                                           kebab={false}
+                                          leftAlignToolbar={true}
                                           loading={false}
                                           onBulkSelect={[Function]}
                                           onSelect={[Function]}
@@ -12269,6 +12271,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                             }
                                             hasMultiSelect={true}
                                             kebab={false}
+                                            leftAlignToolbar={true}
                                             loading={false}
                                             onBulkSelect={[Function]}
                                             onSelect={[Function]}
@@ -12319,6 +12322,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                           }
                                           hasMultiSelect={true}
                                           kebab={false}
+                                          leftAlignToolbar={true}
                                           loading={false}
                                           onBulkSelect={[Function]}
                                           onSelect={[Function]}
@@ -12356,6 +12360,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                             fetchBaselines={[Function]}
                                             hasMultiSelect={true}
                                             kebab={false}
+                                            leftAlignToolbar={true}
                                             loading={false}
                                             onBulkSelect={[Function]}
                                             onSelect={[Function]}
@@ -12376,6 +12381,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                               hasMultiSelect={true}
                                               isDeleteDisabled={true}
                                               kebab={false}
+                                              leftAlignToolbar={true}
                                               loading={false}
                                               onBulkSelect={[Function]}
                                               onSearch={[Function]}
@@ -12493,14 +12499,14 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                                 </DeleteBaselinesModal>
                                               </Connect(DeleteBaselinesModal)>
                                               <Toolbar
-                                                className="drift-toolbar"
+                                                className="baseline-toolbar"
                                                 clearAllFilters={[Function]}
                                               >
                                                 <GenerateId
                                                   prefix="pf-random-id-"
                                                 >
                                                   <div
-                                                    className="pf-c-toolbar drift-toolbar"
+                                                    className="pf-c-toolbar baseline-toolbar"
                                                     id="pf-random-id-10"
                                                   >
                                                     <ToolbarContent
@@ -16791,7 +16797,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                             tabindex="0"
                           >
                             <div
-                              class="pf-c-toolbar drift-toolbar"
+                              class="pf-c-toolbar baseline-toolbar"
                               id="pf-random-id-1"
                             >
                               <div
@@ -19140,6 +19146,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                           }
                                           hasMultiSelect={true}
                                           kebab={false}
+                                          leftAlignToolbar={true}
                                           loading={false}
                                           onBulkSelect={[Function]}
                                           onSelect={[Function]}
@@ -19189,6 +19196,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                             }
                                             hasMultiSelect={true}
                                             kebab={false}
+                                            leftAlignToolbar={true}
                                             loading={false}
                                             onBulkSelect={[Function]}
                                             onSelect={[Function]}
@@ -19239,6 +19247,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                           }
                                           hasMultiSelect={true}
                                           kebab={false}
+                                          leftAlignToolbar={true}
                                           loading={false}
                                           onBulkSelect={[Function]}
                                           onSelect={[Function]}
@@ -19276,6 +19285,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                             fetchBaselines={[Function]}
                                             hasMultiSelect={true}
                                             kebab={false}
+                                            leftAlignToolbar={true}
                                             loading={false}
                                             onBulkSelect={[Function]}
                                             onSelect={[Function]}
@@ -19296,6 +19306,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                               hasMultiSelect={true}
                                               isDeleteDisabled={true}
                                               kebab={false}
+                                              leftAlignToolbar={true}
                                               loading={false}
                                               onBulkSelect={[Function]}
                                               onSearch={[Function]}
@@ -19413,14 +19424,14 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                                 </DeleteBaselinesModal>
                                               </Connect(DeleteBaselinesModal)>
                                               <Toolbar
-                                                className="drift-toolbar"
+                                                className="baseline-toolbar"
                                                 clearAllFilters={[Function]}
                                               >
                                                 <GenerateId
                                                   prefix="pf-random-id-"
                                                 >
                                                   <div
-                                                    className="pf-c-toolbar drift-toolbar"
+                                                    className="pf-c-toolbar baseline-toolbar"
                                                     id="pf-random-id-1"
                                                   >
                                                     <ToolbarContent
@@ -23722,7 +23733,7 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                             tabindex="0"
                           >
                             <div
-                              class="pf-c-toolbar drift-toolbar"
+                              class="pf-c-toolbar baseline-toolbar"
                               id="pf-random-id-4"
                             >
                               <div
@@ -25481,6 +25492,7 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                           }
                                           hasMultiSelect={true}
                                           kebab={false}
+                                          leftAlignToolbar={true}
                                           loading={false}
                                           onBulkSelect={[Function]}
                                           onSelect={[Function]}
@@ -25530,6 +25542,7 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                             }
                                             hasMultiSelect={true}
                                             kebab={false}
+                                            leftAlignToolbar={true}
                                             loading={false}
                                             onBulkSelect={[Function]}
                                             onSelect={[Function]}
@@ -25580,6 +25593,7 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                           }
                                           hasMultiSelect={true}
                                           kebab={false}
+                                          leftAlignToolbar={true}
                                           loading={false}
                                           onBulkSelect={[Function]}
                                           onSelect={[Function]}
@@ -25617,6 +25631,7 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                             fetchBaselines={[Function]}
                                             hasMultiSelect={true}
                                             kebab={false}
+                                            leftAlignToolbar={true}
                                             loading={false}
                                             onBulkSelect={[Function]}
                                             onSelect={[Function]}
@@ -25637,6 +25652,7 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                               hasMultiSelect={true}
                                               isDeleteDisabled={true}
                                               kebab={false}
+                                              leftAlignToolbar={true}
                                               loading={false}
                                               onBulkSelect={[Function]}
                                               onSearch={[Function]}
@@ -25754,14 +25770,14 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                                 </DeleteBaselinesModal>
                                               </Connect(DeleteBaselinesModal)>
                                               <Toolbar
-                                                className="drift-toolbar"
+                                                className="baseline-toolbar"
                                                 clearAllFilters={[Function]}
                                               >
                                                 <GenerateId
                                                   prefix="pf-random-id-"
                                                 >
                                                   <div
-                                                    className="pf-c-toolbar drift-toolbar"
+                                                    className="pf-c-toolbar baseline-toolbar"
                                                     id="pf-random-id-4"
                                                   >
                                                     <ToolbarContent

--- a/src/SmartComponents/BaselinesPage/BaselinesPage.js
+++ b/src/SmartComponents/BaselinesPage/BaselinesPage.js
@@ -78,7 +78,7 @@ export class BaselinesPage extends Component {
     }
 
     renderTable(permissions) {
-        const { baselineTableData, loading, createBaselineModalOpened, clearEditBaselineData, selectedBaselineIds,
+        const { baselineTableData, loading, clearEditBaselineData, selectedBaselineIds,
             totalBaselines } = this.props;
         const { columns } = this.state;
 
@@ -98,7 +98,6 @@ export class BaselinesPage extends Component {
                         createButton={ true }
                         exportButton={ true }
                         onClick={ this.fetchBaseline }
-                        createBaselineModalOpened={ createBaselineModalOpened }
                         onBulkSelect={ this.onBulkSelect }
                         selectedBaselineIds={ selectedBaselineIds }
                         totalBaselines={ totalBaselines }
@@ -188,7 +187,6 @@ BaselinesPage.propTypes = {
     loading: PropTypes.bool,
     baselineTableData: PropTypes.array,
     emptyState: PropTypes.bool,
-    createBaselineModalOpened: PropTypes.bool,
     selectBaseline: PropTypes.func,
     history: PropTypes.object,
     baselineError: PropTypes.object,
@@ -206,7 +204,6 @@ function mapStateToProps(state) {
         loading: state.baselinesTableState.checkboxTable.loading,
         emptyState: state.baselinesTableState.checkboxTable.emptyState,
         baselineTableData: state.baselinesTableState.checkboxTable.baselineTableData,
-        createBaselineModalOpened: state.createBaselineModalState.createBaselineModalOpened,
         baselineError: state.baselinesTableState.checkboxTable.baselineError,
         selectedBaselineIds: state.baselinesTableState.checkboxTable.selectedBaselineIds,
         totalBaselines: state.baselinesTableState.checkboxTable.totalBaselines

--- a/src/SmartComponents/BaselinesPage/CreateBaselineModal/CreateBaselineModal.js
+++ b/src/SmartComponents/BaselinesPage/CreateBaselineModal/CreateBaselineModal.js
@@ -202,7 +202,7 @@ export class CreateBaselineModal extends Component {
     }
 
     renderCopyBaseline() {
-        const { baselineTableData, createBaselineModalOpened, loading, permissions, selectedBaselineIds, totalBaselines } = this.props;
+        const { baselineTableData, loading, permissions, selectedBaselineIds, totalBaselines } = this.props;
         const { columns } = this.state;
 
         return (<React.Fragment>
@@ -212,12 +212,12 @@ export class CreateBaselineModal extends Component {
                 onSelect={ this.onSelect }
                 tableData={ baselineTableData }
                 loading={ loading }
-                createBaselineModalOpened={ createBaselineModalOpened }
                 columns={ columns }
                 totalBaselines={ totalBaselines }
                 permissions={ permissions }
                 hasMultiSelect={ false }
                 selectedBaselineIds={ selectedBaselineIds }
+                leftAlignToolbar={ true }
             />
         </React.Fragment>
         );

--- a/src/SmartComponents/BaselinesPage/__tests__/__snapshots__/BaselinesPage.tests.js.snap
+++ b/src/SmartComponents/BaselinesPage/__tests__/__snapshots__/BaselinesPage.tests.js.snap
@@ -101,7 +101,6 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
             baselineError={Object {}}
             baselineTableData={Array []}
             clearEditBaselineData={[Function]}
-            createBaselineModalOpened={false}
             emptyState={false}
             history={
               Object {
@@ -457,7 +456,6 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                                   },
                                 ]
                               }
-                              createBaselineModalOpened={false}
                               createButton={true}
                               exportButton={true}
                               hasMultiSelect={true}
@@ -502,7 +500,6 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                                     },
                                   ]
                                 }
-                                createBaselineModalOpened={false}
                                 createButton={true}
                                 exportButton={true}
                                 exportToCSV={[Function]}
@@ -645,14 +642,14 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                                     </DeleteBaselinesModal>
                                   </Connect(DeleteBaselinesModal)>
                                   <Toolbar
-                                    className="drift-toolbar"
+                                    className={null}
                                     clearAllFilters={[Function]}
                                   >
                                     <GenerateId
                                       prefix="pf-random-id-"
                                     >
                                       <div
-                                        className="pf-c-toolbar drift-toolbar"
+                                        className="pf-c-toolbar"
                                         id="pf-random-id-0"
                                       >
                                         <ToolbarContent
@@ -5593,7 +5590,6 @@ exports[`ConnectedBaselinesPage should render empty state 1`] = `
             baselineError={Object {}}
             baselineTableData={Array []}
             clearEditBaselineData={[Function]}
-            createBaselineModalOpened={false}
             emptyState={true}
             history={
               Object {

--- a/src/SmartComponents/BaselinesTable/BaselinesTable.js
+++ b/src/SmartComponents/BaselinesTable/BaselinesTable.js
@@ -215,8 +215,8 @@ export class BaselinesTable extends Component {
     }
 
     render() {
-        const { kebab, createButton, exportToCSV, exportButton, hasMultiSelect, loading, onBulkSelect, permissions,
-            selectedBaselineIds, tableData, tableId, totalBaselines } = this.props;
+        const { kebab, createButton, exportToCSV, exportButton, hasMultiSelect, leftAlignToolbar, loading,
+            onBulkSelect, permissions, selectedBaselineIds, tableData, tableId, totalBaselines } = this.props;
         const { page, perPage } = this.state;
 
         return (
@@ -238,6 +238,7 @@ export class BaselinesTable extends Component {
                     totalBaselines={ totalBaselines }
                     updatePagination={ this.updatePagination }
                     exportToCSV={ exportToCSV }
+                    leftAlignToolbar={ leftAlignToolbar }
                     loading={ loading }
                     permissions={ permissions }
                 />
@@ -278,7 +279,8 @@ BaselinesTable.propTypes = {
     totalBaselines: PropTypes.number,
     exportToCSV: PropTypes.func,
     permissions: PropTypes.object,
-    basketIsVisible: PropTypes.bool
+    basketIsVisible: PropTypes.bool,
+    leftAlignToolbar: PropTypes.bool
 };
 
 function mapDispatchToProps(dispatch) {

--- a/src/SmartComponents/BaselinesTable/BaselinesToolbar/BaselinesToolbar.js
+++ b/src/SmartComponents/BaselinesTable/BaselinesToolbar/BaselinesToolbar.js
@@ -106,7 +106,7 @@ export class BaselinesToolbar extends Component {
     }, 250)
 
     render() {
-        const { createButton, exportButton, fetchWithParams, hasMultiSelect, kebab, loading, onBulkSelect,
+        const { createButton, exportButton, fetchWithParams, hasMultiSelect, kebab, leftAlignToolbar, loading, onBulkSelect,
             tableData, tableId, page, permissions, perPage, selectedBaselineIds, totalBaselines, updatePagination } = this.props;
         const { bulkSelectItems, dropdownItems, dropdownOpen, modalOpened, nameSearch } = this.state;
         let selected = tableData.filter(baseline => baseline.selected === true).length;
@@ -120,7 +120,9 @@ export class BaselinesToolbar extends Component {
                     toggleModal={ this.toggleModal }
                     selectedBaselineIds={ selectedBaselineIds }
                 />
-                <Toolbar className="drift-toolbar" clearAllFilters={ this.clearFilters }>
+                <Toolbar
+                    className={ leftAlignToolbar ? 'baseline-toolbar' : null }
+                    clearAllFilters={ this.clearFilters }>
                     <ToolbarContent>
                         { hasMultiSelect
                             ? <ToolbarGroup variant='filter-group'>
@@ -222,7 +224,8 @@ BaselinesToolbar.propTypes = {
     updatePagination: PropTypes.func,
     exportToCSV: PropTypes.func,
     loading: PropTypes.bool,
-    permissions: PropTypes.object
+    permissions: PropTypes.object,
+    leftAlignToolbar: PropTypes.bool
 };
 
 export default BaselinesToolbar;

--- a/src/SmartComponents/BaselinesTable/BaselinesToolbar/__test__/__snapshots__/BaselinesToolbar.test.js.snap
+++ b/src/SmartComponents/BaselinesTable/BaselinesToolbar/__test__/__snapshots__/BaselinesToolbar.test.js.snap
@@ -8,7 +8,7 @@ exports[`jest-tests BaselinesToolbar should render correctly 1`] = `
     toggleModal={[Function]}
   />
   <Toolbar
-    className="drift-toolbar"
+    className={null}
     clearAllFilters={[Function]}
   >
     <ToolbarContent
@@ -302,14 +302,14 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
           </DeleteBaselinesModal>
         </Connect(DeleteBaselinesModal)>
         <Toolbar
-          className="drift-toolbar"
+          className={null}
           clearAllFilters={[Function]}
         >
           <GenerateId
             prefix="pf-random-id-"
           >
             <div
-              className="pf-c-toolbar drift-toolbar"
+              className="pf-c-toolbar"
               id="pf-random-id-0"
             >
               <ToolbarContent

--- a/src/SmartComponents/BaselinesTable/__tests__/__snapshots__/BaselinesTable.tests.js.snap
+++ b/src/SmartComponents/BaselinesTable/__tests__/__snapshots__/BaselinesTable.tests.js.snap
@@ -300,14 +300,14 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
               </DeleteBaselinesModal>
             </Connect(DeleteBaselinesModal)>
             <Toolbar
-              className="drift-toolbar"
+              className={null}
               clearAllFilters={[Function]}
             >
               <GenerateId
                 prefix="pf-random-id-"
               >
                 <div
-                  className="pf-c-toolbar drift-toolbar"
+                  className="pf-c-toolbar"
                   id="pf-random-id-12"
                 >
                   <ToolbarContent
@@ -7131,14 +7131,14 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
               </DeleteBaselinesModal>
             </Connect(DeleteBaselinesModal)>
             <Toolbar
-              className="drift-toolbar"
+              className={null}
               clearAllFilters={[Function]}
             >
               <GenerateId
                 prefix="pf-random-id-"
               >
                 <div
-                  className="pf-c-toolbar drift-toolbar"
+                  className="pf-c-toolbar"
                   id="pf-random-id-14"
                 >
                   <ToolbarContent
@@ -13818,14 +13818,14 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
               </DeleteBaselinesModal>
             </Connect(DeleteBaselinesModal)>
             <Toolbar
-              className="drift-toolbar"
+              className={null}
               clearAllFilters={[Function]}
             >
               <GenerateId
                 prefix="pf-random-id-"
               >
                 <div
-                  className="pf-c-toolbar drift-toolbar"
+                  className="pf-c-toolbar"
                   id="pf-random-id-8"
                 >
                   <ToolbarContent
@@ -25697,14 +25697,14 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
               </DeleteBaselinesModal>
             </Connect(DeleteBaselinesModal)>
             <Toolbar
-              className="drift-toolbar"
+              className={null}
               clearAllFilters={[Function]}
             >
               <GenerateId
                 prefix="pf-random-id-"
               >
                 <div
-                  className="pf-c-toolbar drift-toolbar"
+                  className="pf-c-toolbar"
                   id="pf-random-id-10"
                 >
                   <ToolbarContent
@@ -37175,14 +37175,14 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
               </DeleteBaselinesModal>
             </Connect(DeleteBaselinesModal)>
             <Toolbar
-              className="drift-toolbar"
+              className={null}
               clearAllFilters={[Function]}
             >
               <GenerateId
                 prefix="pf-random-id-"
               >
                 <div
-                  className="pf-c-toolbar drift-toolbar"
+                  className="pf-c-toolbar"
                   id="pf-random-id-4"
                 >
                   <ToolbarContent
@@ -43783,14 +43783,14 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
               </DeleteBaselinesModal>
             </Connect(DeleteBaselinesModal)>
             <Toolbar
-              className="drift-toolbar"
+              className={null}
               clearAllFilters={[Function]}
             >
               <GenerateId
                 prefix="pf-random-id-"
               >
                 <div
-                  className="pf-c-toolbar drift-toolbar"
+                  className="pf-c-toolbar"
                   id="pf-random-id-6"
                 >
                   <ToolbarContent
@@ -48872,14 +48872,14 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
               </DeleteBaselinesModal>
             </Connect(DeleteBaselinesModal)>
             <Toolbar
-              className="drift-toolbar"
+              className={null}
               clearAllFilters={[Function]}
             >
               <GenerateId
                 prefix="pf-random-id-"
               >
                 <div
-                  className="pf-c-toolbar drift-toolbar"
+                  className="pf-c-toolbar"
                   id="pf-random-id-0"
                 >
                   <ToolbarContent


### PR DESCRIPTION
To repro
Click 'Add to comparison' on /drift page
Click 'Baselines' tab

Click 'Create baseline' on /drift/baselines page
Click 'Copy and existing baseline' radio button

In both instances you should see that the toolbar has padding on the left. With this PR, we remove that padding. The padding should remain on the baselines table at /drift/baselines.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
