### PR TITLE
[DRFT-910] Add border to left most system in comparison header

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -210,8 +210,11 @@
   .sticky-column-header .drift-header {
     padding: 16px;
     margin: 0;
-    border-right: 1px solid #CCC;
     min-width: 250px;
+
+    &.right-border {
+      border-right: 1px solid #CCC;
+    }
 
     &.remove-system-icon {
       position: relative;
@@ -289,6 +292,10 @@
 .state-header {
   font-weight: bold;
   vertical-align: bottom;
+
+  &.right-border {
+    border-right: 1px solid #CCC;
+  }
 }
 .fixed-column-1 {
   left: 0;

--- a/src/SmartComponents/DriftPage/DriftTable/ComparisonHeader/ComparisonHeader.js
+++ b/src/SmartComponents/DriftPage/DriftTable/ComparisonHeader/ComparisonHeader.js
@@ -83,8 +83,8 @@ class ComparisonHeader extends Component {
                     header-id={ item.id }
                     key={ item.id }
                     className={ item.id === referenceId
-                        ? 'drift-header reference-header'
-                        : `drift-header ${item.type}-header` }
+                        ? 'drift-header right-border reference-header'
+                        : `drift-header right-border ${item.type}-header` }
                 >
                     <div>
                         <a
@@ -161,7 +161,7 @@ class ComparisonHeader extends Component {
                     <div className="active-blue">Fact { this.renderSortButton(factSort) }</div>
                 </th>
                 <th
-                    className="state-header sticky-column fixed-column-2 pointer"
+                    className="state-header sticky-column fixed-column-2 pointer right-border"
                     key='state-header'
                     id={ stateSort || 'disabled' }
                     data-ouia-component-type='PF4/Button'

--- a/src/SmartComponents/DriftPage/DriftTable/ComparisonHeader/__tests__/__snapshots__/ComparisonHeader.tests.js.snap
+++ b/src/SmartComponents/DriftPage/DriftTable/ComparisonHeader/__tests__/__snapshots__/ComparisonHeader.tests.js.snap
@@ -28,7 +28,7 @@ exports[`ComparisonHeader should not render HistoricalProfilesPopover with no hs
       </div>
     </th>
     <th
-      className="state-header sticky-column fixed-column-2 pointer"
+      className="state-header sticky-column fixed-column-2 pointer right-border"
       data-ouia-component-id="state-sort-button"
       data-ouia-component-type="PF4/Button"
       id="disabled"
@@ -46,7 +46,7 @@ exports[`ComparisonHeader should not render HistoricalProfilesPopover with no hs
       </div>
     </th>
     <th
-      className="drift-header baseline-header"
+      className="drift-header right-border baseline-header"
       header-id="12e4d81b-f1c6-489a-a829-9d96f3a71f53"
       key="12e4d81b-f1c6-489a-a829-9d96f3a71f53"
     >
@@ -112,7 +112,7 @@ exports[`ComparisonHeader should not render HistoricalProfilesPopover with no hs
       </div>
     </th>
     <th
-      className="drift-header system-header"
+      className="drift-header right-border system-header"
       header-id="dc47qffd-09rt-2kw7-8b9b-53f4g716fec5"
       key="dc47qffd-09rt-2kw7-8b9b-53f4g716fec5"
     >
@@ -178,7 +178,7 @@ exports[`ComparisonHeader should not render HistoricalProfilesPopover with no hs
       </div>
     </th>
     <th
-      className="drift-header historical-system-profile-header"
+      className="drift-header right-border historical-system-profile-header"
       header-id="e3ed3e34-eaa1-45c4-8633-94fef1f678f1"
       key="e3ed3e34-eaa1-45c4-8633-94fef1f678f1"
     >
@@ -276,7 +276,7 @@ exports[`ComparisonHeader should render a system, baseline and hsp 1`] = `
       </div>
     </th>
     <th
-      className="state-header sticky-column fixed-column-2 pointer"
+      className="state-header sticky-column fixed-column-2 pointer right-border"
       data-ouia-component-id="state-sort-button"
       data-ouia-component-type="PF4/Button"
       id="disabled"
@@ -294,7 +294,7 @@ exports[`ComparisonHeader should render a system, baseline and hsp 1`] = `
       </div>
     </th>
     <th
-      className="drift-header baseline-header"
+      className="drift-header right-border baseline-header"
       header-id="12e4d81b-f1c6-489a-a829-9d96f3a71f53"
       key="12e4d81b-f1c6-489a-a829-9d96f3a71f53"
     >
@@ -360,7 +360,7 @@ exports[`ComparisonHeader should render a system, baseline and hsp 1`] = `
       </div>
     </th>
     <th
-      className="drift-header system-header"
+      className="drift-header right-border system-header"
       header-id="dc47qffd-09rt-2kw7-8b9b-53f4g716fec5"
       key="dc47qffd-09rt-2kw7-8b9b-53f4g716fec5"
     >
@@ -441,7 +441,7 @@ exports[`ComparisonHeader should render a system, baseline and hsp 1`] = `
       </div>
     </th>
     <th
-      className="drift-header historical-system-profile-header"
+      className="drift-header right-border historical-system-profile-header"
       header-id="e3ed3e34-eaa1-45c4-8633-94fef1f678f1"
       key="e3ed3e34-eaa1-45c4-8633-94fef1f678f1"
     >
@@ -555,7 +555,7 @@ exports[`ComparisonHeader should render correctly 1`] = `
       </div>
     </th>
     <th
-      className="state-header sticky-column fixed-column-2 pointer"
+      className="state-header sticky-column fixed-column-2 pointer right-border"
       data-ouia-component-id="state-sort-button"
       data-ouia-component-type="PF4/Button"
       id="disabled"
@@ -604,7 +604,7 @@ exports[`ComparisonHeader should render fact sort asc 1`] = `
       </div>
     </th>
     <th
-      className="state-header sticky-column fixed-column-2 pointer"
+      className="state-header sticky-column fixed-column-2 pointer right-border"
       data-ouia-component-id="state-sort-button"
       data-ouia-component-type="PF4/Button"
       id="disabled"
@@ -653,7 +653,7 @@ exports[`ComparisonHeader should render fact sort desc 1`] = `
       </div>
     </th>
     <th
-      className="state-header sticky-column fixed-column-2 pointer"
+      className="state-header sticky-column fixed-column-2 pointer right-border"
       data-ouia-component-id="state-sort-button"
       data-ouia-component-type="PF4/Button"
       id="disabled"
@@ -702,7 +702,7 @@ exports[`ComparisonHeader should render state sort asc 1`] = `
       </div>
     </th>
     <th
-      className="state-header sticky-column fixed-column-2 pointer"
+      className="state-header sticky-column fixed-column-2 pointer right-border"
       data-ouia-component-id="state-sort-button"
       data-ouia-component-type="PF4/Button"
       id="asc"
@@ -753,7 +753,7 @@ exports[`ComparisonHeader should render state sort desc 1`] = `
       </div>
     </th>
     <th
-      className="state-header sticky-column fixed-column-2 pointer"
+      className="state-header sticky-column fixed-column-2 pointer right-border"
       data-ouia-component-id="state-sort-button"
       data-ouia-component-type="PF4/Button"
       id="desc"

--- a/src/SmartComponents/DriftPage/DriftTable/__tests__/__snapshots__/DriftTable.tests.js.snap
+++ b/src/SmartComponents/DriftPage/DriftTable/__tests__/__snapshots__/DriftTable.tests.js.snap
@@ -401,7 +401,7 @@ exports[`ConnectedDriftTable should render correctly 1`] = `
                         </div>
                       </th>
                       <th
-                        className="state-header sticky-column fixed-column-2 pointer"
+                        className="state-header sticky-column fixed-column-2 pointer right-border"
                         data-ouia-component-id="state-sort-button"
                         data-ouia-component-type="PF4/Button"
                         id="disabled"
@@ -855,7 +855,7 @@ exports[`ConnectedDriftTable should render loading rows 1`] = `
                         </div>
                       </th>
                       <th
-                        className="state-header sticky-column fixed-column-2 pointer"
+                        className="state-header sticky-column fixed-column-2 pointer right-border"
                         data-ouia-component-id="state-sort-button"
                         data-ouia-component-type="PF4/Button"
                         id="disabled"
@@ -2366,7 +2366,7 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
                         </div>
                       </th>
                       <th
-                        className="state-header sticky-column fixed-column-2 pointer"
+                        className="state-header sticky-column fixed-column-2 pointer right-border"
                         data-ouia-component-id="state-sort-button"
                         data-ouia-component-type="PF4/Button"
                         id="disabled"
@@ -2406,7 +2406,7 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
                         </div>
                       </th>
                       <th
-                        className="drift-header baseline-header"
+                        className="drift-header right-border baseline-header"
                         header-id="9bbbefcc-8f23-4d97-07f2-142asdl234e9"
                         key="9bbbefcc-8f23-4d97-07f2-142asdl234e9"
                       >
@@ -2700,7 +2700,7 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
                         </div>
                       </th>
                       <th
-                        className="drift-header baseline-header"
+                        className="drift-header right-border baseline-header"
                         header-id="fdmk59dj-fn42-dfjk-alv3-bmn2854mnn29"
                         key="fdmk59dj-fn42-dfjk-alv3-bmn2854mnn29"
                       >
@@ -2994,7 +2994,7 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
                         </div>
                       </th>
                       <th
-                        className="drift-header system-header"
+                        className="drift-header right-border system-header"
                         header-id="9c79efcc-8f9a-47c7-b0f2-142ff52e89e9"
                         key="9c79efcc-8f9a-47c7-b0f2-142ff52e89e9"
                       >
@@ -3666,7 +3666,7 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
                         </div>
                       </th>
                       <th
-                        className="drift-header historical-system-profile-header"
+                        className="drift-header right-border historical-system-profile-header"
                         header-id="9bbbefcc-8f23-4d97-07f2-142asdl234e8"
                         key="9bbbefcc-8f23-4d97-07f2-142asdl234e8"
                       >
@@ -4342,7 +4342,7 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
                         </div>
                       </th>
                       <th
-                        className="drift-header historical-system-profile-header"
+                        className="drift-header right-border historical-system-profile-header"
                         header-id="edmk59dj-fn42-dfjk-alv3-bmn2854mnn27"
                         key="edmk59dj-fn42-dfjk-alv3-bmn2854mnn27"
                       >
@@ -5018,7 +5018,7 @@ exports[`ConnectedDriftTable should render multi fact values 1`] = `
                         </div>
                       </th>
                       <th
-                        className="drift-header system-header"
+                        className="drift-header right-border system-header"
                         header-id="f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2"
                         key="f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2"
                       >
@@ -9260,7 +9260,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                         </div>
                       </th>
                       <th
-                        className="state-header sticky-column fixed-column-2 pointer"
+                        className="state-header sticky-column fixed-column-2 pointer right-border"
                         data-ouia-component-id="state-sort-button"
                         data-ouia-component-type="PF4/Button"
                         id="disabled"
@@ -9300,7 +9300,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                         </div>
                       </th>
                       <th
-                        className="drift-header baseline-header"
+                        className="drift-header right-border baseline-header"
                         header-id="9bbbefcc-8f23-4d97-07f2-142asdl234e9"
                         key="9bbbefcc-8f23-4d97-07f2-142asdl234e9"
                       >
@@ -9594,7 +9594,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                         </div>
                       </th>
                       <th
-                        className="drift-header baseline-header"
+                        className="drift-header right-border baseline-header"
                         header-id="fdmk59dj-fn42-dfjk-alv3-bmn2854mnn29"
                         key="fdmk59dj-fn42-dfjk-alv3-bmn2854mnn29"
                       >
@@ -9888,7 +9888,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                         </div>
                       </th>
                       <th
-                        className="drift-header system-header"
+                        className="drift-header right-border system-header"
                         header-id="9c79efcc-8f9a-47c7-b0f2-142ff52e89e9"
                         key="9c79efcc-8f9a-47c7-b0f2-142ff52e89e9"
                       >
@@ -10560,7 +10560,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                         </div>
                       </th>
                       <th
-                        className="drift-header historical-system-profile-header"
+                        className="drift-header right-border historical-system-profile-header"
                         header-id="9bbbefcc-8f23-4d97-07f2-142asdl234e8"
                         key="9bbbefcc-8f23-4d97-07f2-142asdl234e8"
                       >
@@ -11236,7 +11236,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                         </div>
                       </th>
                       <th
-                        className="drift-header historical-system-profile-header"
+                        className="drift-header right-border historical-system-profile-header"
                         header-id="edmk59dj-fn42-dfjk-alv3-bmn2854mnn27"
                         key="edmk59dj-fn42-dfjk-alv3-bmn2854mnn27"
                       >
@@ -11912,7 +11912,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                         </div>
                       </th>
                       <th
-                        className="drift-header system-header"
+                        className="drift-header right-border system-header"
                         header-id="f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2"
                         key="f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2"
                       >

--- a/src/SmartComponents/DriftPage/__tests__/__snapshots__/DriftPage.tests.js.snap
+++ b/src/SmartComponents/DriftPage/__tests__/__snapshots__/DriftPage.tests.js.snap
@@ -3721,7 +3721,7 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
                                             </div>
                                           </th>
                                           <th
-                                            className="state-header sticky-column fixed-column-2 pointer"
+                                            className="state-header sticky-column fixed-column-2 pointer right-border"
                                             data-ouia-component-id="state-sort-button"
                                             data-ouia-component-type="PF4/Button"
                                             id="disabled"
@@ -8394,7 +8394,7 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                             </div>
                                           </th>
                                           <th
-                                            className="state-header sticky-column fixed-column-2 pointer"
+                                            className="state-header sticky-column fixed-column-2 pointer right-border"
                                             data-ouia-component-id="state-sort-button"
                                             data-ouia-component-type="PF4/Button"
                                             id="disabled"


### PR DESCRIPTION
In the comparison header, the system, baseline or HSP cell farthest to the left doesn't have a border on the left. This PR adds a border.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
