### PR TITLE
[DRFT-907] Standarize the width of modals in drift

### DIFF
--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/SystemNotification/SystemNotification.js
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/SystemNotification/SystemNotification.js
@@ -114,6 +114,7 @@ export class SystemNotification extends Component {
                 />
                 <Modal
                     className="drift"
+                    width='1200px'
                     ouiaId='add-baseline-notification-modal'
                     variant={ ModalVariant.medium }
                     title={ 'Associate system with ' + baselineName }

--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/SystemNotification/__tests__/__snapshots__/SystemNotification.tests.js.snap
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/SystemNotification/__tests__/__snapshots__/SystemNotification.tests.js.snap
@@ -191,6 +191,7 @@ exports[`ConnectedSystemNotification should render correctly 1`] = `
             titleIconVariant={null}
             titleLabel=""
             variant="medium"
+            width="1200px"
           >
             <Portal
               containerInfo={<div />}
@@ -231,6 +232,7 @@ exports[`ConnectedSystemNotification should render correctly 1`] = `
                 titleIconVariant={null}
                 titleLabel=""
                 variant="medium"
+                width="1200px"
               />
             </Portal>
           </Modal>
@@ -545,6 +547,7 @@ exports[`SystemNotification should render 1`] = `
     titleIconVariant={null}
     titleLabel=""
     variant="medium"
+    width="1200px"
   >
     <Connect(SystemsTable)
       hasMultiSelect={true}


### PR DESCRIPTION
Before, some of the modals had different sizes. These have been normalized for consistency across the app. Modal widths should be as follows:

1200 px:

- Add system modal
- Create baseline modal
- System notification

560 px:

- Delete baselines modal
- Delete fact modal
- Edit baseline name modal
- Fact modal
- Delete notification modal

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
