### PR TITLE
[DRFT-366] Add button to apply changes to Selected Basket

### DIFF
--- a/src/SmartComponents/AddSystemModal/SelectedBasket/SelectedBasket.js
+++ b/src/SmartComponents/AddSystemModal/SelectedBasket/SelectedBasket.js
@@ -1,7 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Popover, PopoverPosition } from '@patternfly/react-core';
+import { Button, Popover, PopoverPosition } from '@patternfly/react-core';
 import SelectedTable from './SelectedTable/SelectedTable';
+import EmptyStateDisplay from '../../EmptyStateDisplay/EmptyStateDisplay';
 
 export class SelectedBasket extends Component {
     constructor(props) {
@@ -20,7 +21,14 @@ export class SelectedBasket extends Component {
         };
     }
 
-    onToggle = async () => {
+    toggleBasket = () => {
+        const { toggleBasketVisible } = this.props;
+
+        this.clearDeselected();
+        toggleBasketVisible();
+    }
+
+    applyChanges = async () => {
         const { baselinesToDeselect, hspsToDeselect, systemsToDeselect } = this.state;
         const { handleBaselineSelection, handleHSPSelection, selectBaseline, selectEntity, selectHistoricProfiles,
             selectedBaselineContent, selectedHSPContent, toggleBasketVisible } = this.props;
@@ -101,8 +109,31 @@ export class SelectedBasket extends Component {
         return selectedCount;
     }
 
+    displayBodyContent = (isEmpty) => {
+        const { entities, selectedSystemContent, selectedBaselineContent, selectedHSPContent } = this.props;
+        let bodyContent;
+
+        if (isEmpty) {
+            bodyContent = <EmptyStateDisplay
+                title='Nothing selected'
+                text={ [ 'Select systems and baselines to compare.' ] }
+            />;
+        } else {
+            bodyContent = <SelectedTable
+                selectedBaselineContent={ selectedBaselineContent }
+                entities={ entities }
+                selectedHSPContent={ selectedHSPContent }
+                findType={ this.findType }
+                handleDeselect={ this.handleDeselect }
+                selectedSystemContent={ selectedSystemContent }
+            />;
+        }
+
+        return bodyContent;
+    }
+
     render() {
-        const { entities, isVisible, selectedBaselineContent, selectedHSPContent, selectedSystemContent } = this.props;
+        const { isVisible } = this.props;
 
         return (
             <React.Fragment>
@@ -111,21 +142,22 @@ export class SelectedBasket extends Component {
                         id='selected-basket'
                         style={{ minWidth: '500px' }}
                         isVisible={ isVisible }
-                        shouldClose={ () => this.onToggle() }
-                        headerContent={ <div>Selected items</div> }
+                        shouldClose={ () => this.toggleBasket() }
+                        headerContent={ <div>Selected items ({ this.findSelected() })</div> }
+                        footerContent={ <Button
+                            key="confirm"
+                            variant="primary"
+                            onClick={ () => this.applyChanges() }
+                            ouiaId="confirm-selected-basket-button"
+                        >
+                            Apply changes
+                        </Button> }
                         position={ PopoverPosition.bottom }
                         bodyContent={ <div style={{ maxHeight: '500px', overflowY: 'auto' }}>
-                            <SelectedTable
-                                selectedBaselineContent={ selectedBaselineContent }
-                                entities={ entities }
-                                selectedHSPContent={ selectedHSPContent }
-                                findType={ this.findType }
-                                handleDeselect={ this.handleDeselect }
-                                selectedSystemContent={ selectedSystemContent }
-                            />
+                            { this.displayBodyContent(this.findSelected() === 0) }
                         </div> }
                     >
-                        <a onClick={ () => this.onToggle() }>
+                        <a onClick={ () => this.toggleBasket() }>
                             Selected ({ this.findSelected() })
                         </a>
                     </Popover>

--- a/src/SmartComponents/AddSystemModal/SelectedBasket/__tests__/SelectedBasket.tests.js
+++ b/src/SmartComponents/AddSystemModal/SelectedBasket/__tests__/SelectedBasket.tests.js
@@ -79,7 +79,7 @@ describe('SelectedBasket', () => {
         wrapper.setState({ systemsToDeselect: [ 'efgh5678' ]});
         wrapper.setState({ isVisible: true });
 
-        wrapper.instance().onToggle();
+        wrapper.instance().applyChanges();
         expect(props.selectEntity).toHaveBeenCalledWith('efgh5678', false);
         expect(props.selectBaseline).not.toHaveBeenCalled();
         expect(props.selectHistoricProfiles).not.toHaveBeenCalled();
@@ -101,7 +101,7 @@ describe('SelectedBasket', () => {
         wrapper.setState({ hspsToDeselect: [ 'ijkl9101' ]});
         wrapper.setState({ isVisible: true });
 
-        wrapper.instance().onToggle();
+        wrapper.instance().applyChanges();
         expect(props.selectHistoricProfiles).toHaveBeenCalledWith([ 'mnop1121' ]);
     });
 
@@ -119,7 +119,7 @@ describe('SelectedBasket', () => {
         });
         wrapper.setState({ isVisible: true });
 
-        await wrapper.instance().onToggle();
+        await wrapper.instance().applyChanges();
         await expect(props.selectBaseline).toHaveBeenCalledWith([ 'abcd1234' ], false, 'COMPARISON');
         await expect(props.handleBaselineSelection).toHaveBeenCalledWith(
             [{ id: 'abcd1234', name: 'baseline', icon: <BlueprintIcon /> }],
@@ -203,6 +203,27 @@ describe('SelectedBasket', () => {
         );
 
         expect(wrapper.instance().removeId('efgh5678', [ 'abcd1234', 'efgh5678' ])).toEqual([ 'abcd1234' ]);
+    });
+
+    it('should clear items to deselect', () => {
+        const wrapper = shallow(
+            <SelectedBasket
+                { ...props }
+            />
+        );
+
+        wrapper.setState({
+            systemsToDeselect: [ 'efgh5678' ],
+            baselinesToDeselect: [ 'abcd1234' ],
+            hspsToDeselect: [ 'ijkl9101' ]
+        });
+        wrapper.setState({ isVisible: true });
+
+        wrapper.instance().toggleBasket();
+        expect(props.toggleBasketVisible).toHaveBeenCalled();
+        expect(wrapper.state('systemsToDeselect')).toEqual([]);
+        expect(wrapper.state('baselinesToDeselect')).toEqual([]);
+        expect(wrapper.state('hspsToDeselect')).toEqual([]);
     });
 });
 /*eslint-enable camelcase*/

--- a/src/SmartComponents/AddSystemModal/SelectedBasket/__tests__/__snapshots__/SelectedBasket.tests.js.snap
+++ b/src/SmartComponents/AddSystemModal/SelectedBasket/__tests__/__snapshots__/SelectedBasket.tests.js.snap
@@ -58,9 +58,20 @@ exports[`SelectedBasket should not be visible with selected count 1`] = `
           />
         </div>
       }
+      footerContent={
+        <Button
+          onClick={[Function]}
+          ouiaId="confirm-selected-basket-button"
+          variant="primary"
+        >
+          Apply changes
+        </Button>
+      }
       headerContent={
         <div>
-          Selected items
+          Selected items (
+          3
+          )
         </div>
       }
       id="selected-basket"
@@ -97,17 +108,30 @@ exports[`SelectedBasket should render empty 1`] = `
             }
           }
         >
-          <SelectedTable
-            findType={[Function]}
-            selectedBaselineContent={Array []}
-            selectedHSPContent={Array []}
-            selectedSystemContent={Array []}
+          <EmptyStateDisplay
+            text={
+              Array [
+                "Select systems and baselines to compare.",
+              ]
+            }
+            title="Nothing selected"
           />
         </div>
       }
+      footerContent={
+        <Button
+          onClick={[Function]}
+          ouiaId="confirm-selected-basket-button"
+          variant="primary"
+        >
+          Apply changes
+        </Button>
+      }
       headerContent={
         <div>
-          Selected items
+          Selected items (
+          0
+          )
         </div>
       }
       id="selected-basket"
@@ -189,9 +213,20 @@ exports[`SelectedBasket should toggle to visible with system, baseline and hsp 1
           />
         </div>
       }
+      footerContent={
+        <Button
+          onClick={[Function]}
+          ouiaId="confirm-selected-basket-button"
+          variant="primary"
+        >
+          Apply changes
+        </Button>
+      }
       headerContent={
         <div>
-          Selected items
+          Selected items (
+          3
+          )
         </div>
       }
       id="selected-basket"

--- a/src/SmartComponents/AddSystemModal/__tests__/__snapshots__/AddSystemModal.tests.js.snap
+++ b/src/SmartComponents/AddSystemModal/__tests__/__snapshots__/AddSystemModal.tests.js.snap
@@ -10736,32 +10736,30 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                                             }
                                                           }
                                                         >
-                                                          <SelectedTable
-                                                            entities={
-                                                              Object {
-                                                                "rows": Array [
-                                                                  Object {
-                                                                    "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
-                                                                    "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
-                                                                  },
-                                                                  Object {
-                                                                    "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
-                                                                    "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
-                                                                  },
-                                                                ],
-                                                                "selectedSystemIds": Array [],
-                                                              }
+                                                          <EmptyStateDisplay
+                                                            text={
+                                                              Array [
+                                                                "Select systems and baselines to compare.",
+                                                              ]
                                                             }
-                                                            findType={[Function]}
-                                                            selectedBaselineContent={Array []}
-                                                            selectedHSPContent={Array []}
-                                                            selectedSystemContent={Array []}
+                                                            title="Nothing selected"
                                                           />
                                                         </div>
                                                       }
+                                                      footerContent={
+                                                        <Button
+                                                          onClick={[Function]}
+                                                          ouiaId="confirm-selected-basket-button"
+                                                          variant="primary"
+                                                        >
+                                                          Apply changes
+                                                        </Button>
+                                                      }
                                                       headerContent={
                                                         <div>
-                                                          Selected items
+                                                          Selected items (
+                                                          0
+                                                          )
                                                         </div>
                                                       }
                                                       id="selected-basket"
@@ -10829,7 +10827,9 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                                                 id="popover-selected-basket-header"
                                                               >
                                                                 <div>
-                                                                  Selected items
+                                                                  Selected items (
+                                                                  0
+                                                                  )
                                                                 </div>
                                                               </PopoverHeader>
                                                               <PopoverBody
@@ -10843,29 +10843,27 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                                                     }
                                                                   }
                                                                 >
-                                                                  <SelectedTable
-                                                                    entities={
-                                                                      Object {
-                                                                        "rows": Array [
-                                                                          Object {
-                                                                            "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
-                                                                            "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
-                                                                          },
-                                                                          Object {
-                                                                            "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
-                                                                            "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
-                                                                          },
-                                                                        ],
-                                                                        "selectedSystemIds": Array [],
-                                                                      }
+                                                                  <EmptyStateDisplay
+                                                                    text={
+                                                                      Array [
+                                                                        "Select systems and baselines to compare.",
+                                                                      ]
                                                                     }
-                                                                    findType={[Function]}
-                                                                    selectedBaselineContent={Array []}
-                                                                    selectedHSPContent={Array []}
-                                                                    selectedSystemContent={Array []}
+                                                                    title="Nothing selected"
                                                                   />
                                                                 </div>
                                                               </PopoverBody>
+                                                              <PopoverFooter
+                                                                id="popover-selected-basket-footer"
+                                                              >
+                                                                <Button
+                                                                  onClick={[Function]}
+                                                                  ouiaId="confirm-selected-basket-button"
+                                                                  variant="primary"
+                                                                >
+                                                                  Apply changes
+                                                                </Button>
+                                                              </PopoverFooter>
                                                             </PopoverContent>
                                                           </FocusTrap>
                                                         }
@@ -18344,32 +18342,30 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                                             }
                                                           }
                                                         >
-                                                          <SelectedTable
-                                                            entities={
-                                                              Object {
-                                                                "rows": Array [
-                                                                  Object {
-                                                                    "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
-                                                                    "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
-                                                                  },
-                                                                  Object {
-                                                                    "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
-                                                                    "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
-                                                                  },
-                                                                ],
-                                                                "selectedSystemIds": Array [],
-                                                              }
+                                                          <EmptyStateDisplay
+                                                            text={
+                                                              Array [
+                                                                "Select systems and baselines to compare.",
+                                                              ]
                                                             }
-                                                            findType={[Function]}
-                                                            selectedBaselineContent={Array []}
-                                                            selectedHSPContent={Array []}
-                                                            selectedSystemContent={Array []}
+                                                            title="Nothing selected"
                                                           />
                                                         </div>
                                                       }
+                                                      footerContent={
+                                                        <Button
+                                                          onClick={[Function]}
+                                                          ouiaId="confirm-selected-basket-button"
+                                                          variant="primary"
+                                                        >
+                                                          Apply changes
+                                                        </Button>
+                                                      }
                                                       headerContent={
                                                         <div>
-                                                          Selected items
+                                                          Selected items (
+                                                          0
+                                                          )
                                                         </div>
                                                       }
                                                       id="selected-basket"
@@ -18437,7 +18433,9 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                                                 id="popover-selected-basket-header"
                                                               >
                                                                 <div>
-                                                                  Selected items
+                                                                  Selected items (
+                                                                  0
+                                                                  )
                                                                 </div>
                                                               </PopoverHeader>
                                                               <PopoverBody
@@ -18451,29 +18449,27 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                                                     }
                                                                   }
                                                                 >
-                                                                  <SelectedTable
-                                                                    entities={
-                                                                      Object {
-                                                                        "rows": Array [
-                                                                          Object {
-                                                                            "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
-                                                                            "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
-                                                                          },
-                                                                          Object {
-                                                                            "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
-                                                                            "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
-                                                                          },
-                                                                        ],
-                                                                        "selectedSystemIds": Array [],
-                                                                      }
+                                                                  <EmptyStateDisplay
+                                                                    text={
+                                                                      Array [
+                                                                        "Select systems and baselines to compare.",
+                                                                      ]
                                                                     }
-                                                                    findType={[Function]}
-                                                                    selectedBaselineContent={Array []}
-                                                                    selectedHSPContent={Array []}
-                                                                    selectedSystemContent={Array []}
+                                                                    title="Nothing selected"
                                                                   />
                                                                 </div>
                                                               </PopoverBody>
+                                                              <PopoverFooter
+                                                                id="popover-selected-basket-footer"
+                                                              >
+                                                                <Button
+                                                                  onClick={[Function]}
+                                                                  ouiaId="confirm-selected-basket-button"
+                                                                  variant="primary"
+                                                                >
+                                                                  Apply changes
+                                                                </Button>
+                                                              </PopoverFooter>
                                                             </PopoverContent>
                                                           </FocusTrap>
                                                         }
@@ -25973,32 +25969,30 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                                             }
                                                           }
                                                         >
-                                                          <SelectedTable
-                                                            entities={
-                                                              Object {
-                                                                "rows": Array [
-                                                                  Object {
-                                                                    "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
-                                                                    "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
-                                                                  },
-                                                                  Object {
-                                                                    "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
-                                                                    "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
-                                                                  },
-                                                                ],
-                                                                "selectedSystemIds": Array [],
-                                                              }
+                                                          <EmptyStateDisplay
+                                                            text={
+                                                              Array [
+                                                                "Select systems and baselines to compare.",
+                                                              ]
                                                             }
-                                                            findType={[Function]}
-                                                            selectedBaselineContent={Array []}
-                                                            selectedHSPContent={Array []}
-                                                            selectedSystemContent={Array []}
+                                                            title="Nothing selected"
                                                           />
                                                         </div>
                                                       }
+                                                      footerContent={
+                                                        <Button
+                                                          onClick={[Function]}
+                                                          ouiaId="confirm-selected-basket-button"
+                                                          variant="primary"
+                                                        >
+                                                          Apply changes
+                                                        </Button>
+                                                      }
                                                       headerContent={
                                                         <div>
-                                                          Selected items
+                                                          Selected items (
+                                                          0
+                                                          )
                                                         </div>
                                                       }
                                                       id="selected-basket"
@@ -26066,7 +26060,9 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                                                 id="popover-selected-basket-header"
                                                               >
                                                                 <div>
-                                                                  Selected items
+                                                                  Selected items (
+                                                                  0
+                                                                  )
                                                                 </div>
                                                               </PopoverHeader>
                                                               <PopoverBody
@@ -26080,29 +26076,27 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                                                     }
                                                                   }
                                                                 >
-                                                                  <SelectedTable
-                                                                    entities={
-                                                                      Object {
-                                                                        "rows": Array [
-                                                                          Object {
-                                                                            "display_name": "sgi-xe500-01.rhts.eng.bos.redhat.com",
-                                                                            "id": "9c79efcc-8f9a-47c7-b0f2-142ff52e89e9",
-                                                                          },
-                                                                          Object {
-                                                                            "display_name": "ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com",
-                                                                            "id": "f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2",
-                                                                          },
-                                                                        ],
-                                                                        "selectedSystemIds": Array [],
-                                                                      }
+                                                                  <EmptyStateDisplay
+                                                                    text={
+                                                                      Array [
+                                                                        "Select systems and baselines to compare.",
+                                                                      ]
                                                                     }
-                                                                    findType={[Function]}
-                                                                    selectedBaselineContent={Array []}
-                                                                    selectedHSPContent={Array []}
-                                                                    selectedSystemContent={Array []}
+                                                                    title="Nothing selected"
                                                                   />
                                                                 </div>
                                                               </PopoverBody>
+                                                              <PopoverFooter
+                                                                id="popover-selected-basket-footer"
+                                                              >
+                                                                <Button
+                                                                  onClick={[Function]}
+                                                                  ouiaId="confirm-selected-basket-button"
+                                                                  variant="primary"
+                                                                >
+                                                                  Apply changes
+                                                                </Button>
+                                                              </PopoverFooter>
                                                             </PopoverContent>
                                                           </FocusTrap>
                                                         }


### PR DESCRIPTION
Before, in order to apply changes made to the Selected Basket, a user had to click the close button in the popover. Now, a user must click the "Apply changes" button. If a user makes changes to the Selected Basket and either clicks out of the popover or clicks the "X" to close the popover, the changes will NOT be applied.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
