### PR TITLE
[DRFT-918] Update notification switch states

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -445,3 +445,7 @@
 .float-right {
   float: right;
 }
+
+.no-left-padding {
+  padding-left: 0;
+}

--- a/src/SmartComponents/BaselinesTable/BaselinesTable.js
+++ b/src/SmartComponents/BaselinesTable/BaselinesTable.js
@@ -117,7 +117,7 @@ export class BaselinesTable extends Component {
 
             row.push(baseline[2]);
             /*eslint-disable camelcase*/
-            row.push(<div>
+            row.push(<div className='no-left-padding'>
                 <NotificationDetails
                     classname='sm-padding-right'
                     index={ index }

--- a/src/SmartComponents/BaselinesTable/NotificationDetails/NotificationDetails.js
+++ b/src/SmartComponents/BaselinesTable/NotificationDetails/NotificationDetails.js
@@ -46,7 +46,7 @@ function NotificationDetails(props) {
                 hasBadge
                     ? <Badge
                         key={ index }
-                        isRead={ isChecked ? null : true }
+                        isRead={ badgeCount > 0 ? null : true }
                     >
                         { badgeCount }
                     </Badge>

--- a/src/SmartComponents/BaselinesTable/__tests__/__snapshots__/BaselinesTable.tests.js.snap
+++ b/src/SmartComponents/BaselinesTable/__tests__/__snapshots__/BaselinesTable.tests.js.snap
@@ -2453,7 +2453,9 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                 Array [
                   "beavs baseline",
                   "2 years ago",
-                  <div>
+                  <div
+                    className="no-left-padding"
+                  >
                     <NotificationDetails
                       badgeCount={3}
                       baselineData={
@@ -2497,7 +2499,9 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                 Array [
                   "micjohns baseline",
                   "2 years ago",
-                  <div>
+                  <div
+                    className="no-left-padding"
+                  >
                     <NotificationDetails
                       badgeCount={0}
                       baselineData={
@@ -3801,7 +3805,9 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                             Array [
                               "beavs baseline",
                               "2 years ago",
-                              <div>
+                              <div
+                                className="no-left-padding"
+                              >
                                 <NotificationDetails
                                   badgeCount={3}
                                   baselineData={
@@ -3845,7 +3851,9 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                             Array [
                               "micjohns baseline",
                               "2 years ago",
-                              <div>
+                              <div
+                                className="no-left-padding"
+                              >
                                 <NotificationDetails
                                   badgeCount={0}
                                   baselineData={
@@ -3897,7 +3905,9 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                               Object {
                                 "0": "beavs baseline",
                                 "1": "2 years ago",
-                                "2": <div>
+                                "2": <div
+                                  className="no-left-padding"
+                                >
                                   <NotificationDetails
                                     badgeCount={3}
                                     baselineData={
@@ -3957,6 +3967,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                       toggleNotificationPending={[Function]}
                                       toggleNotificationRejected={[Function]}
                                     />,
+                                    "className": "no-left-padding",
                                     "isVisible": true,
                                   },
                                   "title": undefined,
@@ -4014,7 +4025,9 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                               Object {
                                 "0": "micjohns baseline",
                                 "1": "2 years ago",
-                                "2": <div>
+                                "2": <div
+                                  className="no-left-padding"
+                                >
                                   <NotificationDetails
                                     badgeCount={0}
                                     baselineData={
@@ -4074,6 +4087,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                       toggleNotificationPending={[Function]}
                                       toggleNotificationRejected={[Function]}
                                     />,
+                                    "className": "no-left-padding",
                                     "isVisible": true,
                                   },
                                   "title": undefined,
@@ -4136,7 +4150,9 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                               Object {
                                 "0": "beavs baseline",
                                 "1": "2 years ago",
-                                "2": <div>
+                                "2": <div
+                                  className="no-left-padding"
+                                >
                                   <NotificationDetails
                                     badgeCount={3}
                                     baselineData={
@@ -4196,6 +4212,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                       toggleNotificationPending={[Function]}
                                       toggleNotificationRejected={[Function]}
                                     />,
+                                    "className": "no-left-padding",
                                     "isVisible": true,
                                   },
                                   "title": undefined,
@@ -4253,7 +4270,9 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                               Object {
                                 "0": "micjohns baseline",
                                 "1": "2 years ago",
-                                "2": <div>
+                                "2": <div
+                                  className="no-left-padding"
+                                >
                                   <NotificationDetails
                                     badgeCount={0}
                                     baselineData={
@@ -4313,6 +4332,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                       toggleNotificationPending={[Function]}
                                       toggleNotificationRejected={[Function]}
                                     />,
+                                    "className": "no-left-padding",
                                     "isVisible": true,
                                   },
                                   "title": undefined,
@@ -4583,7 +4603,9 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                 Object {
                                   "0": "beavs baseline",
                                   "1": "2 years ago",
-                                  "2": <div>
+                                  "2": <div
+                                    className="no-left-padding"
+                                  >
                                     <NotificationDetails
                                       badgeCount={3}
                                       baselineData={
@@ -4643,6 +4665,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                         toggleNotificationPending={[Function]}
                                         toggleNotificationRejected={[Function]}
                                       />,
+                                      "className": "no-left-padding",
                                       "isVisible": true,
                                     },
                                     "title": undefined,
@@ -4700,7 +4723,9 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                 Object {
                                   "0": "micjohns baseline",
                                   "1": "2 years ago",
-                                  "2": <div>
+                                  "2": <div
+                                    className="no-left-padding"
+                                  >
                                     <NotificationDetails
                                       badgeCount={0}
                                       baselineData={
@@ -4760,6 +4785,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                         toggleNotificationPending={[Function]}
                                         toggleNotificationRejected={[Function]}
                                       />,
+                                      "className": "no-left-padding",
                                       "isVisible": true,
                                     },
                                     "title": undefined,
@@ -4849,7 +4875,9 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                 Object {
                                   "0": "beavs baseline",
                                   "1": "2 years ago",
-                                  "2": <div>
+                                  "2": <div
+                                    className="no-left-padding"
+                                  >
                                     <NotificationDetails
                                       badgeCount={3}
                                       baselineData={
@@ -4909,6 +4937,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                         toggleNotificationPending={[Function]}
                                         toggleNotificationRejected={[Function]}
                                       />,
+                                      "className": "no-left-padding",
                                       "isVisible": true,
                                     },
                                     "title": undefined,
@@ -4966,7 +4995,9 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                 Object {
                                   "0": "micjohns baseline",
                                   "1": "2 years ago",
-                                  "2": <div>
+                                  "2": <div
+                                    className="no-left-padding"
+                                  >
                                     <NotificationDetails
                                       badgeCount={0}
                                       baselineData={
@@ -5026,6 +5057,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                         toggleNotificationPending={[Function]}
                                         toggleNotificationRejected={[Function]}
                                       />,
+                                      "className": "no-left-padding",
                                       "isVisible": true,
                                     },
                                     "title": undefined,
@@ -5090,7 +5122,9 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                   Object {
                                     "0": "beavs baseline",
                                     "1": "2 years ago",
-                                    "2": <div>
+                                    "2": <div
+                                      className="no-left-padding"
+                                    >
                                       <NotificationDetails
                                         badgeCount={3}
                                         baselineData={
@@ -5150,6 +5184,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                           toggleNotificationPending={[Function]}
                                           toggleNotificationRejected={[Function]}
                                         />,
+                                        "className": "no-left-padding",
                                         "isVisible": true,
                                       },
                                       "title": undefined,
@@ -5207,7 +5242,9 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                   Object {
                                     "0": "micjohns baseline",
                                     "1": "2 years ago",
-                                    "2": <div>
+                                    "2": <div
+                                      className="no-left-padding"
+                                    >
                                       <NotificationDetails
                                         badgeCount={0}
                                         baselineData={
@@ -5267,6 +5304,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                           toggleNotificationPending={[Function]}
                                           toggleNotificationRejected={[Function]}
                                         />,
+                                        "className": "no-left-padding",
                                         "isVisible": true,
                                       },
                                       "title": undefined,
@@ -5554,7 +5592,9 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                         Object {
                                           "0": "beavs baseline",
                                           "1": "2 years ago",
-                                          "2": <div>
+                                          "2": <div
+                                            className="no-left-padding"
+                                          >
                                             <NotificationDetails
                                               badgeCount={3}
                                               baselineData={
@@ -5614,6 +5654,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                                 toggleNotificationPending={[Function]}
                                                 toggleNotificationRejected={[Function]}
                                               />,
+                                              "className": "no-left-padding",
                                               "isVisible": true,
                                             },
                                             "title": undefined,
@@ -5680,7 +5721,9 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                           Object {
                                             "0": "beavs baseline",
                                             "1": "2 years ago",
-                                            "2": <div>
+                                            "2": <div
+                                              className="no-left-padding"
+                                            >
                                               <NotificationDetails
                                                 badgeCount={3}
                                                 baselineData={
@@ -5740,6 +5783,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                                   toggleNotificationPending={[Function]}
                                                   toggleNotificationRejected={[Function]}
                                                 />,
+                                                "className": "no-left-padding",
                                                 "isVisible": true,
                                               },
                                               "title": undefined,
@@ -5891,13 +5935,14 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                                 </Td>
                                               </BodyCell>
                                               <BodyCell
+                                                className="no-left-padding"
                                                 data-key={2}
                                                 data-label="Associated systems"
                                                 isVisible={true}
                                                 key="col-2-row-0"
                                               >
                                                 <Td
-                                                  className=""
+                                                  className="no-left-padding"
                                                   component="td"
                                                   data-key={2}
                                                   dataLabel="Associated systems"
@@ -5905,7 +5950,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                                   textCenter={false}
                                                 >
                                                   <TdBase
-                                                    className=""
+                                                    className="no-left-padding"
                                                     component="td"
                                                     data-key={2}
                                                     dataLabel="Associated systems"
@@ -5914,7 +5959,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                                     textCenter={false}
                                                   >
                                                     <td
-                                                      className=""
+                                                      className="no-left-padding"
                                                       data-key={2}
                                                       data-label="Associated systems"
                                                       onMouseEnter={[Function]}
@@ -6527,7 +6572,9 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                         Object {
                                           "0": "micjohns baseline",
                                           "1": "2 years ago",
-                                          "2": <div>
+                                          "2": <div
+                                            className="no-left-padding"
+                                          >
                                             <NotificationDetails
                                               badgeCount={0}
                                               baselineData={
@@ -6587,6 +6634,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                                 toggleNotificationPending={[Function]}
                                                 toggleNotificationRejected={[Function]}
                                               />,
+                                              "className": "no-left-padding",
                                               "isVisible": true,
                                             },
                                             "title": undefined,
@@ -6652,7 +6700,9 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                           Object {
                                             "0": "micjohns baseline",
                                             "1": "2 years ago",
-                                            "2": <div>
+                                            "2": <div
+                                              className="no-left-padding"
+                                            >
                                               <NotificationDetails
                                                 badgeCount={0}
                                                 baselineData={
@@ -6712,6 +6762,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                                   toggleNotificationPending={[Function]}
                                                   toggleNotificationRejected={[Function]}
                                                 />,
+                                                "className": "no-left-padding",
                                                 "isVisible": true,
                                               },
                                               "title": undefined,
@@ -6862,13 +6913,14 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                                 </Td>
                                               </BodyCell>
                                               <BodyCell
+                                                className="no-left-padding"
                                                 data-key={2}
                                                 data-label="Associated systems"
                                                 isVisible={true}
                                                 key="col-2-row-1"
                                               >
                                                 <Td
-                                                  className=""
+                                                  className="no-left-padding"
                                                   component="td"
                                                   data-key={2}
                                                   dataLabel="Associated systems"
@@ -6876,7 +6928,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                                   textCenter={false}
                                                 >
                                                   <TdBase
-                                                    className=""
+                                                    className="no-left-padding"
                                                     component="td"
                                                     data-key={2}
                                                     dataLabel="Associated systems"
@@ -6885,7 +6937,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                                     textCenter={false}
                                                   >
                                                     <td
-                                                      className=""
+                                                      className="no-left-padding"
                                                       data-key={2}
                                                       data-label="Associated systems"
                                                       onMouseEnter={[Function]}
@@ -10617,7 +10669,9 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                 Array [
                   "beavs baseline",
                   "2 years ago",
-                  <div>
+                  <div
+                    className="no-left-padding"
+                  >
                     <NotificationDetails
                       badgeCount={3}
                       baselineData={
@@ -10657,7 +10711,9 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                 Array [
                   "micjohns baseline",
                   "2 years ago",
-                  <div>
+                  <div
+                    className="no-left-padding"
+                  >
                     <NotificationDetails
                       badgeCount={0}
                       baselineData={
@@ -11957,7 +12013,9 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                             Array [
                               "beavs baseline",
                               "2 years ago",
-                              <div>
+                              <div
+                                className="no-left-padding"
+                              >
                                 <NotificationDetails
                                   badgeCount={3}
                                   baselineData={
@@ -11997,7 +12055,9 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                             Array [
                               "micjohns baseline",
                               "2 years ago",
-                              <div>
+                              <div
+                                className="no-left-padding"
+                              >
                                 <NotificationDetails
                                   badgeCount={0}
                                   baselineData={
@@ -12045,7 +12105,9 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                               Object {
                                 "0": "beavs baseline",
                                 "1": "2 years ago",
-                                "2": <div>
+                                "2": <div
+                                  className="no-left-padding"
+                                >
                                   <NotificationDetails
                                     badgeCount={3}
                                     baselineData={
@@ -12101,6 +12163,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                       toggleNotificationPending={[Function]}
                                       toggleNotificationRejected={[Function]}
                                     />,
+                                    "className": "no-left-padding",
                                     "isVisible": true,
                                   },
                                   "title": undefined,
@@ -12154,7 +12217,9 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                               Object {
                                 "0": "micjohns baseline",
                                 "1": "2 years ago",
-                                "2": <div>
+                                "2": <div
+                                  className="no-left-padding"
+                                >
                                   <NotificationDetails
                                     badgeCount={0}
                                     baselineData={
@@ -12210,6 +12275,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                       toggleNotificationPending={[Function]}
                                       toggleNotificationRejected={[Function]}
                                     />,
+                                    "className": "no-left-padding",
                                     "isVisible": true,
                                   },
                                   "title": undefined,
@@ -12268,7 +12334,9 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                               Object {
                                 "0": "beavs baseline",
                                 "1": "2 years ago",
-                                "2": <div>
+                                "2": <div
+                                  className="no-left-padding"
+                                >
                                   <NotificationDetails
                                     badgeCount={3}
                                     baselineData={
@@ -12324,6 +12392,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                       toggleNotificationPending={[Function]}
                                       toggleNotificationRejected={[Function]}
                                     />,
+                                    "className": "no-left-padding",
                                     "isVisible": true,
                                   },
                                   "title": undefined,
@@ -12377,7 +12446,9 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                               Object {
                                 "0": "micjohns baseline",
                                 "1": "2 years ago",
-                                "2": <div>
+                                "2": <div
+                                  className="no-left-padding"
+                                >
                                   <NotificationDetails
                                     badgeCount={0}
                                     baselineData={
@@ -12433,6 +12504,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                       toggleNotificationPending={[Function]}
                                       toggleNotificationRejected={[Function]}
                                     />,
+                                    "className": "no-left-padding",
                                     "isVisible": true,
                                   },
                                   "title": undefined,
@@ -12699,7 +12771,9 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                 Object {
                                   "0": "beavs baseline",
                                   "1": "2 years ago",
-                                  "2": <div>
+                                  "2": <div
+                                    className="no-left-padding"
+                                  >
                                     <NotificationDetails
                                       badgeCount={3}
                                       baselineData={
@@ -12755,6 +12829,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                         toggleNotificationPending={[Function]}
                                         toggleNotificationRejected={[Function]}
                                       />,
+                                      "className": "no-left-padding",
                                       "isVisible": true,
                                     },
                                     "title": undefined,
@@ -12808,7 +12883,9 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                 Object {
                                   "0": "micjohns baseline",
                                   "1": "2 years ago",
-                                  "2": <div>
+                                  "2": <div
+                                    className="no-left-padding"
+                                  >
                                     <NotificationDetails
                                       badgeCount={0}
                                       baselineData={
@@ -12864,6 +12941,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                         toggleNotificationPending={[Function]}
                                         toggleNotificationRejected={[Function]}
                                       />,
+                                      "className": "no-left-padding",
                                       "isVisible": true,
                                     },
                                     "title": undefined,
@@ -12949,7 +13027,9 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                 Object {
                                   "0": "beavs baseline",
                                   "1": "2 years ago",
-                                  "2": <div>
+                                  "2": <div
+                                    className="no-left-padding"
+                                  >
                                     <NotificationDetails
                                       badgeCount={3}
                                       baselineData={
@@ -13005,6 +13085,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                         toggleNotificationPending={[Function]}
                                         toggleNotificationRejected={[Function]}
                                       />,
+                                      "className": "no-left-padding",
                                       "isVisible": true,
                                     },
                                     "title": undefined,
@@ -13058,7 +13139,9 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                 Object {
                                   "0": "micjohns baseline",
                                   "1": "2 years ago",
-                                  "2": <div>
+                                  "2": <div
+                                    className="no-left-padding"
+                                  >
                                     <NotificationDetails
                                       badgeCount={0}
                                       baselineData={
@@ -13114,6 +13197,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                         toggleNotificationPending={[Function]}
                                         toggleNotificationRejected={[Function]}
                                       />,
+                                      "className": "no-left-padding",
                                       "isVisible": true,
                                     },
                                     "title": undefined,
@@ -13174,7 +13258,9 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                   Object {
                                     "0": "beavs baseline",
                                     "1": "2 years ago",
-                                    "2": <div>
+                                    "2": <div
+                                      className="no-left-padding"
+                                    >
                                       <NotificationDetails
                                         badgeCount={3}
                                         baselineData={
@@ -13230,6 +13316,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                           toggleNotificationPending={[Function]}
                                           toggleNotificationRejected={[Function]}
                                         />,
+                                        "className": "no-left-padding",
                                         "isVisible": true,
                                       },
                                       "title": undefined,
@@ -13283,7 +13370,9 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                   Object {
                                     "0": "micjohns baseline",
                                     "1": "2 years ago",
-                                    "2": <div>
+                                    "2": <div
+                                      className="no-left-padding"
+                                    >
                                       <NotificationDetails
                                         badgeCount={0}
                                         baselineData={
@@ -13339,6 +13428,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                           toggleNotificationPending={[Function]}
                                           toggleNotificationRejected={[Function]}
                                         />,
+                                        "className": "no-left-padding",
                                         "isVisible": true,
                                       },
                                       "title": undefined,
@@ -13622,7 +13712,9 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                         Object {
                                           "0": "beavs baseline",
                                           "1": "2 years ago",
-                                          "2": <div>
+                                          "2": <div
+                                            className="no-left-padding"
+                                          >
                                             <NotificationDetails
                                               badgeCount={3}
                                               baselineData={
@@ -13678,6 +13770,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                                 toggleNotificationPending={[Function]}
                                                 toggleNotificationRejected={[Function]}
                                               />,
+                                              "className": "no-left-padding",
                                               "isVisible": true,
                                             },
                                             "title": undefined,
@@ -13740,7 +13833,9 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                           Object {
                                             "0": "beavs baseline",
                                             "1": "2 years ago",
-                                            "2": <div>
+                                            "2": <div
+                                              className="no-left-padding"
+                                            >
                                               <NotificationDetails
                                                 badgeCount={3}
                                                 baselineData={
@@ -13796,6 +13891,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                                   toggleNotificationPending={[Function]}
                                                   toggleNotificationRejected={[Function]}
                                                 />,
+                                                "className": "no-left-padding",
                                                 "isVisible": true,
                                               },
                                               "title": undefined,
@@ -13943,13 +14039,14 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                                 </Td>
                                               </BodyCell>
                                               <BodyCell
+                                                className="no-left-padding"
                                                 data-key={2}
                                                 data-label="Associated systems"
                                                 isVisible={true}
                                                 key="col-2-row-0"
                                               >
                                                 <Td
-                                                  className=""
+                                                  className="no-left-padding"
                                                   component="td"
                                                   data-key={2}
                                                   dataLabel="Associated systems"
@@ -13957,7 +14054,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                                   textCenter={false}
                                                 >
                                                   <TdBase
-                                                    className=""
+                                                    className="no-left-padding"
                                                     component="td"
                                                     data-key={2}
                                                     dataLabel="Associated systems"
@@ -13966,7 +14063,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                                     textCenter={false}
                                                   >
                                                     <td
-                                                      className=""
+                                                      className="no-left-padding"
                                                       data-key={2}
                                                       data-label="Associated systems"
                                                       onMouseEnter={[Function]}
@@ -14571,7 +14668,9 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                         Object {
                                           "0": "micjohns baseline",
                                           "1": "2 years ago",
-                                          "2": <div>
+                                          "2": <div
+                                            className="no-left-padding"
+                                          >
                                             <NotificationDetails
                                               badgeCount={0}
                                               baselineData={
@@ -14627,6 +14726,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                                 toggleNotificationPending={[Function]}
                                                 toggleNotificationRejected={[Function]}
                                               />,
+                                              "className": "no-left-padding",
                                               "isVisible": true,
                                             },
                                             "title": undefined,
@@ -14688,7 +14788,9 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                           Object {
                                             "0": "micjohns baseline",
                                             "1": "2 years ago",
-                                            "2": <div>
+                                            "2": <div
+                                              className="no-left-padding"
+                                            >
                                               <NotificationDetails
                                                 badgeCount={0}
                                                 baselineData={
@@ -14744,6 +14846,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                                   toggleNotificationPending={[Function]}
                                                   toggleNotificationRejected={[Function]}
                                                 />,
+                                                "className": "no-left-padding",
                                                 "isVisible": true,
                                               },
                                               "title": undefined,
@@ -14890,13 +14993,14 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                                 </Td>
                                               </BodyCell>
                                               <BodyCell
+                                                className="no-left-padding"
                                                 data-key={2}
                                                 data-label="Associated systems"
                                                 isVisible={true}
                                                 key="col-2-row-1"
                                               >
                                                 <Td
-                                                  className=""
+                                                  className="no-left-padding"
                                                   component="td"
                                                   data-key={2}
                                                   dataLabel="Associated systems"
@@ -14904,7 +15008,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                                   textCenter={false}
                                                 >
                                                   <TdBase
-                                                    className=""
+                                                    className="no-left-padding"
                                                     component="td"
                                                     data-key={2}
                                                     dataLabel="Associated systems"
@@ -14913,7 +15017,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                                     textCenter={false}
                                                   >
                                                     <td
-                                                      className=""
+                                                      className="no-left-padding"
                                                       data-key={2}
                                                       data-label="Associated systems"
                                                       onMouseEnter={[Function]}
@@ -46131,7 +46235,9 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                 Array [
                   "beavs baseline",
                   "2 years ago",
-                  <div>
+                  <div
+                    className="no-left-padding"
+                  >
                     <NotificationDetails
                       badgeCount={3}
                       baselineData={
@@ -46171,7 +46277,9 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                 Array [
                   "micjohns baseline",
                   "2 years ago",
-                  <div>
+                  <div
+                    className="no-left-padding"
+                  >
                     <NotificationDetails
                       badgeCount={0}
                       baselineData={
@@ -47471,7 +47579,9 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                             Array [
                               "beavs baseline",
                               "2 years ago",
-                              <div>
+                              <div
+                                className="no-left-padding"
+                              >
                                 <NotificationDetails
                                   badgeCount={3}
                                   baselineData={
@@ -47511,7 +47621,9 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                             Array [
                               "micjohns baseline",
                               "2 years ago",
-                              <div>
+                              <div
+                                className="no-left-padding"
+                              >
                                 <NotificationDetails
                                   badgeCount={0}
                                   baselineData={
@@ -47559,7 +47671,9 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                               Object {
                                 "0": "beavs baseline",
                                 "1": "2 years ago",
-                                "2": <div>
+                                "2": <div
+                                  className="no-left-padding"
+                                >
                                   <NotificationDetails
                                     badgeCount={3}
                                     baselineData={
@@ -47615,6 +47729,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                       toggleNotificationPending={[Function]}
                                       toggleNotificationRejected={[Function]}
                                     />,
+                                    "className": "no-left-padding",
                                     "isVisible": true,
                                   },
                                   "title": undefined,
@@ -47667,7 +47782,9 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                               Object {
                                 "0": "micjohns baseline",
                                 "1": "2 years ago",
-                                "2": <div>
+                                "2": <div
+                                  className="no-left-padding"
+                                >
                                   <NotificationDetails
                                     badgeCount={0}
                                     baselineData={
@@ -47723,6 +47840,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                       toggleNotificationPending={[Function]}
                                       toggleNotificationRejected={[Function]}
                                     />,
+                                    "className": "no-left-padding",
                                     "isVisible": true,
                                   },
                                   "title": undefined,
@@ -47781,7 +47899,9 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                               Object {
                                 "0": "beavs baseline",
                                 "1": "2 years ago",
-                                "2": <div>
+                                "2": <div
+                                  className="no-left-padding"
+                                >
                                   <NotificationDetails
                                     badgeCount={3}
                                     baselineData={
@@ -47837,6 +47957,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                       toggleNotificationPending={[Function]}
                                       toggleNotificationRejected={[Function]}
                                     />,
+                                    "className": "no-left-padding",
                                     "isVisible": true,
                                   },
                                   "title": undefined,
@@ -47889,7 +48010,9 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                               Object {
                                 "0": "micjohns baseline",
                                 "1": "2 years ago",
-                                "2": <div>
+                                "2": <div
+                                  className="no-left-padding"
+                                >
                                   <NotificationDetails
                                     badgeCount={0}
                                     baselineData={
@@ -47945,6 +48068,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                       toggleNotificationPending={[Function]}
                                       toggleNotificationRejected={[Function]}
                                     />,
+                                    "className": "no-left-padding",
                                     "isVisible": true,
                                   },
                                   "title": undefined,
@@ -48211,7 +48335,9 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                 Object {
                                   "0": "beavs baseline",
                                   "1": "2 years ago",
-                                  "2": <div>
+                                  "2": <div
+                                    className="no-left-padding"
+                                  >
                                     <NotificationDetails
                                       badgeCount={3}
                                       baselineData={
@@ -48267,6 +48393,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                         toggleNotificationPending={[Function]}
                                         toggleNotificationRejected={[Function]}
                                       />,
+                                      "className": "no-left-padding",
                                       "isVisible": true,
                                     },
                                     "title": undefined,
@@ -48319,7 +48446,9 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                 Object {
                                   "0": "micjohns baseline",
                                   "1": "2 years ago",
-                                  "2": <div>
+                                  "2": <div
+                                    className="no-left-padding"
+                                  >
                                     <NotificationDetails
                                       badgeCount={0}
                                       baselineData={
@@ -48375,6 +48504,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                         toggleNotificationPending={[Function]}
                                         toggleNotificationRejected={[Function]}
                                       />,
+                                      "className": "no-left-padding",
                                       "isVisible": true,
                                     },
                                     "title": undefined,
@@ -48460,7 +48590,9 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                 Object {
                                   "0": "beavs baseline",
                                   "1": "2 years ago",
-                                  "2": <div>
+                                  "2": <div
+                                    className="no-left-padding"
+                                  >
                                     <NotificationDetails
                                       badgeCount={3}
                                       baselineData={
@@ -48516,6 +48648,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                         toggleNotificationPending={[Function]}
                                         toggleNotificationRejected={[Function]}
                                       />,
+                                      "className": "no-left-padding",
                                       "isVisible": true,
                                     },
                                     "title": undefined,
@@ -48568,7 +48701,9 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                 Object {
                                   "0": "micjohns baseline",
                                   "1": "2 years ago",
-                                  "2": <div>
+                                  "2": <div
+                                    className="no-left-padding"
+                                  >
                                     <NotificationDetails
                                       badgeCount={0}
                                       baselineData={
@@ -48624,6 +48759,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                         toggleNotificationPending={[Function]}
                                         toggleNotificationRejected={[Function]}
                                       />,
+                                      "className": "no-left-padding",
                                       "isVisible": true,
                                     },
                                     "title": undefined,
@@ -48684,7 +48820,9 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                   Object {
                                     "0": "beavs baseline",
                                     "1": "2 years ago",
-                                    "2": <div>
+                                    "2": <div
+                                      className="no-left-padding"
+                                    >
                                       <NotificationDetails
                                         badgeCount={3}
                                         baselineData={
@@ -48740,6 +48878,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                           toggleNotificationPending={[Function]}
                                           toggleNotificationRejected={[Function]}
                                         />,
+                                        "className": "no-left-padding",
                                         "isVisible": true,
                                       },
                                       "title": undefined,
@@ -48792,7 +48931,9 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                   Object {
                                     "0": "micjohns baseline",
                                     "1": "2 years ago",
-                                    "2": <div>
+                                    "2": <div
+                                      className="no-left-padding"
+                                    >
                                       <NotificationDetails
                                         badgeCount={0}
                                         baselineData={
@@ -48848,6 +48989,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                           toggleNotificationPending={[Function]}
                                           toggleNotificationRejected={[Function]}
                                         />,
+                                        "className": "no-left-padding",
                                         "isVisible": true,
                                       },
                                       "title": undefined,
@@ -49131,7 +49273,9 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                         Object {
                                           "0": "beavs baseline",
                                           "1": "2 years ago",
-                                          "2": <div>
+                                          "2": <div
+                                            className="no-left-padding"
+                                          >
                                             <NotificationDetails
                                               badgeCount={3}
                                               baselineData={
@@ -49187,6 +49331,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                                 toggleNotificationPending={[Function]}
                                                 toggleNotificationRejected={[Function]}
                                               />,
+                                              "className": "no-left-padding",
                                               "isVisible": true,
                                             },
                                             "title": undefined,
@@ -49248,7 +49393,9 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                           Object {
                                             "0": "beavs baseline",
                                             "1": "2 years ago",
-                                            "2": <div>
+                                            "2": <div
+                                              className="no-left-padding"
+                                            >
                                               <NotificationDetails
                                                 badgeCount={3}
                                                 baselineData={
@@ -49304,6 +49451,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                                   toggleNotificationPending={[Function]}
                                                   toggleNotificationRejected={[Function]}
                                                 />,
+                                                "className": "no-left-padding",
                                                 "isVisible": true,
                                               },
                                               "title": undefined,
@@ -49450,13 +49598,14 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                                 </Td>
                                               </BodyCell>
                                               <BodyCell
+                                                className="no-left-padding"
                                                 data-key={2}
                                                 data-label="Associated systems"
                                                 isVisible={true}
                                                 key="col-2-row-0"
                                               >
                                                 <Td
-                                                  className=""
+                                                  className="no-left-padding"
                                                   component="td"
                                                   data-key={2}
                                                   dataLabel="Associated systems"
@@ -49464,7 +49613,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                                   textCenter={false}
                                                 >
                                                   <TdBase
-                                                    className=""
+                                                    className="no-left-padding"
                                                     component="td"
                                                     data-key={2}
                                                     dataLabel="Associated systems"
@@ -49473,7 +49622,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                                     textCenter={false}
                                                   >
                                                     <td
-                                                      className=""
+                                                      className="no-left-padding"
                                                       data-key={2}
                                                       data-label="Associated systems"
                                                       onMouseEnter={[Function]}
@@ -50078,7 +50227,9 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                         Object {
                                           "0": "micjohns baseline",
                                           "1": "2 years ago",
-                                          "2": <div>
+                                          "2": <div
+                                            className="no-left-padding"
+                                          >
                                             <NotificationDetails
                                               badgeCount={0}
                                               baselineData={
@@ -50134,6 +50285,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                                 toggleNotificationPending={[Function]}
                                                 toggleNotificationRejected={[Function]}
                                               />,
+                                              "className": "no-left-padding",
                                               "isVisible": true,
                                             },
                                             "title": undefined,
@@ -50195,7 +50347,9 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                           Object {
                                             "0": "micjohns baseline",
                                             "1": "2 years ago",
-                                            "2": <div>
+                                            "2": <div
+                                              className="no-left-padding"
+                                            >
                                               <NotificationDetails
                                                 badgeCount={0}
                                                 baselineData={
@@ -50251,6 +50405,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                                   toggleNotificationPending={[Function]}
                                                   toggleNotificationRejected={[Function]}
                                                 />,
+                                                "className": "no-left-padding",
                                                 "isVisible": true,
                                               },
                                               "title": undefined,
@@ -50397,13 +50552,14 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                                 </Td>
                                               </BodyCell>
                                               <BodyCell
+                                                className="no-left-padding"
                                                 data-key={2}
                                                 data-label="Associated systems"
                                                 isVisible={true}
                                                 key="col-2-row-1"
                                               >
                                                 <Td
-                                                  className=""
+                                                  className="no-left-padding"
                                                   component="td"
                                                   data-key={2}
                                                   dataLabel="Associated systems"
@@ -50411,7 +50567,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                                   textCenter={false}
                                                 >
                                                   <TdBase
-                                                    className=""
+                                                    className="no-left-padding"
                                                     component="td"
                                                     data-key={2}
                                                     dataLabel="Associated systems"
@@ -50420,7 +50576,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                                     textCenter={false}
                                                   >
                                                     <td
-                                                      className=""
+                                                      className="no-left-padding"
                                                       data-key={2}
                                                       data-label="Associated systems"
                                                       onMouseEnter={[Function]}
@@ -59640,7 +59796,9 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                 Array [
                   "beavs baseline",
                   "2 years ago",
-                  <div>
+                  <div
+                    className="no-left-padding"
+                  >
                     <NotificationDetails
                       badgeCount={3}
                       baselineData={
@@ -59663,7 +59821,9 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                 Array [
                   "micjohns baseline",
                   "2 years ago",
-                  <div>
+                  <div
+                    className="no-left-padding"
+                  >
                     <NotificationDetails
                       badgeCount={0}
                       baselineData={
@@ -60946,7 +61106,9 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                             Array [
                               "beavs baseline",
                               "2 years ago",
-                              <div>
+                              <div
+                                className="no-left-padding"
+                              >
                                 <NotificationDetails
                                   badgeCount={3}
                                   baselineData={
@@ -60969,7 +61131,9 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                             Array [
                               "micjohns baseline",
                               "2 years ago",
-                              <div>
+                              <div
+                                className="no-left-padding"
+                              >
                                 <NotificationDetails
                                   badgeCount={0}
                                   baselineData={
@@ -61000,7 +61164,9 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                               Object {
                                 "0": "beavs baseline",
                                 "1": "2 years ago",
-                                "2": <div>
+                                "2": <div
+                                  className="no-left-padding"
+                                >
                                   <NotificationDetails
                                     badgeCount={3}
                                     baselineData={
@@ -61039,6 +61205,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                       toggleNotificationPending={[Function]}
                                       toggleNotificationRejected={[Function]}
                                     />,
+                                    "className": "no-left-padding",
                                     "isVisible": true,
                                   },
                                   "title": undefined,
@@ -61069,7 +61236,9 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                               Object {
                                 "0": "micjohns baseline",
                                 "1": "2 years ago",
-                                "2": <div>
+                                "2": <div
+                                  className="no-left-padding"
+                                >
                                   <NotificationDetails
                                     badgeCount={0}
                                     baselineData={
@@ -61108,6 +61277,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                       toggleNotificationPending={[Function]}
                                       toggleNotificationRejected={[Function]}
                                     />,
+                                    "className": "no-left-padding",
                                     "isVisible": true,
                                   },
                                   "title": undefined,
@@ -61144,7 +61314,9 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                               Object {
                                 "0": "beavs baseline",
                                 "1": "2 years ago",
-                                "2": <div>
+                                "2": <div
+                                  className="no-left-padding"
+                                >
                                   <NotificationDetails
                                     badgeCount={3}
                                     baselineData={
@@ -61183,6 +61355,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                       toggleNotificationPending={[Function]}
                                       toggleNotificationRejected={[Function]}
                                     />,
+                                    "className": "no-left-padding",
                                     "isVisible": true,
                                   },
                                   "title": undefined,
@@ -61213,7 +61386,9 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                               Object {
                                 "0": "micjohns baseline",
                                 "1": "2 years ago",
-                                "2": <div>
+                                "2": <div
+                                  className="no-left-padding"
+                                >
                                   <NotificationDetails
                                     badgeCount={0}
                                     baselineData={
@@ -61252,6 +61427,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                       toggleNotificationPending={[Function]}
                                       toggleNotificationRejected={[Function]}
                                     />,
+                                    "className": "no-left-padding",
                                     "isVisible": true,
                                   },
                                   "title": undefined,
@@ -61496,7 +61672,9 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                 Object {
                                   "0": "beavs baseline",
                                   "1": "2 years ago",
-                                  "2": <div>
+                                  "2": <div
+                                    className="no-left-padding"
+                                  >
                                     <NotificationDetails
                                       badgeCount={3}
                                       baselineData={
@@ -61535,6 +61713,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                         toggleNotificationPending={[Function]}
                                         toggleNotificationRejected={[Function]}
                                       />,
+                                      "className": "no-left-padding",
                                       "isVisible": true,
                                     },
                                     "title": undefined,
@@ -61565,7 +61744,9 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                 Object {
                                   "0": "micjohns baseline",
                                   "1": "2 years ago",
-                                  "2": <div>
+                                  "2": <div
+                                    className="no-left-padding"
+                                  >
                                     <NotificationDetails
                                       badgeCount={0}
                                       baselineData={
@@ -61604,6 +61785,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                         toggleNotificationPending={[Function]}
                                         toggleNotificationRejected={[Function]}
                                       />,
+                                      "className": "no-left-padding",
                                       "isVisible": true,
                                     },
                                     "title": undefined,
@@ -61667,7 +61849,9 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                 Object {
                                   "0": "beavs baseline",
                                   "1": "2 years ago",
-                                  "2": <div>
+                                  "2": <div
+                                    className="no-left-padding"
+                                  >
                                     <NotificationDetails
                                       badgeCount={3}
                                       baselineData={
@@ -61706,6 +61890,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                         toggleNotificationPending={[Function]}
                                         toggleNotificationRejected={[Function]}
                                       />,
+                                      "className": "no-left-padding",
                                       "isVisible": true,
                                     },
                                     "title": undefined,
@@ -61736,7 +61921,9 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                 Object {
                                   "0": "micjohns baseline",
                                   "1": "2 years ago",
-                                  "2": <div>
+                                  "2": <div
+                                    className="no-left-padding"
+                                  >
                                     <NotificationDetails
                                       badgeCount={0}
                                       baselineData={
@@ -61775,6 +61962,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                         toggleNotificationPending={[Function]}
                                         toggleNotificationRejected={[Function]}
                                       />,
+                                      "className": "no-left-padding",
                                       "isVisible": true,
                                     },
                                     "title": undefined,
@@ -61813,7 +62001,9 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                   Object {
                                     "0": "beavs baseline",
                                     "1": "2 years ago",
-                                    "2": <div>
+                                    "2": <div
+                                      className="no-left-padding"
+                                    >
                                       <NotificationDetails
                                         badgeCount={3}
                                         baselineData={
@@ -61852,6 +62042,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                           toggleNotificationPending={[Function]}
                                           toggleNotificationRejected={[Function]}
                                         />,
+                                        "className": "no-left-padding",
                                         "isVisible": true,
                                       },
                                       "title": undefined,
@@ -61882,7 +62073,9 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                   Object {
                                     "0": "micjohns baseline",
                                     "1": "2 years ago",
-                                    "2": <div>
+                                    "2": <div
+                                      className="no-left-padding"
+                                    >
                                       <NotificationDetails
                                         badgeCount={0}
                                         baselineData={
@@ -61921,6 +62114,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                           toggleNotificationPending={[Function]}
                                           toggleNotificationRejected={[Function]}
                                         />,
+                                        "className": "no-left-padding",
                                         "isVisible": true,
                                       },
                                       "title": undefined,
@@ -62182,7 +62376,9 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                         Object {
                                           "0": "beavs baseline",
                                           "1": "2 years ago",
-                                          "2": <div>
+                                          "2": <div
+                                            className="no-left-padding"
+                                          >
                                             <NotificationDetails
                                               badgeCount={3}
                                               baselineData={
@@ -62221,6 +62417,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                                 toggleNotificationPending={[Function]}
                                                 toggleNotificationRejected={[Function]}
                                               />,
+                                              "className": "no-left-padding",
                                               "isVisible": true,
                                             },
                                             "title": undefined,
@@ -62260,7 +62457,9 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                           Object {
                                             "0": "beavs baseline",
                                             "1": "2 years ago",
-                                            "2": <div>
+                                            "2": <div
+                                              className="no-left-padding"
+                                            >
                                               <NotificationDetails
                                                 badgeCount={3}
                                                 baselineData={
@@ -62299,6 +62498,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                                   toggleNotificationPending={[Function]}
                                                   toggleNotificationRejected={[Function]}
                                                 />,
+                                                "className": "no-left-padding",
                                                 "isVisible": true,
                                               },
                                               "title": undefined,
@@ -62423,13 +62623,14 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                                 </Td>
                                               </BodyCell>
                                               <BodyCell
+                                                className="no-left-padding"
                                                 data-key={2}
                                                 data-label="Associated systems"
                                                 isVisible={true}
                                                 key="col-2-row-0"
                                               >
                                                 <Td
-                                                  className=""
+                                                  className="no-left-padding"
                                                   component="td"
                                                   data-key={2}
                                                   dataLabel="Associated systems"
@@ -62437,7 +62638,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                                   textCenter={false}
                                                 >
                                                   <TdBase
-                                                    className=""
+                                                    className="no-left-padding"
                                                     component="td"
                                                     data-key={2}
                                                     dataLabel="Associated systems"
@@ -62446,7 +62647,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                                     textCenter={false}
                                                   >
                                                     <td
-                                                      className=""
+                                                      className="no-left-padding"
                                                       data-key={2}
                                                       data-label="Associated systems"
                                                       onMouseEnter={[Function]}
@@ -62713,7 +62914,9 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                         Object {
                                           "0": "micjohns baseline",
                                           "1": "2 years ago",
-                                          "2": <div>
+                                          "2": <div
+                                            className="no-left-padding"
+                                          >
                                             <NotificationDetails
                                               badgeCount={0}
                                               baselineData={
@@ -62752,6 +62955,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                                 toggleNotificationPending={[Function]}
                                                 toggleNotificationRejected={[Function]}
                                               />,
+                                              "className": "no-left-padding",
                                               "isVisible": true,
                                             },
                                             "title": undefined,
@@ -62791,7 +62995,9 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                           Object {
                                             "0": "micjohns baseline",
                                             "1": "2 years ago",
-                                            "2": <div>
+                                            "2": <div
+                                              className="no-left-padding"
+                                            >
                                               <NotificationDetails
                                                 badgeCount={0}
                                                 baselineData={
@@ -62830,6 +63036,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                                   toggleNotificationPending={[Function]}
                                                   toggleNotificationRejected={[Function]}
                                                 />,
+                                                "className": "no-left-padding",
                                                 "isVisible": true,
                                               },
                                               "title": undefined,
@@ -62954,13 +63161,14 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                                 </Td>
                                               </BodyCell>
                                               <BodyCell
+                                                className="no-left-padding"
                                                 data-key={2}
                                                 data-label="Associated systems"
                                                 isVisible={true}
                                                 key="col-2-row-1"
                                               >
                                                 <Td
-                                                  className=""
+                                                  className="no-left-padding"
                                                   component="td"
                                                   data-key={2}
                                                   dataLabel="Associated systems"
@@ -62968,7 +63176,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                                   textCenter={false}
                                                 >
                                                   <TdBase
-                                                    className=""
+                                                    className="no-left-padding"
                                                     component="td"
                                                     data-key={2}
                                                     dataLabel="Associated systems"
@@ -62977,7 +63185,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                                     textCenter={false}
                                                   >
                                                     <td
-                                                      className=""
+                                                      className="no-left-padding"
                                                       data-key={2}
                                                       data-label="Associated systems"
                                                       onMouseEnter={[Function]}

--- a/src/SmartComponents/NotificationsSwitch/NotificationsSwitch.js
+++ b/src/SmartComponents/NotificationsSwitch/NotificationsSwitch.js
@@ -14,7 +14,6 @@ function NotificationsSwitch(props) {
             labelOff={ hasLabel ? 'Notifications are disabled' : null }
             label={ hasLabel ? 'Notifications are enabled' : null }
             isReversed
-            isDisabled={ baselineData.associated_systems === 0 }
         />
     );
 }


### PR DESCRIPTION
Before, if a system had 0 associated systems, we disabled the Switch. Now, the Switch is always enabled, allowing a user to flip notifications on and off not matter how many systems are associated.

Before, the color of the badge would be blue if notifications were turned on, and gray if notifications were turned off. This action mimicked the color of the switch. This PR disassociates the state of the Switch and the badge color. Now, if there are greater than 0 associated systems, the badge color will be blue, and if there are 0 associated systems, the badge will be gray.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
