### PR TITLE
[DRFT-904] Left align tags icon in inv table

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -380,8 +380,6 @@
 }
 
 .hsp-icon-padding {
-  padding-left: 8px;
-  padding-right: 8px;
   height: 22px;
 }
 
@@ -448,4 +446,8 @@
 
 .no-left-padding {
   padding-left: 0;
+}
+
+.ins-c-tag-count {
+  padding-left: 0px;
 }


### PR DESCRIPTION
Before, the tags icon in the inventory table was not left aligned to the text in the header. This PR ensures that it is left-aligned. I also left-aligned the HSP icon to the header as well.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
