### PR TITLE
[DRFT-847] Remove ability to close global filter alert

### DIFF
--- a/src/SmartComponents/GlobalFilterAlert/GlobalFilterAlert.js
+++ b/src/SmartComponents/GlobalFilterAlert/GlobalFilterAlert.js
@@ -1,22 +1,10 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Alert, AlertActionCloseButton } from '@patternfly/react-core';
+import { Alert } from '@patternfly/react-core';
 
 export class GlobalFilterAlert extends Component {
     constructor(props) {
         super(props);
-
-        this.state = {
-            isOpen: true
-        };
-
-        this.toggleIsOpen = () => {
-            const { isOpen } = this.state;
-
-            this.setState({
-                isOpen: !isOpen
-            });
-        };
     }
 
     buildBody = () => {
@@ -73,16 +61,14 @@ export class GlobalFilterAlert extends Component {
 
     render() {
         const { sidsFilter, tagsFilter, workloadsFilter } = this.props.globalFilterState;
-        const { isOpen } = this.state;
 
         return (
             <React.Fragment>
-                { isOpen && (workloadsFilter.SAP?.isSelected || sidsFilter.length > 0 || tagsFilter.length > 0)
+                { workloadsFilter.SAP?.isSelected || sidsFilter.length > 0 || tagsFilter.length > 0
                     ? <Alert
                         variant='info'
                         title='Your systems are pre-filtered by the global context selector.'
                         isInline
-                        actionClose={ <AlertActionCloseButton onClose={ () => this.toggleIsOpen() } /> }
                     >
                         <p>
                             { this.buildBody() }

--- a/src/SmartComponents/GlobalFilterAlert/__tests__/GlobalFilterAlert.tests.js
+++ b/src/SmartComponents/GlobalFilterAlert/__tests__/GlobalFilterAlert.tests.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 
 import { GlobalFilterAlert } from '../GlobalFilterAlert';
@@ -112,22 +112,5 @@ describe('GlobalFilterAlert', () => {
         );
 
         expect(toJson(wrapper)).toMatchSnapshot();
-    });
-
-    it('should close alert', () => {
-        props.globalFilterState.workloadsFilter = {
-            SAP: {
-                isSelected: true
-            }
-        };
-
-        const wrapper = mount(
-            <GlobalFilterAlert
-                { ...props }
-            />
-        );
-
-        wrapper.find('AlertActionCloseButton').simulate('click');
-        expect(wrapper.state('isOpen')).toBe(false);
     });
 });

--- a/src/SmartComponents/GlobalFilterAlert/__tests__/__snapshots__/GlobalFilterAlert.tests.js.snap
+++ b/src/SmartComponents/GlobalFilterAlert/__tests__/__snapshots__/GlobalFilterAlert.tests.js.snap
@@ -9,11 +9,6 @@ exports[`GlobalFilterAlert should not render with all workloads 1`] = `<Fragment
 exports[`GlobalFilterAlert should render with SAP 1`] = `
 <Fragment>
   <Alert
-    actionClose={
-      <AlertActionCloseButton
-        onClose={[Function]}
-      />
-    }
     isInline={true}
     title="Your systems are pre-filtered by the global context selector."
     variant="info"
@@ -28,11 +23,6 @@ exports[`GlobalFilterAlert should render with SAP 1`] = `
 exports[`GlobalFilterAlert should render with SAP and filters 1`] = `
 <Fragment>
   <Alert
-    actionClose={
-      <AlertActionCloseButton
-        onClose={[Function]}
-      />
-    }
     isInline={true}
     title="Your systems are pre-filtered by the global context selector."
     variant="info"


### PR DESCRIPTION
Before, the global filter alert was able to be closed in the add system modal. To repro:

Go to the Comparison screen
Select a global filter at the top of the screen, in the header
Click button to add a system to the comparison

You'll see the inline alert at the top of the modal showing which global filters are applied. You should see an 'X' you can click to close the alert.

This PR removes the ability to close that alert.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
