### PR TITLE
[DRFT-840] Add correct baseline ids to HistoricalProfilesPopover

### DIFF
--- a/src/SmartComponents/DriftPage/DriftTable/__tests__/__snapshots__/DriftTable.tests.js.snap
+++ b/src/SmartComponents/DriftPage/DriftTable/__tests__/__snapshots__/DriftTable.tests.js.snap
@@ -3381,7 +3381,6 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
                                   selectHistoricProfiles={[Function]}
                                   selectSingleHSP={[Function]}
                                   selectSystem={[Function]}
-                                  selectedBaselineIds={Array []}
                                   selectedHSPIds={Array []}
                                   system={
                                     Object {
@@ -4057,7 +4056,6 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
                                   selectHistoricProfiles={[Function]}
                                   selectSingleHSP={[Function]}
                                   selectSystem={[Function]}
-                                  selectedBaselineIds={Array []}
                                   selectedHSPIds={Array []}
                                   system={
                                     Object {
@@ -4734,7 +4732,6 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
                                   selectHistoricProfiles={[Function]}
                                   selectSingleHSP={[Function]}
                                   selectSystem={[Function]}
-                                  selectedBaselineIds={Array []}
                                   selectedHSPIds={Array []}
                                   system={
                                     Object {
@@ -5408,7 +5405,6 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
                                   selectHistoricProfiles={[Function]}
                                   selectSingleHSP={[Function]}
                                   selectSystem={[Function]}
-                                  selectedBaselineIds={Array []}
                                   selectedHSPIds={Array []}
                                   system={
                                     Object {
@@ -9247,7 +9243,6 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                                   selectHistoricProfiles={[Function]}
                                   selectSingleHSP={[Function]}
                                   selectSystem={[Function]}
-                                  selectedBaselineIds={Array []}
                                   selectedHSPIds={Array []}
                                   system={
                                     Object {
@@ -9923,7 +9918,6 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                                   selectHistoricProfiles={[Function]}
                                   selectSingleHSP={[Function]}
                                   selectSystem={[Function]}
-                                  selectedBaselineIds={Array []}
                                   selectedHSPIds={Array []}
                                   system={
                                     Object {
@@ -10600,7 +10594,6 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                                   selectHistoricProfiles={[Function]}
                                   selectSingleHSP={[Function]}
                                   selectSystem={[Function]}
-                                  selectedBaselineIds={Array []}
                                   selectedHSPIds={Array []}
                                   system={
                                     Object {
@@ -11274,7 +11267,6 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                                   selectHistoricProfiles={[Function]}
                                   selectSingleHSP={[Function]}
                                   selectSystem={[Function]}
-                                  selectedBaselineIds={Array []}
                                   selectedHSPIds={Array []}
                                   system={
                                     Object {

--- a/src/SmartComponents/HistoricalProfilesPopover/HistoricalProfilesPopover.js
+++ b/src/SmartComponents/HistoricalProfilesPopover/HistoricalProfilesPopover.js
@@ -270,8 +270,7 @@ HistoricalProfilesPopover.propTypes = {
 
 function mapStateToProps(state) {
     return {
-        selectedHSPIds: state.historicProfilesState?.selectedHSPIds || [],
-        selectedBaselineIds: state.baselinesTableState?.checkboxTable.selectedBaselineIds || []
+        selectedHSPIds: state.historicProfilesState?.selectedHSPIds || []
     };
 }
 

--- a/src/SmartComponents/HistoricalProfilesPopover/__tests__/HistoricalProfilesPopover.tests.js
+++ b/src/SmartComponents/HistoricalProfilesPopover/__tests__/HistoricalProfilesPopover.tests.js
@@ -16,8 +16,10 @@ describe('HistoricalProfilesPopover', () => {
 
     beforeEach(() => {
         props = {
+            systemIds: [],
             selectedHSPIds: [],
             selectedBaselineIds: [],
+            referenceId: undefined,
             dropdownDirection: DropdownDirection.down,
             hasBadge: true,
             hasCompareButton: false,
@@ -25,7 +27,8 @@ describe('HistoricalProfilesPopover', () => {
             system: {
                 id: '4416c520-a339-4dde-b303-f317ea9efc5f',
                 last_updated: '2020-05-04T18:33:12.249348+00:00'
-            }
+            },
+            fetchCompare: jest.fn()
         };
     });
 
@@ -41,6 +44,21 @@ describe('HistoricalProfilesPopover', () => {
             <HistoricalProfilesPopover { ...props }/>
         );
         expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('should call fetchCompare correctly', () => {
+        props.systemIds = [ 'abc' ];
+        props.selectedHSPIds = [ '123' ];
+        props.selectedBaselineIds = [ 'def' ];
+        props.referenceId = 'def';
+        const wrapper = mount(
+            <HistoricalProfilesPopover { ...props }/>
+        );
+
+        wrapper.instance().fetchCompare();
+        expect(props.fetchCompare).toHaveBeenCalledWith(
+            props.systemIds, props.selectedBaselineIds, props.selectedHSPIds, props.referenceId
+        );
     });
 
     describe('API', () => {
@@ -79,11 +97,6 @@ describe('ConnectedHistoricalProfilesPopover', () => {
         initialState = {
             historicProfilesState: {
                 selectedHSPIds: []
-            },
-            baselinesTableState: {
-                checkboxTable: {
-                    selectedBaselineIds: []
-                }
             }
         };
 

--- a/src/SmartComponents/HistoricalProfilesPopover/__tests__/__snapshots__/HistoricalProfilesPopover.tests.js.snap
+++ b/src/SmartComponents/HistoricalProfilesPopover/__tests__/__snapshots__/HistoricalProfilesPopover.tests.js.snap
@@ -526,7 +526,6 @@ exports[`ConnectedHistoricalProfilesPopover should render correctly 1`] = `
             }
             selectSingleHSP={[Function]}
             selectSystem={[Function]}
-            selectedBaselineIds={Array []}
             selectedHSPIds={Array []}
           >
             <span
@@ -1153,6 +1152,7 @@ exports[`HistoricalProfilesPopover should render mount correctly 1`] = `
 <HistoricalProfilesPopover
   badgeCount={0}
   dropdownDirection="down"
+  fetchCompare={[MockFunction]}
   hasBadge={true}
   hasCompareButton={false}
   selectedBaselineIds={Array []}
@@ -1163,6 +1163,7 @@ exports[`HistoricalProfilesPopover should render mount correctly 1`] = `
       "last_updated": "2020-05-04T18:33:12.249348+00:00",
     }
   }
+  systemIds={Array []}
 >
   <span
     className="hsp-icon-padding"


### PR DESCRIPTION
To reproduce:
Select baseline and system to compare
On the Comparison screen, try to add a HSP to the comparison
This causes an error (reference id) and the baseline to disappear from the comparison

Now, the correct set of selected baseline ids is being passed to the component.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
