### PR TITLE
[DRFT-914] Remove extra comma at end of row in CSV

### DIFF
--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaseline/__tests__/helpers.fixtures.js
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaseline/__tests__/helpers.fixtures.js
@@ -288,19 +288,19 @@ const editParentFactAPIBody = {
 };
 
 const csvContent = 'lotr-baseline\n\
-Fact,Value,\n\
-Sauron,the Dark Lord,\n\
-Galadriel,the Elven Queen,\n\
-The Fellowship of the Ring,\n\
-    Frodo,Baggins,\n\
-    Samwise,Gamgee,\n\
-    Gandalf,the Grey,\n\
-    Meriadoc,Brandybuck,\n\
-    Peregrin,Took,\n\
-    Gimli,son of Gloin,\n\
-    Legolas,Greenleaf,\n\
-    Boromir,son of Denethor,\n\
-    Aragorn,son of Arathorn,\n\
+Fact,Value\n\
+Sauron,the Dark Lord\n\
+Galadriel,the Elven Queen\n\
+The Fellowship of the Ring\n\
+    Frodo,Baggins\n\
+    Samwise,Gamgee\n\
+    Gandalf,the Grey\n\
+    Meriadoc,Brandybuck\n\
+    Peregrin,Took\n\
+    Gimli,son of Gloin\n\
+    Legolas,Greenleaf\n\
+    Boromir,son of Denethor\n\
+    Aragorn,son of Arathorn\n\
 ';
 
 const jsonContent = [

--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaseline/helpers.js
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaseline/helpers.js
@@ -407,32 +407,38 @@ function convertDataToCSV(data, baselineData) {
     let lineDelimiter = '\n';
 
     /*eslint-disable camelcase*/
-    let headers = 'Fact,Value,';
+    let headers = 'Fact,Value';
     let result = baselineData.display_name + lineDelimiter + headers + lineDelimiter;
     /*eslint-enable camelcase*/
 
     data.forEach(function(row) {
-        row.forEach(function(rowData) {
+        row.forEach(function(rowData, index) {
             if (row[0] === rowData) {
                 return;
+            }
+
+            if (index !== 1 && !Array.isArray(row[index])) {
+                result += columnDelimiter;
             }
 
             if (Array.isArray(rowData)) {
                 rowData.forEach(function(subFact) {
                     result += lineDelimiter;
                     result += '    ';
-                    subFact.forEach(function(subFactData) {
+                    subFact.forEach(function(subFactData, i) {
                         if (subFact[0] === subFactData) {
                             return;
                         }
 
+                        if (i !== 1) {
+                            result += columnDelimiter;
+                        }
+
                         result += subFactData;
-                        result += columnDelimiter;
                     });
                 });
             } else {
                 result += rowData;
-                result += columnDelimiter;
             }
         });
 

--- a/src/SmartComponents/BaselinesTable/redux/__tests__/baselinesTableReducer.fixtures.js
+++ b/src/SmartComponents/BaselinesTable/redux/__tests__/baselinesTableReducer.fixtures.js
@@ -93,8 +93,8 @@ function baselineTableDataOneSelected() {
 }
 
 const tableDataCSV = 'UUID,Name,Last updated,Associated systems\n\
-1234,beavs baseline,3 years ago,3,true,\n\
-abcd,micjohns baseline,3 years ago,0,false,\n\
+1234,beavs baseline,3 years ago,3,true\n\
+abcd,micjohns baseline,3 years ago,0,false\n\
 ';
 
 /*eslint-disable camelcase*/

--- a/src/SmartComponents/BaselinesTable/redux/helpers.js
+++ b/src/SmartComponents/BaselinesTable/redux/helpers.js
@@ -97,9 +97,11 @@ function convertListToCSV(data) {
     let result = headers + lineDelimiter;
 
     data.forEach(function(baseline) {
-        baseline.forEach(function(detail) {
+        baseline.forEach(function(detail, index) {
             result += detail;
-            result += columnDelimiter;
+            if (index + 1 !== baseline.length) {
+                result += columnDelimiter;
+            }
         });
 
         result += lineDelimiter;

--- a/src/SmartComponents/helpers.js
+++ b/src/SmartComponents/helpers.js
@@ -109,7 +109,6 @@ function downloadHelper(baselineData) {
 
     let today = new Date();
     filename += today.toISOString();
-    //filename += '.' + baselineData.type;
 
     downloadFile(file, filename, baselineData.type);
 }

--- a/src/SmartComponents/modules/__tests__/reducer.fixtures.js
+++ b/src/SmartComponents/modules/__tests__/reducer.fixtures.js
@@ -1230,12 +1230,12 @@ export const mockMultiValueFacts = ({
 
 export const comparisonCSV = 'Fact,State,sgi-xe500-01.rhts.eng.bos.redhat.com(reference),ibm-x3650m4-03-vm03.lab.eng.brq.redhat.com\n\
 ,,15 Jan 2019 14:53 UTC(reference),15 Jan 2019 15:25 UTC\n\
-cpus,DIFFERENT,4,3,\n\
-bios_uuid,SAME,FAKE-BIOS,FAKE-BIOS,\n\
-display_name,SAME,PC-NAME,PC-NAME,\n\
-cpu_flags,DIFFERENT,\n\
-     abm,SAME,enabled,enabled,\n\
-     adx,INCOMPLETE_DATA,disabled,,\n\
+cpus,DIFFERENT,4,3\n\
+bios_uuid,SAME,FAKE-BIOS,FAKE-BIOS\n\
+display_name,SAME,PC-NAME,PC-NAME\n\
+cpu_flags,DIFFERENT\n\
+     abm,SAME,enabled,enabled\n\
+     adx,INCOMPLETE_DATA,disabled,\n\
 ';
 
 export const fullSimpleComparison = ({

--- a/src/SmartComponents/modules/helpers.js
+++ b/src/SmartComponents/modules/helpers.js
@@ -310,13 +310,19 @@ function addRow(fact) {
     let result = '';
 
     result += factName + COLUMN_DELIMITER;
-    result += fact.state + COLUMN_DELIMITER;
+    result += fact.state;
+    if (!fact.multivalues && !fact.comparisons) {
+        result += COLUMN_DELIMITER;
+    }
 
     if (fact.systems) {
-        fact.systems.forEach(function(system) {
+        fact.systems.forEach(function(system, index) {
+            if (index !== 0) {
+                result += COLUMN_DELIMITER;
+            }
+
             value = system.value ? system.value.replace(/,/g, '') : '';
             result += value;
-            result += COLUMN_DELIMITER;
         });
     } else if (fact.multivalues) {
         fact.multivalues.forEach(function(value) {


### PR DESCRIPTION
For comparison, baseline list and baseline details CSV export, if you export to CSV, you will notice that a comma is added at the end of each row. This PR removes the final comma.

Be aware, in the case of multivalues, if a fact has an empty value, you may notice a comma after the end of the row. So, in the case of this layout:
![image](https://user-images.githubusercontent.com/15373136/144113892-5c5d83b1-19ee-4401-b9a6-256a1503081a.png)

This output is expected, and okay:
![image](https://user-images.githubusercontent.com/15373136/144113852-e80681ea-13fc-4e19-9af2-9fec11441cf2.png)

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
