### PR TITLE
[DRFT-908] Close Selected Basket popover on modal scroll

### DIFF
--- a/src/SmartComponents/AddSystemModal/AddSystemModal.js
+++ b/src/SmartComponents/AddSystemModal/AddSystemModal.js
@@ -32,6 +32,8 @@ export class AddSystemModal extends Component {
             ],
             basketIsVisible: false
         };
+
+        this.addSystemModal = React.createRef();
     }
 
     async componentDidMount() {
@@ -43,6 +45,13 @@ export class AddSystemModal extends Component {
                 this.props.addSystemModalOpened ? this.systemContentSelect(data) : null;
             }
         });
+    }
+
+    closePopover = () => {
+        const { disableSystemTable } = this.props;
+
+        disableSystemTable(false);
+        this.setState({ basketIsVisible: false });
     }
 
     buildSystemColumns(permissions) {
@@ -247,7 +256,9 @@ export class AddSystemModal extends Component {
         return (
             <React.Fragment>
                 <Modal
-                    className="drift"
+                    ref={ this.addSystemModal }
+                    onScroll={ basketIsVisible ? this.closePopover : null }
+                    style={{ maxHeight: '600px' }}
                     width={ '950px' }
                     title="Add to comparison"
                     ouiaId='add-to-comparison-modal'

--- a/src/SmartComponents/AddSystemModal/__tests__/__snapshots__/AddSystemModal.tests.js.snap
+++ b/src/SmartComponents/AddSystemModal/__tests__/__snapshots__/AddSystemModal.tests.js.snap
@@ -27,13 +27,19 @@ exports[`AddSystemModal should render correctly 1`] = `
     aria-describedby=""
     aria-label=""
     aria-labelledby=""
-    className="drift"
+    className=""
     hasNoBodyWrapper={false}
     isOpen={true}
     onClose={[Function]}
+    onScroll={null}
     ouiaId="add-to-comparison-modal"
     ouiaSafe={true}
     showClose={true}
+    style={
+      Object {
+        "maxHeight": "600px",
+      }
+    }
     title="Add to comparison"
     titleIconVariant={null}
     titleLabel=""
@@ -9512,13 +9518,19 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
             aria-describedby=""
             aria-label=""
             aria-labelledby=""
-            className="drift"
+            className=""
             hasNoBodyWrapper={false}
             isOpen={true}
             onClose={[Function]}
+            onScroll={null}
             ouiaId="add-to-comparison-modal"
             ouiaSafe={true}
             showClose={true}
+            style={
+              Object {
+                "maxHeight": "600px",
+              }
+            }
             title="Add to comparison"
             titleIconVariant={null}
             titleLabel=""
@@ -9538,7 +9550,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                         aria-describedby="pf-modal-part-8"
                         aria-labelledby="pf-modal-part-7"
                         aria-modal="true"
-                        class="pf-c-modal-box drift"
+                        class="pf-c-modal-box"
                         data-ouia-component-id="add-to-comparison-modal"
                         data-ouia-component-type="PF4/ModalContent"
                         data-ouia-safe="true"
@@ -9587,6 +9599,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                         <div
                           class="pf-c-modal-box__body"
                           id="pf-modal-part-8"
+                          style="max-height: 600px;"
                         >
                           <div
                             class="pf-c-toolbar"
@@ -10497,15 +10510,21 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                 aria-label=""
                 aria-labelledby=""
                 boxId="pf-modal-part-6"
-                className="drift"
+                className=""
                 descriptorId="pf-modal-part-8"
                 hasNoBodyWrapper={false}
                 isOpen={true}
                 labelId="pf-modal-part-7"
                 onClose={[Function]}
+                onScroll={null}
                 ouiaId="add-to-comparison-modal"
                 ouiaSafe={true}
                 showClose={true}
+                style={
+                  Object {
+                    "maxHeight": "600px",
+                  }
+                }
                 title="Add to comparison"
                 titleIconVariant={null}
                 titleLabel=""
@@ -10534,7 +10553,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                           aria-describedby="pf-modal-part-8"
                           aria-label=""
                           aria-labelledby="pf-modal-part-7"
-                          className="drift"
+                          className=""
                           data-ouia-component-id="add-to-comparison-modal"
                           data-ouia-component-type="PF4/ModalContent"
                           data-ouia-safe={true}
@@ -10551,7 +10570,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                             aria-label={null}
                             aria-labelledby="pf-modal-part-7"
                             aria-modal="true"
-                            className="pf-c-modal-box drift"
+                            className="pf-c-modal-box"
                             data-ouia-component-id="add-to-comparison-modal"
                             data-ouia-component-type="PF4/ModalContent"
                             data-ouia-safe={true}
@@ -10646,10 +10665,22 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                             </ModalBoxHeader>
                             <ModalBoxBody
                               id="pf-modal-part-8"
+                              onScroll={null}
+                              style={
+                                Object {
+                                  "maxHeight": "600px",
+                                }
+                              }
                             >
                               <div
                                 className="pf-c-modal-box__body"
                                 id="pf-modal-part-8"
+                                onScroll={null}
+                                style={
+                                  Object {
+                                    "maxHeight": "600px",
+                                  }
+                                }
                               >
                                 <GlobalFilterAlert
                                   globalFilterState={
@@ -17118,13 +17149,19 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
             aria-describedby=""
             aria-label=""
             aria-labelledby=""
-            className="drift"
+            className=""
             hasNoBodyWrapper={false}
             isOpen={true}
             onClose={[Function]}
+            onScroll={null}
             ouiaId="add-to-comparison-modal"
             ouiaSafe={true}
             showClose={true}
+            style={
+              Object {
+                "maxHeight": "600px",
+              }
+            }
             title="Add to comparison"
             titleIconVariant={null}
             titleLabel=""
@@ -17144,7 +17181,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                         aria-describedby="pf-modal-part-2"
                         aria-labelledby="pf-modal-part-1"
                         aria-modal="true"
-                        class="pf-c-modal-box drift"
+                        class="pf-c-modal-box"
                         data-ouia-component-id="add-to-comparison-modal"
                         data-ouia-component-type="PF4/ModalContent"
                         data-ouia-safe="true"
@@ -17193,6 +17230,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                         <div
                           class="pf-c-modal-box__body"
                           id="pf-modal-part-2"
+                          style="max-height: 600px;"
                         >
                           <div
                             class="pf-c-toolbar"
@@ -18103,15 +18141,21 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                 aria-label=""
                 aria-labelledby=""
                 boxId="pf-modal-part-0"
-                className="drift"
+                className=""
                 descriptorId="pf-modal-part-2"
                 hasNoBodyWrapper={false}
                 isOpen={true}
                 labelId="pf-modal-part-1"
                 onClose={[Function]}
+                onScroll={null}
                 ouiaId="add-to-comparison-modal"
                 ouiaSafe={true}
                 showClose={true}
+                style={
+                  Object {
+                    "maxHeight": "600px",
+                  }
+                }
                 title="Add to comparison"
                 titleIconVariant={null}
                 titleLabel=""
@@ -18140,7 +18184,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                           aria-describedby="pf-modal-part-2"
                           aria-label=""
                           aria-labelledby="pf-modal-part-1"
-                          className="drift"
+                          className=""
                           data-ouia-component-id="add-to-comparison-modal"
                           data-ouia-component-type="PF4/ModalContent"
                           data-ouia-safe={true}
@@ -18157,7 +18201,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                             aria-label={null}
                             aria-labelledby="pf-modal-part-1"
                             aria-modal="true"
-                            className="pf-c-modal-box drift"
+                            className="pf-c-modal-box"
                             data-ouia-component-id="add-to-comparison-modal"
                             data-ouia-component-type="PF4/ModalContent"
                             data-ouia-safe={true}
@@ -18252,10 +18296,22 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                             </ModalBoxHeader>
                             <ModalBoxBody
                               id="pf-modal-part-2"
+                              onScroll={null}
+                              style={
+                                Object {
+                                  "maxHeight": "600px",
+                                }
+                              }
                             >
                               <div
                                 className="pf-c-modal-box__body"
                                 id="pf-modal-part-2"
+                                onScroll={null}
+                                style={
+                                  Object {
+                                    "maxHeight": "600px",
+                                  }
+                                }
                               >
                                 <GlobalFilterAlert
                                   globalFilterState={
@@ -24724,13 +24780,19 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
             aria-describedby=""
             aria-label=""
             aria-labelledby=""
-            className="drift"
+            className=""
             hasNoBodyWrapper={false}
             isOpen={true}
             onClose={[Function]}
+            onScroll={null}
             ouiaId="add-to-comparison-modal"
             ouiaSafe={true}
             showClose={true}
+            style={
+              Object {
+                "maxHeight": "600px",
+              }
+            }
             title="Add to comparison"
             titleIconVariant={null}
             titleLabel=""
@@ -24750,7 +24812,7 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                         aria-describedby="pf-modal-part-4"
                         aria-labelledby="pf-modal-part-3"
                         aria-modal="true"
-                        class="pf-c-modal-box drift"
+                        class="pf-c-modal-box"
                         data-ouia-component-id="add-to-comparison-modal"
                         data-ouia-component-type="PF4/ModalContent"
                         data-ouia-safe="true"
@@ -24799,6 +24861,7 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                         <div
                           class="pf-c-modal-box__body"
                           id="pf-modal-part-4"
+                          style="max-height: 600px;"
                         >
                           <div
                             class="pf-c-toolbar"
@@ -25730,15 +25793,21 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                 aria-label=""
                 aria-labelledby=""
                 boxId="pf-modal-part-2"
-                className="drift"
+                className=""
                 descriptorId="pf-modal-part-4"
                 hasNoBodyWrapper={false}
                 isOpen={true}
                 labelId="pf-modal-part-3"
                 onClose={[Function]}
+                onScroll={null}
                 ouiaId="add-to-comparison-modal"
                 ouiaSafe={true}
                 showClose={true}
+                style={
+                  Object {
+                    "maxHeight": "600px",
+                  }
+                }
                 title="Add to comparison"
                 titleIconVariant={null}
                 titleLabel=""
@@ -25767,7 +25836,7 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                           aria-describedby="pf-modal-part-4"
                           aria-label=""
                           aria-labelledby="pf-modal-part-3"
-                          className="drift"
+                          className=""
                           data-ouia-component-id="add-to-comparison-modal"
                           data-ouia-component-type="PF4/ModalContent"
                           data-ouia-safe={true}
@@ -25784,7 +25853,7 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                             aria-label={null}
                             aria-labelledby="pf-modal-part-3"
                             aria-modal="true"
-                            className="pf-c-modal-box drift"
+                            className="pf-c-modal-box"
                             data-ouia-component-id="add-to-comparison-modal"
                             data-ouia-component-type="PF4/ModalContent"
                             data-ouia-safe={true}
@@ -25879,10 +25948,22 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                             </ModalBoxHeader>
                             <ModalBoxBody
                               id="pf-modal-part-4"
+                              onScroll={null}
+                              style={
+                                Object {
+                                  "maxHeight": "600px",
+                                }
+                              }
                             >
                               <div
                                 className="pf-c-modal-box__body"
                                 id="pf-modal-part-4"
+                                onScroll={null}
+                                style={
+                                  Object {
+                                    "maxHeight": "600px",
+                                  }
+                                }
                               >
                                 <GlobalFilterAlert
                                   globalFilterState={

--- a/src/SmartComponents/DriftPage/DriftTable/__tests__/__snapshots__/DriftTable.tests.js.snap
+++ b/src/SmartComponents/DriftPage/DriftTable/__tests__/__snapshots__/DriftTable.tests.js.snap
@@ -243,13 +243,19 @@ exports[`ConnectedDriftTable should render correctly 1`] = `
                   aria-describedby=""
                   aria-label=""
                   aria-labelledby=""
-                  className="drift"
+                  className=""
                   hasNoBodyWrapper={false}
                   isOpen={false}
                   onClose={[Function]}
+                  onScroll={null}
                   ouiaId="add-to-comparison-modal"
                   ouiaSafe={true}
                   showClose={true}
+                  style={
+                    Object {
+                      "maxHeight": "600px",
+                    }
+                  }
                   title="Add to comparison"
                   titleIconVariant={null}
                   titleLabel=""
@@ -284,15 +290,21 @@ exports[`ConnectedDriftTable should render correctly 1`] = `
                       aria-label=""
                       aria-labelledby=""
                       boxId="pf-modal-part-0"
-                      className="drift"
+                      className=""
                       descriptorId="pf-modal-part-2"
                       hasNoBodyWrapper={false}
                       isOpen={false}
                       labelId="pf-modal-part-1"
                       onClose={[Function]}
+                      onScroll={null}
                       ouiaId="add-to-comparison-modal"
                       ouiaSafe={true}
                       showClose={true}
+                      style={
+                        Object {
+                          "maxHeight": "600px",
+                        }
+                      }
                       title="Add to comparison"
                       titleIconVariant={null}
                       titleLabel=""
@@ -682,13 +694,19 @@ exports[`ConnectedDriftTable should render loading rows 1`] = `
                   aria-describedby=""
                   aria-label=""
                   aria-labelledby=""
-                  className="drift"
+                  className=""
                   hasNoBodyWrapper={false}
                   isOpen={false}
                   onClose={[Function]}
+                  onScroll={null}
                   ouiaId="add-to-comparison-modal"
                   ouiaSafe={true}
                   showClose={true}
+                  style={
+                    Object {
+                      "maxHeight": "600px",
+                    }
+                  }
                   title="Add to comparison"
                   titleIconVariant={null}
                   titleLabel=""
@@ -723,15 +741,21 @@ exports[`ConnectedDriftTable should render loading rows 1`] = `
                       aria-label=""
                       aria-labelledby=""
                       boxId="pf-modal-part-3"
-                      className="drift"
+                      className=""
                       descriptorId="pf-modal-part-5"
                       hasNoBodyWrapper={false}
                       isOpen={false}
                       labelId="pf-modal-part-4"
                       onClose={[Function]}
+                      onScroll={null}
                       ouiaId="add-to-comparison-modal"
                       ouiaSafe={true}
                       showClose={true}
+                      style={
+                        Object {
+                          "maxHeight": "600px",
+                        }
+                      }
                       title="Add to comparison"
                       titleIconVariant={null}
                       titleLabel=""
@@ -2132,13 +2156,19 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
                   aria-describedby=""
                   aria-label=""
                   aria-labelledby=""
-                  className="drift"
+                  className=""
                   hasNoBodyWrapper={false}
                   isOpen={false}
                   onClose={[Function]}
+                  onScroll={null}
                   ouiaId="add-to-comparison-modal"
                   ouiaSafe={true}
                   showClose={true}
+                  style={
+                    Object {
+                      "maxHeight": "600px",
+                    }
+                  }
                   title="Add to comparison"
                   titleIconVariant={null}
                   titleLabel=""
@@ -2173,15 +2203,21 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
                       aria-label=""
                       aria-labelledby=""
                       boxId="pf-modal-part-2"
-                      className="drift"
+                      className=""
                       descriptorId="pf-modal-part-4"
                       hasNoBodyWrapper={false}
                       isOpen={false}
                       labelId="pf-modal-part-3"
                       onClose={[Function]}
+                      onScroll={null}
                       ouiaId="add-to-comparison-modal"
                       ouiaSafe={true}
                       showClose={true}
+                      style={
+                        Object {
+                          "maxHeight": "600px",
+                        }
+                      }
                       title="Add to comparison"
                       titleIconVariant={null}
                       titleLabel=""
@@ -7994,13 +8030,19 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                   aria-describedby=""
                   aria-label=""
                   aria-labelledby=""
-                  className="drift"
+                  className=""
                   hasNoBodyWrapper={false}
                   isOpen={false}
                   onClose={[Function]}
+                  onScroll={null}
                   ouiaId="add-to-comparison-modal"
                   ouiaSafe={true}
                   showClose={true}
+                  style={
+                    Object {
+                      "maxHeight": "600px",
+                    }
+                  }
                   title="Add to comparison"
                   titleIconVariant={null}
                   titleLabel=""
@@ -8035,15 +8077,21 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                       aria-label=""
                       aria-labelledby=""
                       boxId="pf-modal-part-1"
-                      className="drift"
+                      className=""
                       descriptorId="pf-modal-part-3"
                       hasNoBodyWrapper={false}
                       isOpen={false}
                       labelId="pf-modal-part-2"
                       onClose={[Function]}
+                      onScroll={null}
                       ouiaId="add-to-comparison-modal"
                       ouiaSafe={true}
                       showClose={true}
+                      style={
+                        Object {
+                          "maxHeight": "600px",
+                        }
+                      }
                       title="Add to comparison"
                       titleIconVariant={null}
                       titleLabel=""

--- a/src/SmartComponents/DriftPage/__tests__/__snapshots__/DriftPage.tests.js.snap
+++ b/src/SmartComponents/DriftPage/__tests__/__snapshots__/DriftPage.tests.js.snap
@@ -3558,13 +3558,19 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
                                       aria-describedby=""
                                       aria-label=""
                                       aria-labelledby=""
-                                      className="drift"
+                                      className=""
                                       hasNoBodyWrapper={false}
                                       isOpen={false}
                                       onClose={[Function]}
+                                      onScroll={null}
                                       ouiaId="add-to-comparison-modal"
                                       ouiaSafe={true}
                                       showClose={true}
+                                      style={
+                                        Object {
+                                          "maxHeight": "600px",
+                                        }
+                                      }
                                       title="Add to comparison"
                                       titleIconVariant={null}
                                       titleLabel=""
@@ -3599,15 +3605,21 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
                                           aria-label=""
                                           aria-labelledby=""
                                           boxId="pf-modal-part-0"
-                                          className="drift"
+                                          className=""
                                           descriptorId="pf-modal-part-2"
                                           hasNoBodyWrapper={false}
                                           isOpen={false}
                                           labelId="pf-modal-part-1"
                                           onClose={[Function]}
+                                          onScroll={null}
                                           ouiaId="add-to-comparison-modal"
                                           ouiaSafe={true}
                                           showClose={true}
+                                          style={
+                                            Object {
+                                              "maxHeight": "600px",
+                                            }
+                                          }
                                           title="Add to comparison"
                                           titleIconVariant={null}
                                           titleLabel=""
@@ -8214,13 +8226,19 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                       aria-describedby=""
                                       aria-label=""
                                       aria-labelledby=""
-                                      className="drift"
+                                      className=""
                                       hasNoBodyWrapper={false}
                                       isOpen={false}
                                       onClose={[Function]}
+                                      onScroll={null}
                                       ouiaId="add-to-comparison-modal"
                                       ouiaSafe={true}
                                       showClose={true}
+                                      style={
+                                        Object {
+                                          "maxHeight": "600px",
+                                        }
+                                      }
                                       title="Add to comparison"
                                       titleIconVariant={null}
                                       titleLabel=""
@@ -8255,15 +8273,21 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                           aria-label=""
                                           aria-labelledby=""
                                           boxId="pf-modal-part-2"
-                                          className="drift"
+                                          className=""
                                           descriptorId="pf-modal-part-4"
                                           hasNoBodyWrapper={false}
                                           isOpen={false}
                                           labelId="pf-modal-part-3"
                                           onClose={[Function]}
+                                          onScroll={null}
                                           ouiaId="add-to-comparison-modal"
                                           ouiaSafe={true}
                                           showClose={true}
+                                          style={
+                                            Object {
+                                              "maxHeight": "600px",
+                                            }
+                                          }
                                           title="Add to comparison"
                                           titleIconVariant={null}
                                           titleLabel=""


### PR DESCRIPTION
When in the add system baseline modal, if the selected basket popover is open and you scroll on the add system modal, you will eventually see the popover disappear, but the content will remain scrollable on the screen. This PR updates it so if the popover is open and you scroll the add system modal, the popover will close.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
