### PR TITLE
[DRFT-946] Fix hsp selection for selected basket

### DIFF
--- a/src/SmartComponents/AddSystemModal/AddSystemModal.js
+++ b/src/SmartComponents/AddSystemModal/AddSystemModal.js
@@ -226,10 +226,11 @@ export class AddSystemModal extends Component {
         return (
             <React.Fragment>
                 <Modal
+                    className='drift'
                     ref={ this.addSystemModal }
                     onScroll={ basketIsVisible ? this.closePopover : null }
                     style={{ maxHeight: '600px' }}
-                    width={ '950px' }
+                    width={ '1200px' }
                     title="Add to comparison"
                     ouiaId='add-to-comparison-modal'
                     isOpen={ addSystemModalOpened }

--- a/src/SmartComponents/AddSystemModal/SelectedBasket/SelectedBasket.js
+++ b/src/SmartComponents/AddSystemModal/SelectedBasket/SelectedBasket.js
@@ -27,7 +27,7 @@ export class SelectedBasket extends Component {
             systems: this.props.systems,
             baselines: this.props.baselines,
             historicalProfiles: this.props.historicalProfiles
-        }, this.props.handleSystemSelection, this.props.handleBaselineSelection, this.props.handleHSPSelection);
+        }, this.props.handleSystemSelection, this.props.handleBaselineSelection, this.props.handleHSPSelection, this.props.selectedHSPContent);
     }
 
     toggleBasket = () => {

--- a/src/SmartComponents/AddSystemModal/__tests__/__snapshots__/AddSystemModal.tests.js.snap
+++ b/src/SmartComponents/AddSystemModal/__tests__/__snapshots__/AddSystemModal.tests.js.snap
@@ -27,7 +27,7 @@ exports[`AddSystemModal should render correctly 1`] = `
     aria-describedby=""
     aria-label=""
     aria-labelledby=""
-    className=""
+    className="drift"
     hasNoBodyWrapper={false}
     isOpen={true}
     onClose={[Function]}
@@ -44,7 +44,7 @@ exports[`AddSystemModal should render correctly 1`] = `
     titleIconVariant={null}
     titleLabel=""
     variant="default"
-    width="950px"
+    width="1200px"
   >
     <GlobalFilterAlert />
     <Toolbar
@@ -9523,7 +9523,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
             aria-describedby=""
             aria-label=""
             aria-labelledby=""
-            className=""
+            className="drift"
             hasNoBodyWrapper={false}
             isOpen={true}
             onClose={[Function]}
@@ -9540,7 +9540,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
             titleIconVariant={null}
             titleLabel=""
             variant="default"
-            width="950px"
+            width="1200px"
           >
             <Portal
               containerInfo={
@@ -9555,13 +9555,13 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                         aria-describedby="pf-modal-part-8"
                         aria-labelledby="pf-modal-part-7"
                         aria-modal="true"
-                        class="pf-c-modal-box"
+                        class="pf-c-modal-box drift"
                         data-ouia-component-id="add-to-comparison-modal"
                         data-ouia-component-type="PF4/ModalContent"
                         data-ouia-safe="true"
                         id="pf-modal-part-6"
                         role="dialog"
-                        style="width: 950px;"
+                        style="width: 1200px;"
                       >
                         <button
                           aria-disabled="false"
@@ -10515,7 +10515,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                 aria-label=""
                 aria-labelledby=""
                 boxId="pf-modal-part-6"
-                className=""
+                className="drift"
                 descriptorId="pf-modal-part-8"
                 hasNoBodyWrapper={false}
                 isOpen={true}
@@ -10534,7 +10534,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                 titleIconVariant={null}
                 titleLabel=""
                 variant="default"
-                width="950px"
+                width="1200px"
               >
                 <Backdrop>
                   <div
@@ -10558,14 +10558,14 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                           aria-describedby="pf-modal-part-8"
                           aria-label=""
                           aria-labelledby="pf-modal-part-7"
-                          className=""
+                          className="drift"
                           data-ouia-component-id="add-to-comparison-modal"
                           data-ouia-component-type="PF4/ModalContent"
                           data-ouia-safe={true}
                           id="pf-modal-part-6"
                           style={
                             Object {
-                              "width": "950px",
+                              "width": "1200px",
                             }
                           }
                           variant="default"
@@ -10575,7 +10575,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                             aria-label={null}
                             aria-labelledby="pf-modal-part-7"
                             aria-modal="true"
-                            className="pf-c-modal-box"
+                            className="pf-c-modal-box drift"
                             data-ouia-component-id="add-to-comparison-modal"
                             data-ouia-component-type="PF4/ModalContent"
                             data-ouia-safe={true}
@@ -10583,7 +10583,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                             role="dialog"
                             style={
                               Object {
-                                "width": "950px",
+                                "width": "1200px",
                               }
                             }
                           >
@@ -17172,7 +17172,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
             aria-describedby=""
             aria-label=""
             aria-labelledby=""
-            className=""
+            className="drift"
             hasNoBodyWrapper={false}
             isOpen={true}
             onClose={[Function]}
@@ -17189,7 +17189,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
             titleIconVariant={null}
             titleLabel=""
             variant="default"
-            width="950px"
+            width="1200px"
           >
             <Portal
               containerInfo={
@@ -17204,13 +17204,13 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                         aria-describedby="pf-modal-part-2"
                         aria-labelledby="pf-modal-part-1"
                         aria-modal="true"
-                        class="pf-c-modal-box"
+                        class="pf-c-modal-box drift"
                         data-ouia-component-id="add-to-comparison-modal"
                         data-ouia-component-type="PF4/ModalContent"
                         data-ouia-safe="true"
                         id="pf-modal-part-0"
                         role="dialog"
-                        style="width: 950px;"
+                        style="width: 1200px;"
                       >
                         <button
                           aria-disabled="false"
@@ -18164,7 +18164,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                 aria-label=""
                 aria-labelledby=""
                 boxId="pf-modal-part-0"
-                className=""
+                className="drift"
                 descriptorId="pf-modal-part-2"
                 hasNoBodyWrapper={false}
                 isOpen={true}
@@ -18183,7 +18183,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                 titleIconVariant={null}
                 titleLabel=""
                 variant="default"
-                width="950px"
+                width="1200px"
               >
                 <Backdrop>
                   <div
@@ -18207,14 +18207,14 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                           aria-describedby="pf-modal-part-2"
                           aria-label=""
                           aria-labelledby="pf-modal-part-1"
-                          className=""
+                          className="drift"
                           data-ouia-component-id="add-to-comparison-modal"
                           data-ouia-component-type="PF4/ModalContent"
                           data-ouia-safe={true}
                           id="pf-modal-part-0"
                           style={
                             Object {
-                              "width": "950px",
+                              "width": "1200px",
                             }
                           }
                           variant="default"
@@ -18224,7 +18224,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                             aria-label={null}
                             aria-labelledby="pf-modal-part-1"
                             aria-modal="true"
-                            className="pf-c-modal-box"
+                            className="pf-c-modal-box drift"
                             data-ouia-component-id="add-to-comparison-modal"
                             data-ouia-component-type="PF4/ModalContent"
                             data-ouia-safe={true}
@@ -18232,7 +18232,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                             role="dialog"
                             style={
                               Object {
-                                "width": "950px",
+                                "width": "1200px",
                               }
                             }
                           >
@@ -24821,7 +24821,7 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
             aria-describedby=""
             aria-label=""
             aria-labelledby=""
-            className=""
+            className="drift"
             hasNoBodyWrapper={false}
             isOpen={true}
             onClose={[Function]}
@@ -24838,7 +24838,7 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
             titleIconVariant={null}
             titleLabel=""
             variant="default"
-            width="950px"
+            width="1200px"
           >
             <Portal
               containerInfo={
@@ -24853,13 +24853,13 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                         aria-describedby="pf-modal-part-4"
                         aria-labelledby="pf-modal-part-3"
                         aria-modal="true"
-                        class="pf-c-modal-box"
+                        class="pf-c-modal-box drift"
                         data-ouia-component-id="add-to-comparison-modal"
                         data-ouia-component-type="PF4/ModalContent"
                         data-ouia-safe="true"
                         id="pf-modal-part-2"
                         role="dialog"
-                        style="width: 950px;"
+                        style="width: 1200px;"
                       >
                         <button
                           aria-disabled="false"
@@ -25834,7 +25834,7 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                 aria-label=""
                 aria-labelledby=""
                 boxId="pf-modal-part-2"
-                className=""
+                className="drift"
                 descriptorId="pf-modal-part-4"
                 hasNoBodyWrapper={false}
                 isOpen={true}
@@ -25853,7 +25853,7 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                 titleIconVariant={null}
                 titleLabel=""
                 variant="default"
-                width="950px"
+                width="1200px"
               >
                 <Backdrop>
                   <div
@@ -25877,14 +25877,14 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                           aria-describedby="pf-modal-part-4"
                           aria-label=""
                           aria-labelledby="pf-modal-part-3"
-                          className=""
+                          className="drift"
                           data-ouia-component-id="add-to-comparison-modal"
                           data-ouia-component-type="PF4/ModalContent"
                           data-ouia-safe={true}
                           id="pf-modal-part-2"
                           style={
                             Object {
-                              "width": "950px",
+                              "width": "1200px",
                             }
                           }
                           variant="default"
@@ -25894,7 +25894,7 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                             aria-label={null}
                             aria-labelledby="pf-modal-part-3"
                             aria-modal="true"
-                            className="pf-c-modal-box"
+                            className="pf-c-modal-box drift"
                             data-ouia-component-id="add-to-comparison-modal"
                             data-ouia-component-type="PF4/ModalContent"
                             data-ouia-safe={true}
@@ -25902,7 +25902,7 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                             role="dialog"
                             style={
                               Object {
-                                "width": "950px",
+                                "width": "1200px",
                               }
                             }
                           >

--- a/src/SmartComponents/AddSystemModal/redux/helpers.js
+++ b/src/SmartComponents/AddSystemModal/redux/helpers.js
@@ -57,7 +57,7 @@ function makeHSPSelections(content, selectedContent) {
     return newSelectedContent;
 }
 
-function setContent(selectedIds, handleSystemSelection, handleBaselineSelection, handleHSPSelection) {
+function setContent(selectedIds, handleSystemSelection, handleBaselineSelection, handleHSPSelection, selectedHSPContent) {
     let newSelectedSystems = [];
     let newSelectedBaselines = [];
 
@@ -79,7 +79,13 @@ function setContent(selectedIds, handleSystemSelection, handleBaselineSelection,
 
     /*eslint-disable camelcase*/
     if (selectedIds.historicalProfiles.length) {
-        selectedIds.historicalProfiles.forEach(function(hsp) {
+        let unselectedHSPs = selectedIds.historicalProfiles.filter(function(hsp) {
+            return !selectedHSPContent.some(function(profile) {
+                return hsp.id === profile.id;
+            });
+        });
+
+        unselectedHSPs.forEach(function(hsp) {
             let content = {
                 system_name: hsp.display_name,
                 captured_date: hsp.updated,

--- a/src/SmartComponents/BaselinesTable/BaselinesToolbar/__test__/__snapshots__/BaselinesToolbar.test.js.snap
+++ b/src/SmartComponents/BaselinesTable/BaselinesToolbar/__test__/__snapshots__/BaselinesToolbar.test.js.snap
@@ -212,7 +212,7 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
             Array [
               "abcd",
               "micjohns baseline",
-              "2 years ago",
+              "3 years ago",
               0,
               false,
             ],

--- a/src/SmartComponents/BaselinesTable/__tests__/__snapshots__/BaselinesTable.tests.js.snap
+++ b/src/SmartComponents/BaselinesTable/__tests__/__snapshots__/BaselinesTable.tests.js.snap
@@ -100,7 +100,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
             Array [
               "abcd",
               "micjohns baseline",
-              "2 years ago",
+              "3 years ago",
               0,
               false,
             ],
@@ -163,7 +163,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
               Array [
                 "abcd",
                 "micjohns baseline",
-                "2 years ago",
+                "3 years ago",
                 0,
                 false,
               ],
@@ -210,7 +210,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                 Array [
                   "abcd",
                   "micjohns baseline",
-                  "2 years ago",
+                  "3 years ago",
                   0,
                   false,
                 ],
@@ -2498,7 +2498,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                 ],
                 Array [
                   "micjohns baseline",
-                  "2 years ago",
+                  "3 years ago",
                   <div
                     className="no-left-padding"
                   >
@@ -2527,7 +2527,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                         Array [
                           "abcd",
                           "micjohns baseline",
-                          "2 years ago",
+                          "3 years ago",
                           0,
                           false,
                         ]
@@ -3850,7 +3850,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                             ],
                             Array [
                               "micjohns baseline",
-                              "2 years ago",
+                              "3 years ago",
                               <div
                                 className="no-left-padding"
                               >
@@ -3879,7 +3879,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                     Array [
                                       "abcd",
                                       "micjohns baseline",
-                                      "2 years ago",
+                                      "3 years ago",
                                       0,
                                       false,
                                     ]
@@ -4024,7 +4024,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                               },
                               Object {
                                 "0": "micjohns baseline",
-                                "1": "2 years ago",
+                                "1": "3 years ago",
                                 "2": <div
                                   className="no-left-padding"
                                 >
@@ -4053,7 +4053,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                       Array [
                                         "abcd",
                                         "micjohns baseline",
-                                        "2 years ago",
+                                        "3 years ago",
                                         0,
                                         false,
                                       ]
@@ -4101,7 +4101,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                         Array [
                                           "abcd",
                                           "micjohns baseline",
-                                          "2 years ago",
+                                          "3 years ago",
                                           0,
                                           false,
                                         ]
@@ -4130,7 +4130,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                   "props": Object {
                                     "isVisible": true,
                                   },
-                                  "title": "2 years ago",
+                                  "title": "3 years ago",
                                 },
                                 "name": Object {
                                   "formatters": Array [],
@@ -4269,7 +4269,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                               },
                               Object {
                                 "0": "micjohns baseline",
-                                "1": "2 years ago",
+                                "1": "3 years ago",
                                 "2": <div
                                   className="no-left-padding"
                                 >
@@ -4298,7 +4298,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                       Array [
                                         "abcd",
                                         "micjohns baseline",
-                                        "2 years ago",
+                                        "3 years ago",
                                         0,
                                         false,
                                       ]
@@ -4346,7 +4346,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                         Array [
                                           "abcd",
                                           "micjohns baseline",
-                                          "2 years ago",
+                                          "3 years ago",
                                           0,
                                           false,
                                         ]
@@ -4375,7 +4375,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                   "props": Object {
                                     "isVisible": true,
                                   },
-                                  "title": "2 years ago",
+                                  "title": "3 years ago",
                                 },
                                 "name": Object {
                                   "formatters": Array [],
@@ -4722,7 +4722,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                 },
                                 Object {
                                   "0": "micjohns baseline",
-                                  "1": "2 years ago",
+                                  "1": "3 years ago",
                                   "2": <div
                                     className="no-left-padding"
                                   >
@@ -4751,7 +4751,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                         Array [
                                           "abcd",
                                           "micjohns baseline",
-                                          "2 years ago",
+                                          "3 years ago",
                                           0,
                                           false,
                                         ]
@@ -4799,7 +4799,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                           Array [
                                             "abcd",
                                             "micjohns baseline",
-                                            "2 years ago",
+                                            "3 years ago",
                                             0,
                                             false,
                                           ]
@@ -4828,7 +4828,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                     "props": Object {
                                       "isVisible": true,
                                     },
-                                    "title": "2 years ago",
+                                    "title": "3 years ago",
                                   },
                                   "name": Object {
                                     "formatters": Array [],
@@ -4994,7 +4994,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                 },
                                 Object {
                                   "0": "micjohns baseline",
-                                  "1": "2 years ago",
+                                  "1": "3 years ago",
                                   "2": <div
                                     className="no-left-padding"
                                   >
@@ -5023,7 +5023,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                         Array [
                                           "abcd",
                                           "micjohns baseline",
-                                          "2 years ago",
+                                          "3 years ago",
                                           0,
                                           false,
                                         ]
@@ -5071,7 +5071,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                           Array [
                                             "abcd",
                                             "micjohns baseline",
-                                            "2 years ago",
+                                            "3 years ago",
                                             0,
                                             false,
                                           ]
@@ -5100,7 +5100,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                     "props": Object {
                                       "isVisible": true,
                                     },
-                                    "title": "2 years ago",
+                                    "title": "3 years ago",
                                   },
                                   "name": Object {
                                     "formatters": Array [],
@@ -5241,7 +5241,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                   },
                                   Object {
                                     "0": "micjohns baseline",
-                                    "1": "2 years ago",
+                                    "1": "3 years ago",
                                     "2": <div
                                       className="no-left-padding"
                                     >
@@ -5270,7 +5270,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                           Array [
                                             "abcd",
                                             "micjohns baseline",
-                                            "2 years ago",
+                                            "3 years ago",
                                             0,
                                             false,
                                           ]
@@ -5318,7 +5318,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                             Array [
                                               "abcd",
                                               "micjohns baseline",
-                                              "2 years ago",
+                                              "3 years ago",
                                               0,
                                               false,
                                             ]
@@ -5347,7 +5347,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                       "props": Object {
                                         "isVisible": true,
                                       },
-                                      "title": "2 years ago",
+                                      "title": "3 years ago",
                                     },
                                     "name": Object {
                                       "formatters": Array [],
@@ -6571,7 +6571,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                       rowData={
                                         Object {
                                           "0": "micjohns baseline",
-                                          "1": "2 years ago",
+                                          "1": "3 years ago",
                                           "2": <div
                                             className="no-left-padding"
                                           >
@@ -6600,7 +6600,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                                 Array [
                                                   "abcd",
                                                   "micjohns baseline",
-                                                  "2 years ago",
+                                                  "3 years ago",
                                                   0,
                                                   false,
                                                 ]
@@ -6648,7 +6648,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                                   Array [
                                                     "abcd",
                                                     "micjohns baseline",
-                                                    "2 years ago",
+                                                    "3 years ago",
                                                     0,
                                                     false,
                                                   ]
@@ -6677,7 +6677,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                             "props": Object {
                                               "isVisible": true,
                                             },
-                                            "title": "2 years ago",
+                                            "title": "3 years ago",
                                           },
                                           "name": Object {
                                             "formatters": Array [],
@@ -6699,7 +6699,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                         row={
                                           Object {
                                             "0": "micjohns baseline",
-                                            "1": "2 years ago",
+                                            "1": "3 years ago",
                                             "2": <div
                                               className="no-left-padding"
                                             >
@@ -6728,7 +6728,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                                   Array [
                                                     "abcd",
                                                     "micjohns baseline",
-                                                    "2 years ago",
+                                                    "3 years ago",
                                                     0,
                                                     false,
                                                   ]
@@ -6776,7 +6776,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                                     Array [
                                                       "abcd",
                                                       "micjohns baseline",
-                                                      "2 years ago",
+                                                      "3 years ago",
                                                       0,
                                                       false,
                                                     ]
@@ -6805,7 +6805,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                               "props": Object {
                                                 "isVisible": true,
                                               },
-                                              "title": "2 years ago",
+                                              "title": "3 years ago",
                                             },
                                             "name": Object {
                                               "formatters": Array [],
@@ -6907,7 +6907,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                                       data-label="Last updated"
                                                       onMouseEnter={[Function]}
                                                     >
-                                                      2 years ago
+                                                      3 years ago
                                                     </td>
                                                   </TdBase>
                                                 </Td>
@@ -7009,7 +7009,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                                           Array [
                                                             "abcd",
                                                             "micjohns baseline",
-                                                            "2 years ago",
+                                                            "3 years ago",
                                                             0,
                                                             false,
                                                           ]
@@ -7028,7 +7028,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                                             Array [
                                                               "abcd",
                                                               "micjohns baseline",
-                                                              "2 years ago",
+                                                              "3 years ago",
                                                               0,
                                                               false,
                                                             ]
@@ -8332,7 +8332,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
             Array [
               "abcd",
               "micjohns baseline",
-              "2 years ago",
+              "3 years ago",
               0,
               false,
             ],
@@ -8391,7 +8391,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
               Array [
                 "abcd",
                 "micjohns baseline",
-                "2 years ago",
+                "3 years ago",
                 0,
                 false,
               ],
@@ -8434,7 +8434,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                 Array [
                   "abcd",
                   "micjohns baseline",
-                  "2 years ago",
+                  "3 years ago",
                   0,
                   false,
                 ],
@@ -10710,7 +10710,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                 ],
                 Array [
                   "micjohns baseline",
-                  "2 years ago",
+                  "3 years ago",
                   <div
                     className="no-left-padding"
                   >
@@ -10739,7 +10739,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                         Array [
                           "abcd",
                           "micjohns baseline",
-                          "2 years ago",
+                          "3 years ago",
                           0,
                           false,
                         ]
@@ -12054,7 +12054,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                             ],
                             Array [
                               "micjohns baseline",
-                              "2 years ago",
+                              "3 years ago",
                               <div
                                 className="no-left-padding"
                               >
@@ -12083,7 +12083,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                     Array [
                                       "abcd",
                                       "micjohns baseline",
-                                      "2 years ago",
+                                      "3 years ago",
                                       0,
                                       false,
                                     ]
@@ -12216,7 +12216,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                               },
                               Object {
                                 "0": "micjohns baseline",
-                                "1": "2 years ago",
+                                "1": "3 years ago",
                                 "2": <div
                                   className="no-left-padding"
                                 >
@@ -12245,7 +12245,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                       Array [
                                         "abcd",
                                         "micjohns baseline",
-                                        "2 years ago",
+                                        "3 years ago",
                                         0,
                                         false,
                                       ]
@@ -12289,7 +12289,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                         Array [
                                           "abcd",
                                           "micjohns baseline",
-                                          "2 years ago",
+                                          "3 years ago",
                                           0,
                                           false,
                                         ]
@@ -12314,7 +12314,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                   "props": Object {
                                     "isVisible": true,
                                   },
-                                  "title": "2 years ago",
+                                  "title": "3 years ago",
                                 },
                                 "name": Object {
                                   "formatters": Array [],
@@ -12445,7 +12445,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                               },
                               Object {
                                 "0": "micjohns baseline",
-                                "1": "2 years ago",
+                                "1": "3 years ago",
                                 "2": <div
                                   className="no-left-padding"
                                 >
@@ -12474,7 +12474,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                       Array [
                                         "abcd",
                                         "micjohns baseline",
-                                        "2 years ago",
+                                        "3 years ago",
                                         0,
                                         false,
                                       ]
@@ -12518,7 +12518,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                         Array [
                                           "abcd",
                                           "micjohns baseline",
-                                          "2 years ago",
+                                          "3 years ago",
                                           0,
                                           false,
                                         ]
@@ -12543,7 +12543,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                   "props": Object {
                                     "isVisible": true,
                                   },
-                                  "title": "2 years ago",
+                                  "title": "3 years ago",
                                 },
                                 "name": Object {
                                   "formatters": Array [],
@@ -12882,7 +12882,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                 },
                                 Object {
                                   "0": "micjohns baseline",
-                                  "1": "2 years ago",
+                                  "1": "3 years ago",
                                   "2": <div
                                     className="no-left-padding"
                                   >
@@ -12911,7 +12911,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                         Array [
                                           "abcd",
                                           "micjohns baseline",
-                                          "2 years ago",
+                                          "3 years ago",
                                           0,
                                           false,
                                         ]
@@ -12955,7 +12955,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                           Array [
                                             "abcd",
                                             "micjohns baseline",
-                                            "2 years ago",
+                                            "3 years ago",
                                             0,
                                             false,
                                           ]
@@ -12980,7 +12980,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                     "props": Object {
                                       "isVisible": true,
                                     },
-                                    "title": "2 years ago",
+                                    "title": "3 years ago",
                                   },
                                   "name": Object {
                                     "formatters": Array [],
@@ -13138,7 +13138,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                 },
                                 Object {
                                   "0": "micjohns baseline",
-                                  "1": "2 years ago",
+                                  "1": "3 years ago",
                                   "2": <div
                                     className="no-left-padding"
                                   >
@@ -13167,7 +13167,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                         Array [
                                           "abcd",
                                           "micjohns baseline",
-                                          "2 years ago",
+                                          "3 years ago",
                                           0,
                                           false,
                                         ]
@@ -13211,7 +13211,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                           Array [
                                             "abcd",
                                             "micjohns baseline",
-                                            "2 years ago",
+                                            "3 years ago",
                                             0,
                                             false,
                                           ]
@@ -13236,7 +13236,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                     "props": Object {
                                       "isVisible": true,
                                     },
-                                    "title": "2 years ago",
+                                    "title": "3 years ago",
                                   },
                                   "name": Object {
                                     "formatters": Array [],
@@ -13369,7 +13369,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                   },
                                   Object {
                                     "0": "micjohns baseline",
-                                    "1": "2 years ago",
+                                    "1": "3 years ago",
                                     "2": <div
                                       className="no-left-padding"
                                     >
@@ -13398,7 +13398,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                           Array [
                                             "abcd",
                                             "micjohns baseline",
-                                            "2 years ago",
+                                            "3 years ago",
                                             0,
                                             false,
                                           ]
@@ -13442,7 +13442,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                             Array [
                                               "abcd",
                                               "micjohns baseline",
-                                              "2 years ago",
+                                              "3 years ago",
                                               0,
                                               false,
                                             ]
@@ -13467,7 +13467,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                       "props": Object {
                                         "isVisible": true,
                                       },
-                                      "title": "2 years ago",
+                                      "title": "3 years ago",
                                     },
                                     "name": Object {
                                       "formatters": Array [],
@@ -14667,7 +14667,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                       rowData={
                                         Object {
                                           "0": "micjohns baseline",
-                                          "1": "2 years ago",
+                                          "1": "3 years ago",
                                           "2": <div
                                             className="no-left-padding"
                                           >
@@ -14696,7 +14696,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                                 Array [
                                                   "abcd",
                                                   "micjohns baseline",
-                                                  "2 years ago",
+                                                  "3 years ago",
                                                   0,
                                                   false,
                                                 ]
@@ -14740,7 +14740,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                                   Array [
                                                     "abcd",
                                                     "micjohns baseline",
-                                                    "2 years ago",
+                                                    "3 years ago",
                                                     0,
                                                     false,
                                                   ]
@@ -14765,7 +14765,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                             "props": Object {
                                               "isVisible": true,
                                             },
-                                            "title": "2 years ago",
+                                            "title": "3 years ago",
                                           },
                                           "name": Object {
                                             "formatters": Array [],
@@ -14787,7 +14787,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                         row={
                                           Object {
                                             "0": "micjohns baseline",
-                                            "1": "2 years ago",
+                                            "1": "3 years ago",
                                             "2": <div
                                               className="no-left-padding"
                                             >
@@ -14816,7 +14816,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                                   Array [
                                                     "abcd",
                                                     "micjohns baseline",
-                                                    "2 years ago",
+                                                    "3 years ago",
                                                     0,
                                                     false,
                                                   ]
@@ -14860,7 +14860,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                                     Array [
                                                       "abcd",
                                                       "micjohns baseline",
-                                                      "2 years ago",
+                                                      "3 years ago",
                                                       0,
                                                       false,
                                                     ]
@@ -14885,7 +14885,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                               "props": Object {
                                                 "isVisible": true,
                                               },
-                                              "title": "2 years ago",
+                                              "title": "3 years ago",
                                             },
                                             "name": Object {
                                               "formatters": Array [],
@@ -14987,7 +14987,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                                       data-label="Last updated"
                                                       onMouseEnter={[Function]}
                                                     >
-                                                      2 years ago
+                                                      3 years ago
                                                     </td>
                                                   </TdBase>
                                                 </Td>
@@ -15089,7 +15089,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                                           Array [
                                                             "abcd",
                                                             "micjohns baseline",
-                                                            "2 years ago",
+                                                            "3 years ago",
                                                             0,
                                                             false,
                                                           ]
@@ -15104,7 +15104,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                                             Array [
                                                               "abcd",
                                                               "micjohns baseline",
-                                                              "2 years ago",
+                                                              "3 years ago",
                                                               0,
                                                               false,
                                                             ]
@@ -16404,7 +16404,7 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
             Array [
               "abcd",
               "micjohns baseline",
-              "2 years ago",
+              "3 years ago",
               0,
               false,
             ],
@@ -16463,7 +16463,7 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
               Array [
                 "abcd",
                 "micjohns baseline",
-                "2 years ago",
+                "3 years ago",
                 0,
                 false,
               ],
@@ -16506,7 +16506,7 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                 Array [
                   "abcd",
                   "micjohns baseline",
-                  "2 years ago",
+                  "3 years ago",
                   0,
                   false,
                 ],
@@ -30368,7 +30368,7 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
             Array [
               "abcd",
               "micjohns baseline",
-              "2 years ago",
+              "3 years ago",
               0,
               false,
             ],
@@ -30427,7 +30427,7 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
               Array [
                 "abcd",
                 "micjohns baseline",
-                "2 years ago",
+                "3 years ago",
                 0,
                 false,
               ],
@@ -30470,7 +30470,7 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
                 Array [
                   "abcd",
                   "micjohns baseline",
-                  "2 years ago",
+                  "3 years ago",
                   0,
                   false,
                 ],
@@ -43931,7 +43931,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
             Array [
               "abcd",
               "micjohns baseline",
-              "2 years ago",
+              "3 years ago",
               0,
               false,
             ],
@@ -43990,7 +43990,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
               Array [
                 "abcd",
                 "micjohns baseline",
-                "2 years ago",
+                "3 years ago",
                 0,
                 false,
               ],
@@ -44033,7 +44033,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                 Array [
                   "abcd",
                   "micjohns baseline",
-                  "2 years ago",
+                  "3 years ago",
                   0,
                   false,
                 ],
@@ -46276,7 +46276,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                 ],
                 Array [
                   "micjohns baseline",
-                  "2 years ago",
+                  "3 years ago",
                   <div
                     className="no-left-padding"
                   >
@@ -46305,7 +46305,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                         Array [
                           "abcd",
                           "micjohns baseline",
-                          "2 years ago",
+                          "3 years ago",
                           0,
                           false,
                         ]
@@ -47620,7 +47620,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                             ],
                             Array [
                               "micjohns baseline",
-                              "2 years ago",
+                              "3 years ago",
                               <div
                                 className="no-left-padding"
                               >
@@ -47649,7 +47649,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                     Array [
                                       "abcd",
                                       "micjohns baseline",
-                                      "2 years ago",
+                                      "3 years ago",
                                       0,
                                       false,
                                     ]
@@ -47781,7 +47781,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                               },
                               Object {
                                 "0": "micjohns baseline",
-                                "1": "2 years ago",
+                                "1": "3 years ago",
                                 "2": <div
                                   className="no-left-padding"
                                 >
@@ -47810,7 +47810,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                       Array [
                                         "abcd",
                                         "micjohns baseline",
-                                        "2 years ago",
+                                        "3 years ago",
                                         0,
                                         false,
                                       ]
@@ -47854,7 +47854,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                         Array [
                                           "abcd",
                                           "micjohns baseline",
-                                          "2 years ago",
+                                          "3 years ago",
                                           0,
                                           false,
                                         ]
@@ -47879,7 +47879,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                   "props": Object {
                                     "isVisible": true,
                                   },
-                                  "title": "2 years ago",
+                                  "title": "3 years ago",
                                 },
                                 "name": Object {
                                   "formatters": Array [],
@@ -48009,7 +48009,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                               },
                               Object {
                                 "0": "micjohns baseline",
-                                "1": "2 years ago",
+                                "1": "3 years ago",
                                 "2": <div
                                   className="no-left-padding"
                                 >
@@ -48038,7 +48038,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                       Array [
                                         "abcd",
                                         "micjohns baseline",
-                                        "2 years ago",
+                                        "3 years ago",
                                         0,
                                         false,
                                       ]
@@ -48082,7 +48082,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                         Array [
                                           "abcd",
                                           "micjohns baseline",
-                                          "2 years ago",
+                                          "3 years ago",
                                           0,
                                           false,
                                         ]
@@ -48107,7 +48107,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                   "props": Object {
                                     "isVisible": true,
                                   },
-                                  "title": "2 years ago",
+                                  "title": "3 years ago",
                                 },
                                 "name": Object {
                                   "formatters": Array [],
@@ -48445,7 +48445,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                 },
                                 Object {
                                   "0": "micjohns baseline",
-                                  "1": "2 years ago",
+                                  "1": "3 years ago",
                                   "2": <div
                                     className="no-left-padding"
                                   >
@@ -48474,7 +48474,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                         Array [
                                           "abcd",
                                           "micjohns baseline",
-                                          "2 years ago",
+                                          "3 years ago",
                                           0,
                                           false,
                                         ]
@@ -48518,7 +48518,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                           Array [
                                             "abcd",
                                             "micjohns baseline",
-                                            "2 years ago",
+                                            "3 years ago",
                                             0,
                                             false,
                                           ]
@@ -48543,7 +48543,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                     "props": Object {
                                       "isVisible": true,
                                     },
-                                    "title": "2 years ago",
+                                    "title": "3 years ago",
                                   },
                                   "name": Object {
                                     "formatters": Array [],
@@ -48700,7 +48700,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                 },
                                 Object {
                                   "0": "micjohns baseline",
-                                  "1": "2 years ago",
+                                  "1": "3 years ago",
                                   "2": <div
                                     className="no-left-padding"
                                   >
@@ -48729,7 +48729,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                         Array [
                                           "abcd",
                                           "micjohns baseline",
-                                          "2 years ago",
+                                          "3 years ago",
                                           0,
                                           false,
                                         ]
@@ -48773,7 +48773,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                           Array [
                                             "abcd",
                                             "micjohns baseline",
-                                            "2 years ago",
+                                            "3 years ago",
                                             0,
                                             false,
                                           ]
@@ -48798,7 +48798,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                     "props": Object {
                                       "isVisible": true,
                                     },
-                                    "title": "2 years ago",
+                                    "title": "3 years ago",
                                   },
                                   "name": Object {
                                     "formatters": Array [],
@@ -48930,7 +48930,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                   },
                                   Object {
                                     "0": "micjohns baseline",
-                                    "1": "2 years ago",
+                                    "1": "3 years ago",
                                     "2": <div
                                       className="no-left-padding"
                                     >
@@ -48959,7 +48959,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                           Array [
                                             "abcd",
                                             "micjohns baseline",
-                                            "2 years ago",
+                                            "3 years ago",
                                             0,
                                             false,
                                           ]
@@ -49003,7 +49003,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                             Array [
                                               "abcd",
                                               "micjohns baseline",
-                                              "2 years ago",
+                                              "3 years ago",
                                               0,
                                               false,
                                             ]
@@ -49028,7 +49028,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                       "props": Object {
                                         "isVisible": true,
                                       },
-                                      "title": "2 years ago",
+                                      "title": "3 years ago",
                                     },
                                     "name": Object {
                                       "formatters": Array [],
@@ -50226,7 +50226,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                       rowData={
                                         Object {
                                           "0": "micjohns baseline",
-                                          "1": "2 years ago",
+                                          "1": "3 years ago",
                                           "2": <div
                                             className="no-left-padding"
                                           >
@@ -50255,7 +50255,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                                 Array [
                                                   "abcd",
                                                   "micjohns baseline",
-                                                  "2 years ago",
+                                                  "3 years ago",
                                                   0,
                                                   false,
                                                 ]
@@ -50299,7 +50299,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                                   Array [
                                                     "abcd",
                                                     "micjohns baseline",
-                                                    "2 years ago",
+                                                    "3 years ago",
                                                     0,
                                                     false,
                                                   ]
@@ -50324,7 +50324,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                             "props": Object {
                                               "isVisible": true,
                                             },
-                                            "title": "2 years ago",
+                                            "title": "3 years ago",
                                           },
                                           "name": Object {
                                             "formatters": Array [],
@@ -50346,7 +50346,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                         row={
                                           Object {
                                             "0": "micjohns baseline",
-                                            "1": "2 years ago",
+                                            "1": "3 years ago",
                                             "2": <div
                                               className="no-left-padding"
                                             >
@@ -50375,7 +50375,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                                   Array [
                                                     "abcd",
                                                     "micjohns baseline",
-                                                    "2 years ago",
+                                                    "3 years ago",
                                                     0,
                                                     false,
                                                   ]
@@ -50419,7 +50419,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                                     Array [
                                                       "abcd",
                                                       "micjohns baseline",
-                                                      "2 years ago",
+                                                      "3 years ago",
                                                       0,
                                                       false,
                                                     ]
@@ -50444,7 +50444,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                               "props": Object {
                                                 "isVisible": true,
                                               },
-                                              "title": "2 years ago",
+                                              "title": "3 years ago",
                                             },
                                             "name": Object {
                                               "formatters": Array [],
@@ -50546,7 +50546,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                                       data-label="Last updated"
                                                       onMouseEnter={[Function]}
                                                     >
-                                                      2 years ago
+                                                      3 years ago
                                                     </td>
                                                   </TdBase>
                                                 </Td>
@@ -50648,7 +50648,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                                           Array [
                                                             "abcd",
                                                             "micjohns baseline",
-                                                            "2 years ago",
+                                                            "3 years ago",
                                                             0,
                                                             false,
                                                           ]
@@ -50663,7 +50663,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                                             Array [
                                                               "abcd",
                                                               "micjohns baseline",
-                                                              "2 years ago",
+                                                              "3 years ago",
                                                               0,
                                                               false,
                                                             ]
@@ -57398,7 +57398,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
             Array [
               "abcd",
               "micjohns baseline",
-              "2 years ago",
+              "3 years ago",
               0,
               false,
             ],
@@ -57457,7 +57457,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
               Array [
                 "abcd",
                 "micjohns baseline",
-                "2 years ago",
+                "3 years ago",
                 0,
                 false,
               ],
@@ -57500,7 +57500,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                 Array [
                   "abcd",
                   "micjohns baseline",
-                  "2 years ago",
+                  "3 years ago",
                   0,
                   false,
                 ],
@@ -59820,7 +59820,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                 ],
                 Array [
                   "micjohns baseline",
-                  "2 years ago",
+                  "3 years ago",
                   <div
                     className="no-left-padding"
                   >
@@ -61130,7 +61130,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                             ],
                             Array [
                               "micjohns baseline",
-                              "2 years ago",
+                              "3 years ago",
                               <div
                                 className="no-left-padding"
                               >
@@ -61235,7 +61235,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                               },
                               Object {
                                 "0": "micjohns baseline",
-                                "1": "2 years ago",
+                                "1": "3 years ago",
                                 "2": <div
                                   className="no-left-padding"
                                 >
@@ -61294,7 +61294,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                   "props": Object {
                                     "isVisible": true,
                                   },
-                                  "title": "2 years ago",
+                                  "title": "3 years ago",
                                 },
                                 "name": Object {
                                   "formatters": Array [],
@@ -61385,7 +61385,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                               },
                               Object {
                                 "0": "micjohns baseline",
-                                "1": "2 years ago",
+                                "1": "3 years ago",
                                 "2": <div
                                   className="no-left-padding"
                                 >
@@ -61444,7 +61444,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                   "props": Object {
                                     "isVisible": true,
                                   },
-                                  "title": "2 years ago",
+                                  "title": "3 years ago",
                                 },
                                 "name": Object {
                                   "formatters": Array [],
@@ -61743,7 +61743,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                 },
                                 Object {
                                   "0": "micjohns baseline",
-                                  "1": "2 years ago",
+                                  "1": "3 years ago",
                                   "2": <div
                                     className="no-left-padding"
                                   >
@@ -61802,7 +61802,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                     "props": Object {
                                       "isVisible": true,
                                     },
-                                    "title": "2 years ago",
+                                    "title": "3 years ago",
                                   },
                                   "name": Object {
                                     "formatters": Array [],
@@ -61920,7 +61920,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                 },
                                 Object {
                                   "0": "micjohns baseline",
-                                  "1": "2 years ago",
+                                  "1": "3 years ago",
                                   "2": <div
                                     className="no-left-padding"
                                   >
@@ -61979,7 +61979,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                     "props": Object {
                                       "isVisible": true,
                                     },
-                                    "title": "2 years ago",
+                                    "title": "3 years ago",
                                   },
                                   "name": Object {
                                     "formatters": Array [],
@@ -62072,7 +62072,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                   },
                                   Object {
                                     "0": "micjohns baseline",
-                                    "1": "2 years ago",
+                                    "1": "3 years ago",
                                     "2": <div
                                       className="no-left-padding"
                                     >
@@ -62131,7 +62131,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                       "props": Object {
                                         "isVisible": true,
                                       },
-                                      "title": "2 years ago",
+                                      "title": "3 years ago",
                                     },
                                     "name": Object {
                                       "formatters": Array [],
@@ -62913,7 +62913,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                       rowData={
                                         Object {
                                           "0": "micjohns baseline",
-                                          "1": "2 years ago",
+                                          "1": "3 years ago",
                                           "2": <div
                                             className="no-left-padding"
                                           >
@@ -62972,7 +62972,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                             "props": Object {
                                               "isVisible": true,
                                             },
-                                            "title": "2 years ago",
+                                            "title": "3 years ago",
                                           },
                                           "name": Object {
                                             "formatters": Array [],
@@ -62994,7 +62994,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                         row={
                                           Object {
                                             "0": "micjohns baseline",
-                                            "1": "2 years ago",
+                                            "1": "3 years ago",
                                             "2": <div
                                               className="no-left-padding"
                                             >
@@ -63053,7 +63053,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                               "props": Object {
                                                 "isVisible": true,
                                               },
-                                              "title": "2 years ago",
+                                              "title": "3 years ago",
                                             },
                                             "name": Object {
                                               "formatters": Array [],
@@ -63155,7 +63155,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                                       data-label="Last updated"
                                                       onMouseEnter={[Function]}
                                                     >
-                                                      2 years ago
+                                                      3 years ago
                                                     </td>
                                                   </TdBase>
                                                 </Td>

--- a/src/SmartComponents/BaselinesTable/redux/__tests__/baselinesTableReducer.fixtures.js
+++ b/src/SmartComponents/BaselinesTable/redux/__tests__/baselinesTableReducer.fixtures.js
@@ -94,13 +94,13 @@ function baselineTableDataOneSelected() {
 
 const tableDataCSV = 'UUID,Name,Last updated,Associated systems\n\
 1234,beavs baseline,3 years ago,3,true,\n\
-abcd,micjohns baseline,2 years ago,0,false,\n\
+abcd,micjohns baseline,3 years ago,0,false,\n\
 ';
 
 /*eslint-disable camelcase*/
 const tableDataJSON = [
     { name: 'beavs baseline', last_updated: '3 years ago', associated_systems: 3, notifications_enabled: true },
-    { name: 'micjohns baseline', last_updated: '2 years ago', associated_systems: 0, notifications_enabled: false }
+    { name: 'micjohns baseline', last_updated: '3 years ago', associated_systems: 0, notifications_enabled: false }
 ];
 /*eslint-enable camelcase*/
 

--- a/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
+++ b/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
@@ -14,7 +14,6 @@ import ComparisonHeader from './ComparisonHeader/ComparisonHeader';
 import { compareActions } from '../../modules';
 import { baselinesTableActions } from '../../BaselinesTable/redux';
 import { historicProfilesActions } from '../../HistoricalProfilesPopover/redux';
-import addSystemModalHelpers from '../../AddSystemModal/redux/helpers';
 
 export class DriftTable extends Component {
     constructor(props) {
@@ -61,12 +60,6 @@ export class DriftTable extends Component {
         if (this.systemIds.length > 0 || this.baselineIds.length > 0 || this.HSPIds.length > 0) {
             await this.fetchCompare(this.systemIds, this.baselineIds, this.HSPIds, this.props.referenceId);
         }
-
-        addSystemModalHelpers.setContent({
-            systems: this.props.systems,
-            baselines: this.props.baselines,
-            historicalProfiles: this.props.historicalProfiles
-        }, this.props.handleSystemSelection, this.props.handleBaselineSelection, this.props.handleHSPSelection);
     }
 
     async shouldComponentUpdate(nextProps) {

--- a/src/SmartComponents/DriftPage/DriftTable/__tests__/__snapshots__/DriftTable.tests.js.snap
+++ b/src/SmartComponents/DriftPage/DriftTable/__tests__/__snapshots__/DriftTable.tests.js.snap
@@ -246,7 +246,7 @@ exports[`ConnectedDriftTable should render correctly 1`] = `
                   aria-describedby=""
                   aria-label=""
                   aria-labelledby=""
-                  className=""
+                  className="drift"
                   hasNoBodyWrapper={false}
                   isOpen={false}
                   onClose={[Function]}
@@ -263,7 +263,7 @@ exports[`ConnectedDriftTable should render correctly 1`] = `
                   titleIconVariant={null}
                   titleLabel=""
                   variant="default"
-                  width="950px"
+                  width="1200px"
                 >
                   <Portal
                     containerInfo={<div />}
@@ -293,7 +293,7 @@ exports[`ConnectedDriftTable should render correctly 1`] = `
                       aria-label=""
                       aria-labelledby=""
                       boxId="pf-modal-part-0"
-                      className=""
+                      className="drift"
                       descriptorId="pf-modal-part-2"
                       hasNoBodyWrapper={false}
                       isOpen={false}
@@ -312,7 +312,7 @@ exports[`ConnectedDriftTable should render correctly 1`] = `
                       titleIconVariant={null}
                       titleLabel=""
                       variant="default"
-                      width="950px"
+                      width="1200px"
                     />
                   </Portal>
                 </Modal>
@@ -700,7 +700,7 @@ exports[`ConnectedDriftTable should render loading rows 1`] = `
                   aria-describedby=""
                   aria-label=""
                   aria-labelledby=""
-                  className=""
+                  className="drift"
                   hasNoBodyWrapper={false}
                   isOpen={false}
                   onClose={[Function]}
@@ -717,7 +717,7 @@ exports[`ConnectedDriftTable should render loading rows 1`] = `
                   titleIconVariant={null}
                   titleLabel=""
                   variant="default"
-                  width="950px"
+                  width="1200px"
                 >
                   <Portal
                     containerInfo={<div />}
@@ -747,7 +747,7 @@ exports[`ConnectedDriftTable should render loading rows 1`] = `
                       aria-label=""
                       aria-labelledby=""
                       boxId="pf-modal-part-3"
-                      className=""
+                      className="drift"
                       descriptorId="pf-modal-part-5"
                       hasNoBodyWrapper={false}
                       isOpen={false}
@@ -766,7 +766,7 @@ exports[`ConnectedDriftTable should render loading rows 1`] = `
                       titleIconVariant={null}
                       titleLabel=""
                       variant="default"
-                      width="950px"
+                      width="1200px"
                     />
                   </Portal>
                 </Modal>
@@ -2165,7 +2165,7 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
                   aria-describedby=""
                   aria-label=""
                   aria-labelledby=""
-                  className=""
+                  className="drift"
                   hasNoBodyWrapper={false}
                   isOpen={false}
                   onClose={[Function]}
@@ -2182,7 +2182,7 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
                   titleIconVariant={null}
                   titleLabel=""
                   variant="default"
-                  width="950px"
+                  width="1200px"
                 >
                   <Portal
                     containerInfo={<div />}
@@ -2212,7 +2212,7 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
                       aria-label=""
                       aria-labelledby=""
                       boxId="pf-modal-part-2"
-                      className=""
+                      className="drift"
                       descriptorId="pf-modal-part-4"
                       hasNoBodyWrapper={false}
                       isOpen={false}
@@ -2231,7 +2231,7 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
                       titleIconVariant={null}
                       titleLabel=""
                       variant="default"
-                      width="950px"
+                      width="1200px"
                     />
                   </Portal>
                 </Modal>
@@ -8042,7 +8042,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                   aria-describedby=""
                   aria-label=""
                   aria-labelledby=""
-                  className=""
+                  className="drift"
                   hasNoBodyWrapper={false}
                   isOpen={false}
                   onClose={[Function]}
@@ -8059,7 +8059,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                   titleIconVariant={null}
                   titleLabel=""
                   variant="default"
-                  width="950px"
+                  width="1200px"
                 >
                   <Portal
                     containerInfo={<div />}
@@ -8089,7 +8089,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                       aria-label=""
                       aria-labelledby=""
                       boxId="pf-modal-part-1"
-                      className=""
+                      className="drift"
                       descriptorId="pf-modal-part-3"
                       hasNoBodyWrapper={false}
                       isOpen={false}
@@ -8108,7 +8108,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                       titleIconVariant={null}
                       titleLabel=""
                       variant="default"
-                      width="950px"
+                      width="1200px"
                     />
                   </Portal>
                 </Modal>

--- a/src/SmartComponents/DriftPage/__tests__/__snapshots__/DriftPage.tests.js.snap
+++ b/src/SmartComponents/DriftPage/__tests__/__snapshots__/DriftPage.tests.js.snap
@@ -3563,7 +3563,7 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
                                       aria-describedby=""
                                       aria-label=""
                                       aria-labelledby=""
-                                      className=""
+                                      className="drift"
                                       hasNoBodyWrapper={false}
                                       isOpen={false}
                                       onClose={[Function]}
@@ -3580,7 +3580,7 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
                                       titleIconVariant={null}
                                       titleLabel=""
                                       variant="default"
-                                      width="950px"
+                                      width="1200px"
                                     >
                                       <Portal
                                         containerInfo={<div />}
@@ -3610,7 +3610,7 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
                                           aria-label=""
                                           aria-labelledby=""
                                           boxId="pf-modal-part-0"
-                                          className=""
+                                          className="drift"
                                           descriptorId="pf-modal-part-2"
                                           hasNoBodyWrapper={false}
                                           isOpen={false}
@@ -3629,7 +3629,7 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
                                           titleIconVariant={null}
                                           titleLabel=""
                                           variant="default"
-                                          width="950px"
+                                          width="1200px"
                                         />
                                       </Portal>
                                     </Modal>
@@ -8236,7 +8236,7 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                       aria-describedby=""
                                       aria-label=""
                                       aria-labelledby=""
-                                      className=""
+                                      className="drift"
                                       hasNoBodyWrapper={false}
                                       isOpen={false}
                                       onClose={[Function]}
@@ -8253,7 +8253,7 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                       titleIconVariant={null}
                                       titleLabel=""
                                       variant="default"
-                                      width="950px"
+                                      width="1200px"
                                     >
                                       <Portal
                                         containerInfo={<div />}
@@ -8283,7 +8283,7 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                           aria-label=""
                                           aria-labelledby=""
                                           boxId="pf-modal-part-2"
-                                          className=""
+                                          className="drift"
                                           descriptorId="pf-modal-part-4"
                                           hasNoBodyWrapper={false}
                                           isOpen={false}
@@ -8302,7 +8302,7 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                           titleIconVariant={null}
                                           titleLabel=""
                                           variant="default"
-                                          width="950px"
+                                          width="1200px"
                                         />
                                       </Portal>
                                     </Modal>


### PR DESCRIPTION
To repro:

- Select 2 hsps from the Add to comparison modal and submit
- Return to the Add to comparison modal.  The Selected count is 0 even though I have 2 hsps selected.
- From here, things get a bit weird.  If I deselect one of the hsps from the hsp popover, the Selected count becomes 1 (ok so far).  If I deselect the other hsp, the Selected count becomes 2 (incorrect).

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
