### PR TITLE
[DRFT-866] Remove double suffix on comparison table exports

### DIFF
--- a/src/SmartComponents/modules/helpers.js
+++ b/src/SmartComponents/modules/helpers.js
@@ -425,7 +425,6 @@ function downloadHelper(type, driftData, referenceId, systems) {
     let filename = 'system-comparison-export-';
     let today = new Date();
     filename += today.toISOString();
-    filename += '.' + type;
 
     downloadFile(file, filename, type);
 }


### PR DESCRIPTION
Before, if you exported the comparison table you would get .json.json or .csv.csv at the end of your files. This PR fixes that.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
