### PR TITLE
[DRFT-838] Collapsed multivalue should show blue left border

### DIFF
--- a/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
+++ b/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
@@ -504,18 +504,11 @@ export class DriftTable extends Component {
     }
 
     renderRowChild(fact) {
-        const { expandedRows } = this.props;
         let row = [];
 
         if (fact.multivalues) {
             row.push(
-                this.renderFact(
-                    fact.name,
-                    expandedRows.includes(fact.name)
-                        ? 'nested-fact sticky-column fixed-column-1'
-                        : 'sticky-column fixed-column-1',
-                    true
-                )
+                this.renderFact(fact.name, 'nested-fact sticky-column fixed-column-1', true)
             );
 
             row.push(


### PR DESCRIPTION
Before, if you ran a comparison that included multivalues and expanded the category that included multivalues, all subfacts of that category would have a blue left border to show they belong to the category, but any collapsed multivalues would not have the blue left border.

This PR fixes that by including the blue border for the collapsed multivalue.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
