### PR TITLE
[DRFT-912] Fix obfuscated cell shading

### DIFF
--- a/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
+++ b/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
@@ -463,7 +463,7 @@ export class DriftTable extends Component {
                         data-ouia-component-type='PF4/TableRow'
                         data-ouia-component-id={ 'comparison-table-row-' + comparison.name }
                         category={ fact.name }
-                        className={ comparison.state === 'DIFFERENT' ? 'unexpected-row' : '' }>
+                        className={ comparison.state === 'DIFFERENT' || comparison.state === 'INCOMPLETE_DATA_OBFUSCATED' ? 'unexpected-row' : '' }>
                         { row }
                     </tr>);
                     if (comparison.multivalues) {
@@ -472,7 +472,9 @@ export class DriftTable extends Component {
                                 row = this.renderRowChild(subFactItem);
                                 let rowValue = subFactItem.systems.filter(cell => cell.value !== '')[0].value;
                                 rows.push(<tr
-                                    className={ subFactItem.state === 'DIFFERENT' ? 'unexpected-row' : '' }
+                                    className={ subFactItem.state === 'DIFFERENT' || subFactItem.state === 'INCOMPLETE_DATA_OBFUSCATED'
+                                        ? 'unexpected-row'
+                                        : '' }
                                     data-ouia-component-type='PF4/TableRow'
                                     data-ouia-component-id={ 'comparison-table-row-multivalue-' + comparison.name + '-' + rowValue }>{ row }</tr>);
                             });
@@ -493,7 +495,7 @@ export class DriftTable extends Component {
             rows.push(<tr
                 data-ouia-component-type='PF4/TableRow'
                 data-ouia-component-id={ 'comparison-table-row-' + fact.name }
-                className={ fact.state === 'DIFFERENT' ? 'unexpected-row' : '' }>
+                className={ fact.state === 'DIFFERENT'  || fact.state === 'INCOMPLETE_DATA_OBFUSCATED' ? 'unexpected-row' : '' }>
                 { row }
             </tr>);
         }


### PR DESCRIPTION
To repro:
Create a comparison with at least 1 system with obfuscated values and a ensure that the fact that includes obfuscation results in a state of 'DIFFERENT' for the row. The easiest way to do this is create an empty baseline and compare the baseline to a system with obfuscation and a system with a value that isn't obfuscated.
Set the baseline as reference (should happen out of the box)

The obfuscated value (check for fqdn or ipv) should be completely gray with a lock icon, but the value set as 'DIFFERENT' will have a red border on the left and the background of the cell is gray. With this PR, the background of the 'DIFFERENT' cell will be red.

There is some discussion about whether or not we would highlight these values as red because ip addresses and fqdn should not be the same as others, and therefore should not be flagged with 'DIFFERENT'. In this PR, we are not testing the correctness of this, but simply that IF a fact returns the state of 'DIFFERENT' when compared with a system with obfuscation, that we properly shade it red.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
