### PR TITLE
[DRFT-577] Baseline modal errors fix

### DIFF
--- a/src/SmartComponents/BaselinesPage/CreateBaselineModal/CreateBaselineModal.js
+++ b/src/SmartComponents/BaselinesPage/CreateBaselineModal/CreateBaselineModal.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import { Alert, Button, Modal, Radio, TextInput, Form, FormGroup, ValidatedOptions } from '@patternfly/react-core';
+import { Button, Modal, Radio, TextInput, Form, FormGroup, ValidatedOptions } from '@patternfly/react-core';
 import { sortable, cellWidth } from '@patternfly/react-table';
 import { addNewListener } from '../../../store';
 
@@ -344,7 +344,7 @@ export class CreateBaselineModal extends Component {
     }
 
     render() {
-        const { createBaselineError, createBaselineModalOpened, globalFilterState } = this.props;
+        const { createBaselineModalOpened, globalFilterState } = this.props;
         const { copySystemChecked } = this.state;
 
         return (
@@ -359,19 +359,6 @@ export class CreateBaselineModal extends Component {
                 { copySystemChecked
                     ? <GlobalFilterAlert globalFilterState={ globalFilterState }/>
                     : null
-                }
-                { createBaselineError.status
-                    ? <Alert
-                        variant='danger'
-                        isInline
-                        title={ 'Status: ' + createBaselineError.status }
-                        ouiaId="status"
-                    >
-                        <p>
-                            { createBaselineError.detail }
-                        </p>
-                    </Alert>
-                    : <div></div>
                 }
                 { this.renderModalBody() }
             </Modal>

--- a/src/SmartComponents/BaselinesPage/CreateBaselineModal/__tests__/CreateBaselineModal.tests.js
+++ b/src/SmartComponents/BaselinesPage/CreateBaselineModal/__tests__/CreateBaselineModal.tests.js
@@ -30,14 +30,26 @@ describe('CreateBaselineModal', () => {
         jest.clearAllMocks();
     });
 
-    it('should render correctly', () =>{
+    it('should render correctly', () => {
         const wrapper = shallow(
             <CreateBaselineModal { ...props }/>
         );
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 
-    it('should render mount correctly', () =>{
+    it('should render error correctly', () => {
+        props.createBaselineError = {
+            status: 404,
+            detail: 'This is an error'
+        };
+
+        const wrapper = shallow(
+            <CreateBaselineModal { ...props }/>
+        );
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('should render mount correctly', () => {
         const wrapper = mount(
             <CreateBaselineModal { ...props }/>
         );

--- a/src/SmartComponents/BaselinesPage/CreateBaselineModal/__tests__/__snapshots__/CreateBaselineModal.tests.js.snap
+++ b/src/SmartComponents/BaselinesPage/CreateBaselineModal/__tests__/__snapshots__/CreateBaselineModal.tests.js.snap
@@ -258,7 +258,6 @@ exports[`ConnectedCreateBaselineModal should render correctly 1`] = `
                             class="pf-c-modal-box__body"
                             id="pf-modal-part-7"
                           >
-                            <div />
                             <div
                               class="pf-c-radio"
                             >
@@ -580,7 +579,6 @@ exports[`ConnectedCreateBaselineModal should render correctly 1`] = `
                                   className="pf-c-modal-box__body"
                                   id="pf-modal-part-7"
                                 >
-                                  <div />
                                   <Radio
                                     className=""
                                     id="create baseline"
@@ -898,7 +896,6 @@ exports[`CreateBaselineModal should render correctly 1`] = `
   variant="default"
   width="1200px"
 >
-  <div />
   <Radio
     className=""
     id="create baseline"
@@ -954,6 +951,105 @@ exports[`CreateBaselineModal should render correctly 1`] = `
           onChange={[Function]}
           type="text"
           validated={null}
+          value=""
+        />
+      </FormGroup>
+    </Form>
+  </div>
+</Modal>
+`;
+
+exports[`CreateBaselineModal should render error correctly 1`] = `
+<Modal
+  actions={
+    Array [
+      <Button
+        isDisabled={true}
+        ouiaId="create-baseline-button-fromscratch"
+        variant="primary"
+      >
+        Create baseline
+      </Button>,
+      <Button
+        onClick={[Function]}
+        ouiaId="create-baseline-modal-cancel-button"
+        variant="link"
+      >
+        Cancel
+      </Button>,
+    ]
+  }
+  appendTo={[Function]}
+  aria-describedby=""
+  aria-label=""
+  aria-labelledby=""
+  className="drift"
+  hasNoBodyWrapper={false}
+  isOpen={false}
+  onClose={[Function]}
+  ouiaSafe={true}
+  showClose={true}
+  title="Create baseline"
+  titleIconVariant={null}
+  titleLabel=""
+  variant="default"
+  width="1200px"
+>
+  <Radio
+    className=""
+    id="create baseline"
+    isChecked={true}
+    isDisabled={false}
+    isValid={true}
+    label="Create baseline from scratch"
+    name="baseline-create-options"
+    onChange={[Function]}
+    ouiaId="create-baseline-from-scratch-radio"
+    value="fromScratchChecked"
+  />
+  <Radio
+    className=""
+    id="copy baseline"
+    isChecked={false}
+    isDisabled={false}
+    isValid={true}
+    label="Copy an existing baseline"
+    name="baseline-create-options"
+    onChange={[Function]}
+    ouiaId="create-baseline-copy-baseline-radio"
+    value="copyBaselineChecked"
+  />
+  <Radio
+    className=""
+    id="copy system"
+    isChecked={false}
+    isDisabled={false}
+    isValid={true}
+    label="Copy an existing system or historical profile"
+    name="baseline-create-options"
+    onChange={[Function]}
+    ouiaId="create-baseline-copy-system-radio"
+    value="copySystemChecked"
+  />
+  <div
+    className="md-padding-top md-padding-bottom"
+  >
+    <Form>
+      <FormGroup
+        fieldId="name"
+        helperTextInvalid="This is an error"
+        isRequired={true}
+        label="Baseline name"
+        onKeyPress={[Function]}
+        type="text"
+        validated="error"
+      >
+        <TextInput
+          aria-label="baseline name"
+          className="fact-value"
+          onChange={[Function]}
+          type="text"
+          validated="error"
           value=""
         />
       </FormGroup>

--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaselineNameModal/EditBaselineNameModal.js
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaselineNameModal/EditBaselineNameModal.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Button, Form, FormGroup, Modal, ModalVariant, TextInput, ValidatedOptions, Alert } from '@patternfly/react-core';
+import { Button, Form, FormGroup, Modal, ModalVariant, TextInput, ValidatedOptions } from '@patternfly/react-core';
 
 import { editBaselineActions } from '../redux';
 
@@ -79,7 +79,7 @@ export class EditBaselineNameModal extends Component {
     }
 
     render() {
-        const { modalOpened, error } = this.props;
+        const { modalOpened } = this.props;
 
         return (
             <Modal
@@ -105,15 +105,6 @@ export class EditBaselineNameModal extends Component {
                     </Button>
                 ] }
             >
-                { error.status && <Alert
-                    variant='danger'
-                    isInline
-                    title={ 'Status: ' + error.status }
-                >
-                    <p>
-                        { error.detail }
-                    </p>
-                </Alert> }
                 { this.renderModalBody() }
             </Modal>
         );

--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaselineNameModal/__tests__/EditBaselineNameModal.tests.js
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaselineNameModal/__tests__/EditBaselineNameModal.tests.js
@@ -29,6 +29,19 @@ describe('EditBaselineNameModal', () => {
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 
+    it('should render error correctly', () => {
+        props.error = {
+            status: 404,
+            detail: 'This is an error'
+        };
+
+        const wrapper = shallow(
+            <EditBaselineNameModal { ...props }/>
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
     it('should render mount correctly', () => {
         const wrapper = mount(
             <EditBaselineNameModal { ...props }/>

--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaselineNameModal/__tests__/__snapshots__/EditBaselineNameModal.tests.js.snap
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaselineNameModal/__tests__/__snapshots__/EditBaselineNameModal.tests.js.snap
@@ -60,6 +60,66 @@ exports[`EditBaselineNameModal should render correctly 1`] = `
 </Modal>
 `;
 
+exports[`EditBaselineNameModal should render error correctly 1`] = `
+<Modal
+  actions={
+    Array [
+      <Button
+        onClick={[Function]}
+        ouiaId="save"
+        variant="primary"
+      >
+        Save
+      </Button>,
+      <Button
+        onClick={[Function]}
+        ouiaId="cancel"
+        variant="link"
+      >
+        Cancel
+      </Button>,
+    ]
+  }
+  appendTo={[Function]}
+  aria-describedby=""
+  aria-label=""
+  aria-labelledby=""
+  className="drift"
+  hasNoBodyWrapper={false}
+  isOpen={true}
+  onClose={[Function]}
+  ouiaSafe={true}
+  showClose={true}
+  title="Edit name"
+  titleIconVariant={null}
+  titleLabel=""
+  variant="small"
+>
+  <div
+    className="fact-value"
+  >
+    <Form>
+      <FormGroup
+        fieldId="baseline name"
+        helperTextInvalid="This is an error"
+        isRequired={true}
+        label="Baseline title"
+        onKeyPress={[Function]}
+        validated="error"
+      >
+        <TextInput
+          aria-label="baseline name"
+          onChange={[Function]}
+          type="text"
+          validated="error"
+          value="lotr-baseline"
+        />
+      </FormGroup>
+    </Form>
+  </div>
+</Modal>
+`;
+
 exports[`EditBaselineNameModal should render mount correctly 1`] = `
 <EditBaselineNameModal
   baselineData={

--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/FactModal/FactModal.js
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/FactModal/FactModal.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Alert, Button, Checkbox, Form, FormGroup, Modal, ModalVariant, TextInput, ValidatedOptions } from '@patternfly/react-core';
+import { Button, Checkbox, Form, FormGroup, Modal, ModalVariant, TextInput, ValidatedOptions } from '@patternfly/react-core';
 
 import { editBaselineActions } from '../redux';
 import editBaselineHelpers from '../EditBaseline/helpers';
@@ -169,24 +169,12 @@ export class FactModal extends Component {
     }
 
     renderModalBody() {
-        const { inlineError, isSubFact } = this.props;
+        const { isSubFact } = this.props;
         const { isAddFact, isCategory } = this.state;
         let modalBody;
 
         modalBody =
             <React.Fragment>
-                { inlineError.status
-                    ? <Alert
-                        variant='danger'
-                        isInline
-                        title={ 'Status: ' + inlineError.status }
-                    >
-                        <p>
-                            { inlineError.detail }
-                        </p>
-                    </Alert>
-                    : <div></div>
-                }
                 { (isAddFact && !isSubFact) || isCategory ? this.renderCategoryCheckbox() : null }
                 <Form>
                     { this.renderFactInput() }

--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/FactModal/__tests__/FactModal.tests.js
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/FactModal/__tests__/FactModal.tests.js
@@ -34,6 +34,19 @@ describe('FactModal', () => {
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 
+    it('should render error correctly', () => {
+        props.inlineError = {
+            status: 404,
+            detail: 'This is an error'
+        };
+
+        const wrapper = shallow(
+            <FactModal { ...props } />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
     it('should render fact name and value correctly', () => {
         props.factName = 'cool';
         props.factValue = 'fact';

--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/FactModal/__tests__/__snapshots__/FactModal.tests.js.snap
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/FactModal/__tests__/__snapshots__/FactModal.tests.js.snap
@@ -163,7 +163,6 @@ exports[`ConnectedFactModal should render correctly 1`] = `
                           class="pf-c-modal-box__body"
                           id="pf-modal-part-2"
                         >
-                          <div />
                           <div
                             class="pf-c-check sm-padding-bottom"
                           >
@@ -478,7 +477,6 @@ exports[`ConnectedFactModal should render correctly 1`] = `
                                 className="pf-c-modal-box__body"
                                 id="pf-modal-part-2"
                               >
-                                <div />
                                 <Checkbox
                                   aria-label="controlled checkbox example"
                                   className="sm-padding-bottom"
@@ -815,7 +813,6 @@ exports[`FactModal should render category correctly 1`] = `
   titleLabel=""
   variant="small"
 >
-  <div />
   <Checkbox
     aria-label="controlled checkbox example"
     className="sm-padding-bottom"
@@ -893,7 +890,6 @@ exports[`FactModal should render empty correctly 1`] = `
   titleLabel=""
   variant="small"
 >
-  <div />
   <Checkbox
     aria-label="controlled checkbox example"
     className="sm-padding-bottom"
@@ -958,6 +954,106 @@ exports[`FactModal should render empty correctly 1`] = `
 </Modal>
 `;
 
+exports[`FactModal should render error correctly 1`] = `
+<Modal
+  actions={
+    Array [
+      <Button
+        onClick={[Function]}
+        ouiaId="fact-modal-save-button"
+        variant="primary"
+      >
+        Save
+      </Button>,
+      <Button
+        onClick={[Function]}
+        ouiaId="fact-modal-cancel-button"
+        variant="link"
+      >
+        Cancel
+      </Button>,
+    ]
+  }
+  appendTo={[Function]}
+  aria-describedby=""
+  aria-label=""
+  aria-labelledby=""
+  className="drift"
+  hasNoBodyWrapper={false}
+  isOpen={true}
+  onClose={[Function]}
+  ouiaId="add-fact-modal"
+  ouiaSafe={true}
+  showClose={true}
+  title="Add fact"
+  titleIconVariant={null}
+  titleLabel=""
+  variant="small"
+>
+  <Checkbox
+    aria-label="controlled checkbox example"
+    className="sm-padding-bottom"
+    data-ouia-component-id="category-checkbox"
+    data-ouia-component-type="PF4/Checkbox"
+    id="isCategory"
+    isChecked={false}
+    isDisabled={false}
+    isValid={true}
+    label="This is a category"
+    name="isCategory"
+    onChange={[Function]}
+  />
+  <Form>
+    <div
+      className="fact-value"
+    >
+      <FormGroup
+        fieldId="fact name"
+        helperTextInvalid="This is an error"
+        isRequired={true}
+        label="Fact name"
+        onKeyPress={[Function]}
+        validated="error"
+      >
+        <TextInput
+          aria-label="fact name"
+          data-ouia-component-id="fact-name-input"
+          data-ouia-component-type="PF4/TextInput"
+          onChange={[Function]}
+          placeholder="Name"
+          type="text"
+          validated="error"
+          value=""
+        />
+      </FormGroup>
+    </div>
+    <div
+      className="fact-value"
+    >
+      <FormGroup
+        fieldId="fact value"
+        helperTextInvalid="This is an error"
+        isRequired={true}
+        label="Value"
+        onKeyPress={[Function]}
+        validated="error"
+      >
+        <TextInput
+          aria-label="value"
+          data-ouia-component-id="value-input"
+          data-ouia-component-type="PF4/TextInput"
+          onChange={[Function]}
+          placeholder="Value"
+          type="text"
+          validated="error"
+          value=""
+        />
+      </FormGroup>
+    </div>
+  </Form>
+</Modal>
+`;
+
 exports[`FactModal should render fact name and value correctly 1`] = `
 <Modal
   actions={
@@ -994,7 +1090,6 @@ exports[`FactModal should render fact name and value correctly 1`] = `
   titleLabel=""
   variant="small"
 >
-  <div />
   <Form>
     <div
       className="fact-value"
@@ -1082,7 +1177,6 @@ exports[`FactModal should render sub fact correctly 1`] = `
   titleLabel=""
   variant="small"
 >
-  <div />
   <Form>
     <div
       className="fact-value"


### PR DESCRIPTION
According to our mocks, errors in the baseline modals should only have the inline text errors under the text input boxes. The error alerts that show up at the top of the modal should be removed. Test errors in these locations to ensure that they've been fixed:

Create baseline modal
Edit baseline modal
Create/Edit fact modal

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
