### PR TITLE
[DRFT-588] Add partial select to category checkbox

### DIFF
--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaseline/__tests__/helpers.tests.js
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaseline/__tests__/helpers.tests.js
@@ -101,19 +101,31 @@ describe('edit baseline helpers', () => {
         );
     });
 
-    it('isAllSelected retuns false', () => {
-        editBaselineFixtures.mockBaselineTableData1[0].selected = true;
-        editBaselineFixtures.mockBaselineTableData1[1].selected = true;
+    it('isAllSelected returns null', () => {
+        let subFacts = JSON.parse(JSON.stringify(editBaselineFixtures.mockBaselineTableData1[2][2]));
+        subFacts[0].selected = true;
 
-        expect(editBaselineHelpers.isAllSelected(editBaselineFixtures.mockBaselineTableData1)).toEqual(false);
+        expect(editBaselineHelpers.isAllSelected(subFacts)).toEqual(null);
+    });
+
+    it('isAllSelected retuns false', () => {
+        let subFacts = JSON.parse(JSON.stringify(editBaselineFixtures.mockBaselineTableData1[2][2]));
+        expect(editBaselineHelpers.isAllSelected(subFacts)).toEqual(false);
     });
 
     it('isAllSelected returns true', () => {
-        editBaselineFixtures.mockBaselineTableData1[0].selected = true;
-        editBaselineFixtures.mockBaselineTableData1[1].selected = true;
-        editBaselineFixtures.mockBaselineTableData1[2].selected = true;
+        let subFacts = JSON.parse(JSON.stringify(editBaselineFixtures.mockBaselineTableData1[2][2]));
+        subFacts[0].selected = true;
+        subFacts[1].selected = true;
+        subFacts[2].selected = true;
+        subFacts[3].selected = true;
+        subFacts[4].selected = true;
+        subFacts[5].selected = true;
+        subFacts[6].selected = true;
+        subFacts[7].selected = true;
+        subFacts[8].selected = true;
 
-        expect(editBaselineHelpers.isAllSelected(editBaselineFixtures.mockBaselineTableData1)).toEqual(true);
+        expect(editBaselineHelpers.isAllSelected(subFacts)).toEqual(true);
     });
 
     it('isCategory returns false', () => {
@@ -193,8 +205,7 @@ describe('edit baseline helpers', () => {
     });
 
     it('makeDeleteFactsPatch removes single fact', () => {
-        let factsToDelete = editBaselineFixtures.mockBaselineTableData1;
-        factsToDelete.forEach(fact => fact.selected = false);
+        let factsToDelete = JSON.parse(JSON.stringify(editBaselineFixtures.mockBaselineTableData1));
         factsToDelete[0].selected = true;
         let originalAPIBody = editBaselineFixtures.mockBaselineData1;
         let newAPIBody = {

--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaseline/helpers.js
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaseline/helpers.js
@@ -320,12 +320,18 @@ function toggleExpandedRow(expandedRows, factName) {
 
 function isAllSelected(data) {
     let allSelected = true;
+    let falseCounter = 0;
 
     data.forEach(function(fact) {
         if (!fact.selected) {
-            allSelected = false;
+            allSelected = null;
+            falseCounter++;
         }
     });
+
+    if (falseCounter === data.length) {
+        allSelected = false;
+    }
 
     return allSelected;
 }


### PR DESCRIPTION
Before, in the edit baseline details page, if you selected a single sub fact in a category with 2 or more sub facts, the category would receive a checkmark.

Now, if only some of the sub facts of a category are selected, that category receives a partial select icon in the checkbox (a dash '-').

So:
No sub facts selected - Category checbox is empty
Some sub facts selected - Category checkbox shows dash '-'
All sub facts selected - Category checkbox shows checkmark

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
