### PR TITLE
[DRFT-983] Change comparison filter to dropdown filter selector

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -458,3 +458,10 @@
 .ins-c-tag-count {
   padding-left: 0px;
 }
+
+.comparison-filter-dropdown-width {
+  .pf-c-dropdown__toggle-text {
+    width: 102px;
+    text-align: left;
+  }
+}

--- a/src/SmartComponents/DriftPage/DriftToolbar/DriftFilter/DriftFilter.js
+++ b/src/SmartComponents/DriftPage/DriftToolbar/DriftFilter/DriftFilter.js
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { ToolbarGroup } from '@patternfly/react-core';
+
+import DriftFilterDropdown from './DriftFilterDropdown';
+import DriftFilterValue from './DriftFilterValue';
+
+function DriftFilter(props) {
+    const { activeFactFilters, factFilter, filterByFact, handleFactFilter, removeChip, setHistory, stateFilters } = props;
+    const [ filterType, toggleFilterType ] = useState('Fact name');
+
+    return (
+        <ToolbarGroup variant='filter-group'>
+            <DriftFilterDropdown
+                filterType={ filterType }
+                toggleFilterType={ toggleFilterType }
+            />
+            <DriftFilterValue
+                activeFactFilters={ activeFactFilters }
+                factFilter={ factFilter }
+                filterByFact={ filterByFact }
+                filterType={ filterType }
+                handleFactFilter={ handleFactFilter }
+                removeChip={ removeChip }
+                setHistory={ setHistory }
+                stateFilters={ stateFilters }
+            />
+        </ToolbarGroup>
+    );
+}
+
+DriftFilter.propTypes = {
+    activeFactFilters: PropTypes.array,
+    addStateFilter: PropTypes.func,
+    clearAllFactFilters: PropTypes.func,
+    clearAllStateChips: PropTypes.func,
+    factFilter: PropTypes.string,
+    filterByFact: PropTypes.func,
+    handleFactFilter: PropTypes.func,
+    removeChip: PropTypes.func,
+    setHistory: PropTypes.func,
+    stateFilters: PropTypes.array
+};
+
+export default DriftFilter;

--- a/src/SmartComponents/DriftPage/DriftToolbar/DriftFilter/DriftFilterDropdown.js
+++ b/src/SmartComponents/DriftPage/DriftToolbar/DriftFilter/DriftFilterDropdown.js
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core';
+import { FilterIcon } from '@patternfly/react-icons';
+
+function DriftFilterDropdown(props) {
+    const { filterType, toggleFilterType } = props;
+    const [ isOpen, toggleOpen ] = useState(false);
+
+    const selectFilter = (type) => {
+        toggleFilterType(type);
+        toggleOpen(!isOpen);
+    };
+
+    const dropdownItems = [
+        <DropdownItem
+            data-ouia-component-id='fact-name-filter'
+            key='fact-name'
+            onClick={ () => selectFilter('Fact name') }
+        >
+            Fact name
+        </DropdownItem>,
+        // Using this code block for the next PR.
+        /*<DropdownItem
+            data-ouia-component-id='fact-type-filter'
+            key='fact-type'
+            onClick={ () => selectFilter('Fact type') }
+        >
+            Fact type
+        </DropdownItem>,*/
+        <DropdownItem
+            data-ouia-component-id='state-filter'
+            key='state'
+            onClick={ () => selectFilter('State') }
+        >
+            State
+        </DropdownItem>
+    ];
+
+    return (
+        <Dropdown
+            ouiaId='drift-filter-dropdown'
+            className='comparison-filter-dropdown-width'
+            toggle={ <DropdownToggle
+                onToggle={ toggleOpen }
+                ouiaId='drift-filter-toggle'
+                icon={ <FilterIcon /> }>
+                { filterType }
+            </DropdownToggle> }
+            isOpen={ isOpen }
+            dropdownItems={ dropdownItems }
+        />
+    );
+}
+
+DriftFilterDropdown.propTypes = {
+    filterType: PropTypes.string,
+    toggleFilterType: PropTypes.func
+};
+
+export default DriftFilterDropdown;

--- a/src/SmartComponents/DriftPage/DriftToolbar/DriftFilter/DriftFilterValue.js
+++ b/src/SmartComponents/DriftPage/DriftToolbar/DriftFilter/DriftFilterValue.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { ToolbarFilter } from '@patternfly/react-core';
+import SearchBar from '../../SearchBar/SearchBar';
+import FilterDropDown from '../../FilterDropDown/FilterDropDown';
+
+function DriftFilterValue(props) {
+    const { activeFactFilters, factFilter, filterByFact, filterType, handleFactFilter, removeChip, setHistory, stateFilters } = props;
+
+    const setFactFilterChips = () => {
+        let factFilterChips = [ ...activeFactFilters ];
+
+        if (factFilter.length && !activeFactFilters.includes(factFilter)) {
+            factFilterChips.push(factFilter);
+        }
+
+        return factFilterChips;
+    };
+
+    const setStateChips = (stateFilters) => {
+        let stateChips = [];
+
+        stateFilters.forEach(function(filter) {
+            if (filter.selected) {
+                stateChips.push(filter.display);
+            }
+        });
+
+        return stateChips;
+    };
+
+    const renderFilterInput = (type) => {
+        return <React.Fragment>
+            <ToolbarFilter
+                chips={ setFactFilterChips() }
+                deleteChip={ removeChip }
+                deleteChipGroup={ removeChip }
+                categoryName="Fact name"
+            >
+                { type === 'Fact name'
+                    ? <SearchBar
+                        factFilter={ factFilter }
+                        activeFactFilters={ activeFactFilters }
+                        handleFactFilter={ handleFactFilter }
+                        filterByFact={ filterByFact }
+                        setHistory={ setHistory }
+                    />
+                    : null
+                }
+            </ToolbarFilter>
+            { /*<ToolbarFilter
+                chips={ setFactTypeChips() }
+                deleteChip={ removeChip }
+                deleteChipGroup={ removeChip }
+                categoryName="Fact type"
+            >
+                { type === 'Fact type' ? }
+            </ToolbarFilter>*/ }
+            <ToolbarFilter
+                chips={ setStateChips(stateFilters) }
+                deleteChip={ removeChip }
+                deleteChipGroup={ removeChip }
+                categoryName="State"
+            >
+                { type === 'State' ? <FilterDropDown setHistory={ setHistory } /> : null }
+            </ToolbarFilter>
+        </React.Fragment>;
+    };
+
+    return (
+        <React.Fragment>
+            { renderFilterInput(filterType) }
+        </React.Fragment>
+    );
+}
+
+DriftFilterValue.propTypes = {
+    activeFactFilters: PropTypes.array,
+    factFilter: PropTypes.string,
+    filterByFact: PropTypes.func,
+    filterType: PropTypes.string,
+    handleFactFilter: PropTypes.func,
+    removeChip: PropTypes.func,
+    setHistory: PropTypes.func,
+    stateFilters: PropTypes.array
+};
+
+export default DriftFilterValue;

--- a/src/SmartComponents/DriftPage/DriftToolbar/DriftFilter/__tests__/DriftFilterDropdown.tests.js
+++ b/src/SmartComponents/DriftPage/DriftToolbar/DriftFilter/__tests__/DriftFilterDropdown.tests.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+
+import DriftFilterDropdown from '../DriftFilterDropdown';
+
+describe('DriftFilterValue', () => {
+    let props;
+    const setState = jest.fn();
+    const useStateSpy = jest.spyOn(React, 'useState');
+    useStateSpy.mockImplementation((init) => [ init, setState ]);
+
+    beforeEach(() => {
+        props = {
+            filterType: 'Fact name',
+            toggleFilterType: jest.fn()
+        };
+    });
+
+    it('should render with fact name', () => {
+        const wrapper = shallow(
+            <DriftFilterDropdown { ...props } />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('should render with state filter', () => {
+        props.filterType = 'State';
+
+        const wrapper = shallow(
+            <DriftFilterDropdown { ...props } />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});

--- a/src/SmartComponents/DriftPage/DriftToolbar/DriftFilter/__tests__/DriftFilterValue.tests.js
+++ b/src/SmartComponents/DriftPage/DriftToolbar/DriftFilter/__tests__/DriftFilterValue.tests.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+
+import DriftFilterValue from '../DriftFilterValue';
+import stateFilters from '../../../../modules/__tests__/state-filter.fixtures';
+
+describe('DriftFilterValue', () => {
+    let props;
+
+    beforeEach(() => {
+        props = {
+            activeFactFilters: [],
+            addStateFilter: jest.fn(),
+            clearAllFactFilters: jest.fn(),
+            factFilter: '',
+            filterByFact: jest.fn(),
+            filterType: 'Fact name',
+            handleFactFilter: jest.fn(),
+            setHistory: jest.fn(),
+            stateFilters: stateFilters.allStatesTrue
+        };
+    });
+
+    it('should render correctly', () => {
+        const wrapper = shallow(
+            <DriftFilterValue { ...props } />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('should render with fact filter chips', () => {
+        props.factFilter = 'dog';
+        props.activeFactFilters = [ 'cat', 'mouse' ];
+
+        const wrapper = shallow(
+            <DriftFilterValue { ...props } />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('should render with state filter deselected', () => {
+        props.filterType = 'State';
+        props.stateFilters[0].selected = false;
+
+        const wrapper = shallow(
+            <DriftFilterValue { ...props } />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});

--- a/src/SmartComponents/DriftPage/DriftToolbar/DriftFilter/__tests__/__snapshots__/DriftFilterDropdown.tests.js.snap
+++ b/src/SmartComponents/DriftPage/DriftToolbar/DriftFilter/__tests__/__snapshots__/DriftFilterDropdown.tests.js.snap
@@ -1,0 +1,79 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DriftFilterValue should render with fact name 1`] = `
+<Dropdown
+  className="comparison-filter-dropdown-width"
+  dropdownItems={
+    Array [
+      <DropdownItem
+        data-ouia-component-id="fact-name-filter"
+        onClick={[Function]}
+      >
+        Fact name
+      </DropdownItem>,
+      <DropdownItem
+        data-ouia-component-id="state-filter"
+        onClick={[Function]}
+      >
+        State
+      </DropdownItem>,
+    ]
+  }
+  isOpen={false}
+  ouiaId="drift-filter-dropdown"
+  toggle={
+    <DropdownToggle
+      icon={
+        <FilterIcon
+          color="currentColor"
+          noVerticalAlign={false}
+          size="sm"
+        />
+      }
+      onToggle={[Function]}
+      ouiaId="drift-filter-toggle"
+    >
+      Fact name
+    </DropdownToggle>
+  }
+/>
+`;
+
+exports[`DriftFilterValue should render with state filter 1`] = `
+<Dropdown
+  className="comparison-filter-dropdown-width"
+  dropdownItems={
+    Array [
+      <DropdownItem
+        data-ouia-component-id="fact-name-filter"
+        onClick={[Function]}
+      >
+        Fact name
+      </DropdownItem>,
+      <DropdownItem
+        data-ouia-component-id="state-filter"
+        onClick={[Function]}
+      >
+        State
+      </DropdownItem>,
+    ]
+  }
+  isOpen={false}
+  ouiaId="drift-filter-dropdown"
+  toggle={
+    <DropdownToggle
+      icon={
+        <FilterIcon
+          color="currentColor"
+          noVerticalAlign={false}
+          size="sm"
+        />
+      }
+      onToggle={[Function]}
+      ouiaId="drift-filter-toggle"
+    >
+      State
+    </DropdownToggle>
+  }
+/>
+`;

--- a/src/SmartComponents/DriftPage/DriftToolbar/DriftFilter/__tests__/__snapshots__/DriftFilterValue.tests.js.snap
+++ b/src/SmartComponents/DriftPage/DriftToolbar/DriftFilter/__tests__/__snapshots__/DriftFilterValue.tests.js.snap
@@ -1,0 +1,94 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DriftFilterValue should render correctly 1`] = `
+<Fragment>
+  <ToolbarFilter
+    categoryName="Fact name"
+    chips={Array []}
+    showToolbarItem={true}
+  >
+    <SearchBar
+      activeFactFilters={Array []}
+      factFilter=""
+      filterByFact={[MockFunction]}
+      handleFactFilter={[MockFunction]}
+      setHistory={[MockFunction]}
+    />
+  </ToolbarFilter>
+  <ToolbarFilter
+    categoryName="State"
+    chips={
+      Array [
+        "Same",
+        "Different",
+        "Incomplete data",
+      ]
+    }
+    showToolbarItem={true}
+  />
+</Fragment>
+`;
+
+exports[`DriftFilterValue should render with fact filter chips 1`] = `
+<Fragment>
+  <ToolbarFilter
+    categoryName="Fact name"
+    chips={
+      Array [
+        "cat",
+        "mouse",
+        "dog",
+      ]
+    }
+    showToolbarItem={true}
+  >
+    <SearchBar
+      activeFactFilters={
+        Array [
+          "cat",
+          "mouse",
+        ]
+      }
+      factFilter="dog"
+      filterByFact={[MockFunction]}
+      handleFactFilter={[MockFunction]}
+      setHistory={[MockFunction]}
+    />
+  </ToolbarFilter>
+  <ToolbarFilter
+    categoryName="State"
+    chips={
+      Array [
+        "Same",
+        "Different",
+        "Incomplete data",
+      ]
+    }
+    showToolbarItem={true}
+  />
+</Fragment>
+`;
+
+exports[`DriftFilterValue should render with state filter deselected 1`] = `
+<Fragment>
+  <ToolbarFilter
+    categoryName="Fact name"
+    chips={Array []}
+    showToolbarItem={true}
+  />
+  <ToolbarFilter
+    categoryName="State"
+    chips={
+      Array [
+        "Different",
+        "Incomplete data",
+      ]
+    }
+    showToolbarItem={true}
+  >
+    <Connect(FilterDropDown)
+      setHistory={[MockFunction]}
+    />
+  </ToolbarFilter>
+</Fragment>
+`;

--- a/src/SmartComponents/DriftPage/DriftToolbar/DriftToolbar.js
+++ b/src/SmartComponents/DriftPage/DriftToolbar/DriftToolbar.js
@@ -2,13 +2,12 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import { DropdownItem, PaginationVariant, Toolbar, ToolbarGroup, ToolbarItem,
-    ToolbarContent, ToolbarFilter } from '@patternfly/react-core';
+    ToolbarContent } from '@patternfly/react-core';
 
-import FilterDropDown from '../FilterDropDown/FilterDropDown';
-import SearchBar from '../SearchBar/SearchBar';
 import ActionKebab from '../ActionKebab/ActionKebab';
 import AddSystemButton from '../AddSystemButton/AddSystemButton';
 import ExportCSVButton from '../../ExportCSVButton/ExportCSVButton';
+import DriftFilter from './DriftFilter/DriftFilter';
 import { TablePagination } from '../../Pagination/Pagination';
 
 export class DriftToolbar extends Component {
@@ -46,29 +45,6 @@ export class DriftToolbar extends Component {
         };
     }
 
-    setFactFilterChips = () => {
-        const { activeFactFilters, factFilter } = this.props;
-        let factFilterChips = [ ...activeFactFilters ];
-
-        if (factFilter.length && !activeFactFilters.includes(factFilter)) {
-            factFilterChips.push(factFilter);
-        }
-
-        return factFilterChips;
-    }
-
-    setStateChips = (stateFilters) => {
-        let stateChips = [];
-
-        stateFilters.forEach(function(filter) {
-            if (filter.selected) {
-                stateChips.push(filter.display);
-            }
-        });
-
-        return stateChips;
-    }
-
     clearAllStateChips = async () => {
         const { addStateFilter, stateFilters } = this.props;
 
@@ -78,41 +54,11 @@ export class DriftToolbar extends Component {
         });
     }
 
-    removeChip = async (type = '', id = '') => {
-        const { activeFactFilters, addStateFilter, clearAllFactFilters, filterByFact, handleFactFilter, setHistory, stateFilters } = this.props;
-
-        if (type === 'State') {
-            if (id === '') {
-                this.clearAllStateChips();
-            } else {
-                stateFilters.forEach(async function(stateFilter) {
-                    if (stateFilter.display === id) {
-                        await addStateFilter(stateFilter);
-                    }
-                });
-            }
-        } else {
-            if (id === '') {
-                await clearAllFactFilters();
-            } else if (activeFactFilters.includes(id)) {
-                await handleFactFilter(id);
-            } else {
-                await filterByFact('');
-            }
-        }
-
-        setHistory();
-    }
-
     resetFilters = async () => {
         const { resetComparisonFilters, setHistory } = this.props;
 
         await resetComparisonFilters();
         setHistory();
-    }
-
-    setIsEmpty = (isEmpty) => {
-        this.setState({ isEmpty });
     }
 
     onToggle = () => {
@@ -142,39 +88,49 @@ export class DriftToolbar extends Component {
 
     }
 
+    removeChip = async (type = '', id = '') => {
+        const { activeFactFilters, addStateFilter, clearAllFactFilters, handleFactFilter, filterByFact, setHistory, stateFilters } = this.props;
+        if (type === 'State') {
+            if (id === '') {
+                this.clearAllStateChips();
+            } else {
+                stateFilters.forEach(async function(stateFilter) {
+                    if (stateFilter.display === id) {
+                        await addStateFilter(stateFilter);
+                    }
+                });
+            }
+        } else {
+            if (id === '') {
+                await clearAllFactFilters();
+            } else if (activeFactFilters.includes(id)) {
+                await handleFactFilter(id);
+            } else {
+                await filterByFact('');
+            }
+        }
+
+        setHistory();
+    }
+
     render() {
-        const { activeFactFilters, factFilter, filterByFact, handleFactFilter, loading, page, perPage,
-            setHistory, stateFilters, totalFacts, updatePagination } = this.props;
+        const { activeFactFilters, factFilter, filterByFact, handleFactFilter, loading,
+            page, perPage, setHistory, stateFilters, totalFacts, updatePagination } = this.props;
         const { actionKebabItems, dropdownItems, dropdownOpen } = this.state;
 
         return (
             <React.Fragment>
                 <Toolbar className="drift-toolbar" clearAllFilters={ this.resetFilters } clearFiltersButtonText='Reset filters'>
                     <ToolbarContent>
-                        <ToolbarGroup variant='filter-group'>
-                            <ToolbarFilter
-                                chips={ this.setFactFilterChips() }
-                                deleteChip={ this.removeChip }
-                                deleteChipGroup={ this.removeChip }
-                                categoryName="Fact name"
-                            >
-                                <SearchBar
-                                    factFilter={ factFilter }
-                                    activeFactFilters={ activeFactFilters }
-                                    handleFactFilter={ handleFactFilter }
-                                    filterByFact={ filterByFact }
-                                    setHistory={ setHistory }
-                                />
-                            </ToolbarFilter>
-                            <ToolbarFilter
-                                chips={ this.setStateChips(stateFilters) }
-                                deleteChip={ this.removeChip }
-                                deleteChipGroup={ this.removeChip }
-                                categoryName="State"
-                            >
-                                <FilterDropDown setHistory={ setHistory } />
-                            </ToolbarFilter>
-                        </ToolbarGroup>
+                        <DriftFilter
+                            activeFactFilters={ activeFactFilters }
+                            factFilter={ factFilter }
+                            filterByFact={ filterByFact }
+                            handleFactFilter={ handleFactFilter }
+                            removeChip={ this.removeChip }
+                            setHistory={ setHistory }
+                            stateFilters={ stateFilters }
+                        />
                         <ToolbarGroup variant='button-group'>
                             <ToolbarItem>
                                 <AddSystemButton loading={ loading } isToolbar={ true } />

--- a/src/SmartComponents/DriftPage/DriftToolbar/__tests__/DriftToolbar.tests.js
+++ b/src/SmartComponents/DriftPage/DriftToolbar/__tests__/DriftToolbar.tests.js
@@ -40,7 +40,7 @@ describe('DriftToolbar', () => {
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 
-    it('should render with fact filter chips', () => {
+    /*it('should render with fact filter chips', () => {
         props.factFilter = 'dog';
         props.activeFactFilters = [ 'cat', 'mouse' ];
 
@@ -49,7 +49,7 @@ describe('DriftToolbar', () => {
         );
 
         expect(toJson(wrapper)).toMatchSnapshot();
-    });
+    });*/
 
     it('should call clearComparisonFilters', () => {
         const wrapper = shallow(
@@ -157,14 +157,5 @@ describe('DriftToolbar', () => {
         );
         wrapper.find('.pf-c-button').simulate('click');
         expect(props.clearComparisonFilters).toHaveBeenCalled();
-    });
-
-    it('should set isEmpty', () => {
-        const wrapper = shallow(
-            <DriftToolbar { ...props } />
-        );
-
-        wrapper.instance().setIsEmpty(false);
-        expect(wrapper.state('isEmpty')).toEqual(false);
     });
 });

--- a/src/SmartComponents/DriftPage/DriftToolbar/__tests__/__snapshots__/DriftToolbar.tests.js.snap
+++ b/src/SmartComponents/DriftPage/DriftToolbar/__tests__/__snapshots__/DriftToolbar.tests.js.snap
@@ -132,179 +132,33 @@ exports[`DriftToolbar should render correctly 1`] = `
       isExpanded={false}
       showClearFiltersButton={false}
     >
-      <ForwardRef
-        variant="filter-group"
-      >
-        <ToolbarFilter
-          categoryName="Fact name"
-          chips={Array []}
-          deleteChip={[Function]}
-          deleteChipGroup={[Function]}
-          showToolbarItem={true}
-        >
-          <SearchBar
-            activeFactFilters={Array []}
-            factFilter=""
-            filterByFact={[MockFunction]}
-            handleFactFilter={[MockFunction]}
-            setHistory={[MockFunction]}
-          />
-        </ToolbarFilter>
-        <ToolbarFilter
-          categoryName="State"
-          chips={
-            Array [
-              "Same",
-              "Different",
-              "Incomplete data",
-            ]
-          }
-          deleteChip={[Function]}
-          deleteChipGroup={[Function]}
-          showToolbarItem={true}
-        >
-          <Connect(FilterDropDown)
-            setHistory={[MockFunction]}
-          />
-        </ToolbarFilter>
-      </ForwardRef>
-      <ForwardRef
-        variant="button-group"
-      >
-        <ToolbarItem>
-          <Connect(AddSystemButton)
-            isToolbar={true}
-            loading={false}
-          />
-        </ToolbarItem>
-      </ForwardRef>
-      <ForwardRef
-        variant="icon-button-group"
-      >
-        <ToolbarItem>
-          <ExportCSVButton
-            dropdownItems={
-              Array [
-                <DropdownItem
-                  component="button"
-                  data-ouia-component-id="export-to-csv-dropdown-item-comparison"
-                  onClick={[Function]}
-                >
-                  Export to CSV
-                </DropdownItem>,
-                <DropdownItem
-                  component="button"
-                  data-ouia-component-id="export-to-json-dropdown-item-comparison"
-                  onClick={[Function]}
-                >
-                  Export to JSON
-                </DropdownItem>,
-              ]
-            }
-            isOpen={false}
-            onToggle={[Function]}
-            ouiaId="export-dropdown-comparison"
-          />
-        </ToolbarItem>
-        <ToolbarItem>
-          <ActionKebab
-            dropdownItems={
-              Array [
-                <DropdownItem
-                  component="button"
-                  data-ouia-component-id="clear-all-comparisons-dropdown-item"
-                  onClick={[Function]}
-                >
-                  Clear all comparisons
-                </DropdownItem>,
-              ]
-            }
-            ouiaId="clear-comparison-dropdown"
-          />
-        </ToolbarItem>
-      </ForwardRef>
-      <ToolbarItem
-        align={
-          Object {
-            "default": "alignRight",
-          }
+      <DriftFilter
+        activeFactFilters={Array []}
+        factFilter=""
+        filterByFact={[MockFunction]}
+        handleFactFilter={[MockFunction]}
+        removeChip={[Function]}
+        setHistory={[MockFunction]}
+        stateFilters={
+          Array [
+            Object {
+              "display": "Same",
+              "filter": "SAME",
+              "selected": true,
+            },
+            Object {
+              "display": "Different",
+              "filter": "DIFFERENT",
+              "selected": true,
+            },
+            Object {
+              "display": "Incomplete data",
+              "filter": "INCOMPLETE_DATA",
+              "selected": true,
+            },
+          ]
         }
-        variant="pagination"
-      >
-        <TablePagination
-          isCompact={true}
-          ouiaId="comparison-pagination-top"
-          page={1}
-          perPage={50}
-          total={30}
-          updatePagination={[MockFunction]}
-          variant="top"
-          widgetId="drift-pagination-top"
-        />
-      </ToolbarItem>
-    </ToolbarContent>
-  </Toolbar>
-</Fragment>
-`;
-
-exports[`DriftToolbar should render with fact filter chips 1`] = `
-<Fragment>
-  <Toolbar
-    className="drift-toolbar"
-    clearAllFilters={[Function]}
-    clearFiltersButtonText="Reset filters"
-  >
-    <ToolbarContent
-      isExpanded={false}
-      showClearFiltersButton={false}
-    >
-      <ForwardRef
-        variant="filter-group"
-      >
-        <ToolbarFilter
-          categoryName="Fact name"
-          chips={
-            Array [
-              "cat",
-              "mouse",
-              "dog",
-            ]
-          }
-          deleteChip={[Function]}
-          deleteChipGroup={[Function]}
-          showToolbarItem={true}
-        >
-          <SearchBar
-            activeFactFilters={
-              Array [
-                "cat",
-                "mouse",
-              ]
-            }
-            factFilter="dog"
-            filterByFact={[MockFunction]}
-            handleFactFilter={[MockFunction]}
-            setHistory={[MockFunction]}
-          />
-        </ToolbarFilter>
-        <ToolbarFilter
-          categoryName="State"
-          chips={
-            Array [
-              "Same",
-              "Different",
-              "Incomplete data",
-            ]
-          }
-          deleteChip={[Function]}
-          deleteChipGroup={[Function]}
-          showToolbarItem={true}
-        >
-          <Connect(FilterDropDown)
-            setHistory={[MockFunction]}
-          />
-        </ToolbarFilter>
-      </ForwardRef>
+      />
       <ForwardRef
         variant="button-group"
       >

--- a/src/SmartComponents/DriftPage/__tests__/__snapshots__/DriftPage.tests.js.snap
+++ b/src/SmartComponents/DriftPage/__tests__/__snapshots__/DriftPage.tests.js.snap
@@ -348,1245 +348,1285 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
                                       <div
                                         className="pf-c-toolbar__content-section"
                                       >
-                                        <ForwardRef
-                                          variant="filter-group"
+                                        <DriftFilter
+                                          activeFactFilters={Array []}
+                                          factFilter=""
+                                          filterByFact={[Function]}
+                                          handleFactFilter={[Function]}
+                                          removeChip={[Function]}
+                                          setHistory={[Function]}
+                                          stateFilters={
+                                            Array [
+                                              Object {
+                                                "display": "Same",
+                                                "filter": "SAME",
+                                                "selected": true,
+                                              },
+                                              Object {
+                                                "display": "Different",
+                                                "filter": "DIFFERENT",
+                                                "selected": true,
+                                              },
+                                              Object {
+                                                "display": "Incomplete data",
+                                                "filter": "INCOMPLETE_DATA",
+                                                "selected": true,
+                                              },
+                                            ]
+                                          }
                                         >
-                                          <ToolbarGroupWithRef
-                                            innerRef={null}
+                                          <ForwardRef
                                             variant="filter-group"
                                           >
-                                            <div
-                                              className="pf-c-toolbar__group pf-m-filter-group"
+                                            <ToolbarGroupWithRef
+                                              innerRef={null}
+                                              variant="filter-group"
                                             >
-                                              <ToolbarFilter
-                                                categoryName="Fact name"
-                                                chips={Array []}
-                                                deleteChip={[Function]}
-                                                deleteChipGroup={[Function]}
-                                                showToolbarItem={true}
+                                              <div
+                                                className="pf-c-toolbar__group pf-m-filter-group"
                                               >
-                                                <ToolbarItem>
-                                                  <div
-                                                    className="pf-c-toolbar__item"
-                                                  >
-                                                    <SearchBar
-                                                      activeFactFilters={Array []}
-                                                      factFilter=""
-                                                      filterByFact={[Function]}
-                                                      handleFactFilter={[Function]}
-                                                      setHistory={[Function]}
-                                                    >
-                                                      <Form>
-                                                        <form
-                                                          className="pf-c-form"
-                                                          noValidate={true}
+                                                <DriftFilterDropdown
+                                                  filterType="Fact name"
+                                                  toggleFilterType={[Function]}
+                                                >
+                                                  <Dropdown
+                                                    className="comparison-filter-dropdown-width"
+                                                    dropdownItems={
+                                                      Array [
+                                                        <DropdownItem
+                                                          data-ouia-component-id="fact-name-filter"
+                                                          onClick={[Function]}
                                                         >
-                                                          <FormGroup
-                                                            fieldId="filter"
-                                                            isRequired={true}
-                                                            onKeyPress={[Function]}
-                                                            type="text"
+                                                          Fact name
+                                                        </DropdownItem>,
+                                                        <DropdownItem
+                                                          data-ouia-component-id="state-filter"
+                                                          onClick={[Function]}
+                                                        >
+                                                          State
+                                                        </DropdownItem>,
+                                                      ]
+                                                    }
+                                                    isOpen={false}
+                                                    ouiaId="drift-filter-dropdown"
+                                                    toggle={
+                                                      <DropdownToggle
+                                                        icon={
+                                                          <FilterIcon
+                                                            color="currentColor"
+                                                            noVerticalAlign={false}
+                                                            size="sm"
+                                                          />
+                                                        }
+                                                        onToggle={[Function]}
+                                                        ouiaId="drift-filter-toggle"
+                                                      >
+                                                        Fact name
+                                                      </DropdownToggle>
+                                                    }
+                                                  >
+                                                    <DropdownWithContext
+                                                      autoFocus={true}
+                                                      className="comparison-filter-dropdown-width"
+                                                      direction="down"
+                                                      dropdownItems={
+                                                        Array [
+                                                          <DropdownItem
+                                                            data-ouia-component-id="fact-name-filter"
+                                                            onClick={[Function]}
                                                           >
-                                                            <div
-                                                              className="pf-c-form__group"
-                                                              onKeyPress={[Function]}
-                                                              type="text"
-                                                            >
-                                                              <div
-                                                                className="pf-c-form__group-control"
-                                                              >
-                                                                <TextInput
-                                                                  aria-label="filter by fact"
-                                                                  data-ouia-component-id="fact-filter-input-comparison"
-                                                                  data-ouia-component-type="PF4/TextInput"
-                                                                  id="filterByFact"
-                                                                  onChange={[Function]}
-                                                                  placeholder="Filter by fact"
-                                                                  value=""
-                                                                >
-                                                                  <TextInputBase
-                                                                    aria-label="filter by fact"
-                                                                    className=""
-                                                                    data-ouia-component-id="fact-filter-input-comparison"
-                                                                    data-ouia-component-type="PF4/TextInput"
-                                                                    id="filterByFact"
-                                                                    innerRef={null}
-                                                                    isDisabled={false}
-                                                                    isLeftTruncated={false}
-                                                                    isReadOnly={false}
-                                                                    isRequired={false}
-                                                                    onChange={[Function]}
-                                                                    ouiaSafe={true}
-                                                                    placeholder="Filter by fact"
-                                                                    type="text"
-                                                                    validated="default"
-                                                                    value=""
-                                                                  >
-                                                                    <input
-                                                                      aria-invalid={false}
-                                                                      aria-label="filter by fact"
-                                                                      className="pf-c-form-control"
-                                                                      data-ouia-component-id="OUIA-Generated-TextInputBase-2"
-                                                                      data-ouia-component-type="PF4/TextInput"
-                                                                      data-ouia-safe={true}
-                                                                      disabled={false}
-                                                                      id="filterByFact"
-                                                                      onBlur={[Function]}
-                                                                      onChange={[Function]}
-                                                                      onFocus={[Function]}
-                                                                      placeholder="Filter by fact"
-                                                                      readOnly={false}
-                                                                      required={false}
-                                                                      type="text"
-                                                                      value=""
-                                                                    />
-                                                                  </TextInputBase>
-                                                                </TextInput>
-                                                              </div>
-                                                            </div>
-                                                          </FormGroup>
-                                                        </form>
-                                                      </Form>
-                                                    </SearchBar>
-                                                  </div>
-                                                </ToolbarItem>
-                                                <Portal
-                                                  containerInfo={
-                                                    <div
-                                                      class="pf-c-toolbar__group"
+                                                            Fact name
+                                                          </DropdownItem>,
+                                                          <DropdownItem
+                                                            data-ouia-component-id="state-filter"
+                                                            onClick={[Function]}
+                                                          >
+                                                            State
+                                                          </DropdownItem>,
+                                                        ]
+                                                      }
+                                                      isGrouped={false}
+                                                      isOpen={false}
+                                                      isPlain={false}
+                                                      menuAppendTo="inline"
+                                                      onSelect={[Function]}
+                                                      position="left"
+                                                      toggle={
+                                                        <DropdownToggle
+                                                          icon={
+                                                            <FilterIcon
+                                                              color="currentColor"
+                                                              noVerticalAlign={false}
+                                                              size="sm"
+                                                            />
+                                                          }
+                                                          onToggle={[Function]}
+                                                          ouiaId="drift-filter-toggle"
+                                                        >
+                                                          Fact name
+                                                        </DropdownToggle>
+                                                      }
                                                     >
                                                       <div
-                                                        class="pf-c-toolbar__item pf-m-chip-group"
+                                                        className="pf-c-dropdown comparison-filter-dropdown-width"
+                                                        data-ouia-component-id="drift-filter-dropdown"
+                                                        data-ouia-component-type="PF4/Dropdown"
+                                                        data-ouia-safe={true}
                                                       >
-                                                        <div
-                                                          class="pf-c-chip-group pf-m-category"
-                                                          data-ouia-component-type="PF4/ChipGroup"
-                                                          data-ouia-safe="true"
-                                                        >
-                                                          <div
-                                                            class="pf-c-chip-group__main"
-                                                          >
-                                                            <span
-                                                              aria-hidden="true"
-                                                              class="pf-c-chip-group__label"
-                                                              id="pf-random-id-2"
-                                                            >
-                                                              State
-                                                            </span>
-                                                            <ul
-                                                              aria-labelledby="pf-random-id-2"
-                                                              class="pf-c-chip-group__list"
-                                                              role="list"
-                                                            >
-                                                              <li
-                                                                class="pf-c-chip-group__list-item"
-                                                              >
-                                                                <div
-                                                                  class="pf-c-chip"
-                                                                  data-ouia-component-id="OUIA-Generated-Chip-1"
-                                                                  data-ouia-component-type="PF4/Chip"
-                                                                  data-ouia-safe="true"
-                                                                >
-                                                                  <span
-                                                                    class="pf-c-chip__text"
-                                                                    id="pf-random-id-3"
-                                                                  >
-                                                                    Same
-                                                                  </span>
-                                                                  <button
-                                                                    aria-disabled="false"
-                                                                    aria-label="close"
-                                                                    aria-labelledby="remove_pf-random-id-3 pf-random-id-3"
-                                                                    class="pf-c-button pf-m-plain"
-                                                                    data-ouia-component-id="close"
-                                                                    data-ouia-component-type="PF4/Button"
-                                                                    data-ouia-safe="true"
-                                                                    id="remove_pf-random-id-3"
-                                                                    type="button"
-                                                                  >
-                                                                    <svg
-                                                                      aria-hidden="true"
-                                                                      fill="currentColor"
-                                                                      height="1em"
-                                                                      role="img"
-                                                                      style="vertical-align: -0.125em;"
-                                                                      viewBox="0 0 352 512"
-                                                                      width="1em"
-                                                                    >
-                                                                      <path
-                                                                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                                                                      />
-                                                                    </svg>
-                                                                  </button>
-                                                                </div>
-                                                              </li>
-                                                              <li
-                                                                class="pf-c-chip-group__list-item"
-                                                              >
-                                                                <div
-                                                                  class="pf-c-chip"
-                                                                  data-ouia-component-id="OUIA-Generated-Chip-2"
-                                                                  data-ouia-component-type="PF4/Chip"
-                                                                  data-ouia-safe="true"
-                                                                >
-                                                                  <span
-                                                                    class="pf-c-chip__text"
-                                                                    id="pf-random-id-4"
-                                                                  >
-                                                                    Different
-                                                                  </span>
-                                                                  <button
-                                                                    aria-disabled="false"
-                                                                    aria-label="close"
-                                                                    aria-labelledby="remove_pf-random-id-4 pf-random-id-4"
-                                                                    class="pf-c-button pf-m-plain"
-                                                                    data-ouia-component-id="close"
-                                                                    data-ouia-component-type="PF4/Button"
-                                                                    data-ouia-safe="true"
-                                                                    id="remove_pf-random-id-4"
-                                                                    type="button"
-                                                                  >
-                                                                    <svg
-                                                                      aria-hidden="true"
-                                                                      fill="currentColor"
-                                                                      height="1em"
-                                                                      role="img"
-                                                                      style="vertical-align: -0.125em;"
-                                                                      viewBox="0 0 352 512"
-                                                                      width="1em"
-                                                                    >
-                                                                      <path
-                                                                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                                                                      />
-                                                                    </svg>
-                                                                  </button>
-                                                                </div>
-                                                              </li>
-                                                              <li
-                                                                class="pf-c-chip-group__list-item"
-                                                              >
-                                                                <div
-                                                                  class="pf-c-chip"
-                                                                  data-ouia-component-id="OUIA-Generated-Chip-3"
-                                                                  data-ouia-component-type="PF4/Chip"
-                                                                  data-ouia-safe="true"
-                                                                >
-                                                                  <span
-                                                                    class="pf-c-chip__text"
-                                                                    id="pf-random-id-5"
-                                                                  >
-                                                                    Incomplete data
-                                                                  </span>
-                                                                  <button
-                                                                    aria-disabled="false"
-                                                                    aria-label="close"
-                                                                    aria-labelledby="remove_pf-random-id-5 pf-random-id-5"
-                                                                    class="pf-c-button pf-m-plain"
-                                                                    data-ouia-component-id="close"
-                                                                    data-ouia-component-type="PF4/Button"
-                                                                    data-ouia-safe="true"
-                                                                    id="remove_pf-random-id-5"
-                                                                    type="button"
-                                                                  >
-                                                                    <svg
-                                                                      aria-hidden="true"
-                                                                      fill="currentColor"
-                                                                      height="1em"
-                                                                      role="img"
-                                                                      style="vertical-align: -0.125em;"
-                                                                      viewBox="0 0 352 512"
-                                                                      width="1em"
-                                                                    >
-                                                                      <path
-                                                                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                                                                      />
-                                                                    </svg>
-                                                                  </button>
-                                                                </div>
-                                                              </li>
-                                                            </ul>
-                                                          </div>
-                                                          <div
-                                                            class="pf-c-chip-group__close"
-                                                          >
-                                                            <button
-                                                              aria-disabled="false"
-                                                              aria-label="Close chip group"
-                                                              aria-labelledby="remove_group_pf-random-id-2 pf-random-id-2"
-                                                              class="pf-c-button pf-m-plain"
-                                                              data-ouia-component-id="Close chip group"
-                                                              data-ouia-component-type="PF4/Button"
-                                                              data-ouia-safe="true"
-                                                              id="remove_group_pf-random-id-2"
-                                                              type="button"
-                                                            >
-                                                              <svg
-                                                                aria-hidden="true"
-                                                                fill="currentColor"
-                                                                height="1em"
-                                                                role="img"
-                                                                style="vertical-align: -0.125em;"
-                                                                viewBox="0 0 512 512"
-                                                                width="1em"
-                                                              >
-                                                                <path
-                                                                  d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
-                                                                />
-                                                              </svg>
-                                                            </button>
-                                                          </div>
-                                                        </div>
-                                                      </div>
-                                                    </div>
-                                                  }
-                                                />
-                                              </ToolbarFilter>
-                                              <ToolbarFilter
-                                                categoryName="State"
-                                                chips={
-                                                  Array [
-                                                    "Same",
-                                                    "Different",
-                                                    "Incomplete data",
-                                                  ]
-                                                }
-                                                deleteChip={[Function]}
-                                                deleteChipGroup={[Function]}
-                                                showToolbarItem={true}
-                                              >
-                                                <ToolbarItem>
-                                                  <div
-                                                    className="pf-c-toolbar__item"
-                                                  >
-                                                    <Connect(FilterDropDown)
-                                                      setHistory={[Function]}
-                                                    >
-                                                      <FilterDropDown
-                                                        addStateFilter={[Function]}
-                                                        setHistory={[Function]}
-                                                        stateFilters={
-                                                          Array [
-                                                            Object {
-                                                              "display": "Same",
-                                                              "filter": "SAME",
-                                                              "selected": true,
-                                                            },
-                                                            Object {
-                                                              "display": "Different",
-                                                              "filter": "DIFFERENT",
-                                                              "selected": true,
-                                                            },
-                                                            Object {
-                                                              "display": "Incomplete data",
-                                                              "filter": "INCOMPLETE_DATA",
-                                                              "selected": true,
-                                                            },
-                                                          ]
-                                                        }
-                                                        toggleDropDown={[Function]}
-                                                      >
-                                                        <Dropdown
-                                                          dropdownItems={
-                                                            Array [
-                                                              <DropdownItem
-                                                                data-ouia-component-id="state-filter-option-Same"
-                                                              >
-                                                                <Checkbox
-                                                                  className=""
-                                                                  data-ouia-component-id="state-filter-option-checkbox-Same"
-                                                                  data-ouia-component-type="PF4/Checkbox"
-                                                                  id="Same"
-                                                                  isChecked={true}
-                                                                  isDisabled={false}
-                                                                  isValid={true}
-                                                                  label="Same"
-                                                                  onChange={[Function]}
-                                                                  ouiaSafe={true}
-                                                                />
-                                                              </DropdownItem>,
-                                                              <DropdownItem
-                                                                data-ouia-component-id="state-filter-option-Different"
-                                                              >
-                                                                <Checkbox
-                                                                  className=""
-                                                                  data-ouia-component-id="state-filter-option-checkbox-Different"
-                                                                  data-ouia-component-type="PF4/Checkbox"
-                                                                  id="Different"
-                                                                  isChecked={true}
-                                                                  isDisabled={false}
-                                                                  isValid={true}
-                                                                  label="Different"
-                                                                  onChange={[Function]}
-                                                                  ouiaSafe={true}
-                                                                />
-                                                              </DropdownItem>,
-                                                              <DropdownItem
-                                                                data-ouia-component-id="state-filter-option-Incomplete data"
-                                                              >
-                                                                <Checkbox
-                                                                  className=""
-                                                                  data-ouia-component-id="state-filter-option-checkbox-Incomplete data"
-                                                                  data-ouia-component-type="PF4/Checkbox"
-                                                                  id="Incomplete data"
-                                                                  isChecked={true}
-                                                                  isDisabled={false}
-                                                                  isValid={true}
-                                                                  label="Incomplete data"
-                                                                  onChange={[Function]}
-                                                                  ouiaSafe={true}
-                                                                />
-                                                              </DropdownItem>,
-                                                            ]
+                                                        <DropdownToggle
+                                                          aria-haspopup={true}
+                                                          getMenuRef={[Function]}
+                                                          icon={
+                                                            <FilterIcon
+                                                              color="currentColor"
+                                                              noVerticalAlign={false}
+                                                              size="sm"
+                                                            />
                                                           }
-                                                          ouiaId="state-filter-dropdown"
-                                                          toggle={
-                                                            <DropdownToggle
-                                                              onToggle={[Function]}
-                                                              ouiaId="state-filter-dropdown-toggle"
-                                                            >
-                                                              View: 
-                                                              Same, Different, Incomplete data
-                                                            </DropdownToggle>
-                                                          }
-                                                        >
-                                                          <DropdownWithContext
-                                                            autoFocus={true}
-                                                            className=""
-                                                            direction="down"
-                                                            dropdownItems={
-                                                              Array [
-                                                                <DropdownItem
-                                                                  data-ouia-component-id="state-filter-option-Same"
+                                                          id="pf-dropdown-toggle-id-0"
+                                                          isOpen={false}
+                                                          isPlain={false}
+                                                          key=".0"
+                                                          onEnter={[Function]}
+                                                          onToggle={[Function]}
+                                                          ouiaId="drift-filter-toggle"
+                                                          parentRef={
+                                                            Object {
+                                                              "current": <div
+                                                                class="pf-c-dropdown comparison-filter-dropdown-width"
+                                                                data-ouia-component-id="drift-filter-dropdown"
+                                                                data-ouia-component-type="PF4/Dropdown"
+                                                                data-ouia-safe="true"
+                                                              >
+                                                                <button
+                                                                  aria-expanded="false"
+                                                                  aria-haspopup="true"
+                                                                  class="pf-c-dropdown__toggle"
+                                                                  data-ouia-component-id="drift-filter-toggle"
+                                                                  data-ouia-component-type="PF4/DropdownToggle"
+                                                                  data-ouia-safe="true"
+                                                                  id="pf-dropdown-toggle-id-0"
+                                                                  type="button"
                                                                 >
-                                                                  <Checkbox
-                                                                    className=""
-                                                                    data-ouia-component-id="state-filter-option-checkbox-Same"
-                                                                    data-ouia-component-type="PF4/Checkbox"
-                                                                    id="Same"
-                                                                    isChecked={true}
-                                                                    isDisabled={false}
-                                                                    isValid={true}
-                                                                    label="Same"
-                                                                    onChange={[Function]}
-                                                                    ouiaSafe={true}
-                                                                  />
-                                                                </DropdownItem>,
-                                                                <DropdownItem
-                                                                  data-ouia-component-id="state-filter-option-Different"
-                                                                >
-                                                                  <Checkbox
-                                                                    className=""
-                                                                    data-ouia-component-id="state-filter-option-checkbox-Different"
-                                                                    data-ouia-component-type="PF4/Checkbox"
-                                                                    id="Different"
-                                                                    isChecked={true}
-                                                                    isDisabled={false}
-                                                                    isValid={true}
-                                                                    label="Different"
-                                                                    onChange={[Function]}
-                                                                    ouiaSafe={true}
-                                                                  />
-                                                                </DropdownItem>,
-                                                                <DropdownItem
-                                                                  data-ouia-component-id="state-filter-option-Incomplete data"
-                                                                >
-                                                                  <Checkbox
-                                                                    className=""
-                                                                    data-ouia-component-id="state-filter-option-checkbox-Incomplete data"
-                                                                    data-ouia-component-type="PF4/Checkbox"
-                                                                    id="Incomplete data"
-                                                                    isChecked={true}
-                                                                    isDisabled={false}
-                                                                    isValid={true}
-                                                                    label="Incomplete data"
-                                                                    onChange={[Function]}
-                                                                    ouiaSafe={true}
-                                                                  />
-                                                                </DropdownItem>,
-                                                              ]
+                                                                  <span
+                                                                    class="pf-c-dropdown__toggle-image"
+                                                                  >
+                                                                    <svg
+                                                                      aria-hidden="true"
+                                                                      fill="currentColor"
+                                                                      height="1em"
+                                                                      role="img"
+                                                                      style="vertical-align: -0.125em;"
+                                                                      viewBox="0 0 512 512"
+                                                                      width="1em"
+                                                                    >
+                                                                      <path
+                                                                        d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
+                                                                      />
+                                                                    </svg>
+                                                                  </span>
+                                                                  <span
+                                                                    class="pf-c-dropdown__toggle-text"
+                                                                  >
+                                                                    Fact name
+                                                                  </span>
+                                                                  <span
+                                                                    class="pf-c-dropdown__toggle-icon"
+                                                                  >
+                                                                    <svg
+                                                                      aria-hidden="true"
+                                                                      fill="currentColor"
+                                                                      height="1em"
+                                                                      role="img"
+                                                                      style="vertical-align: -0.125em;"
+                                                                      viewBox="0 0 320 512"
+                                                                      width="1em"
+                                                                    >
+                                                                      <path
+                                                                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                                                      />
+                                                                    </svg>
+                                                                  </span>
+                                                                </button>
+                                                              </div>,
                                                             }
-                                                            isGrouped={false}
+                                                          }
+                                                        >
+                                                          <Toggle
+                                                            aria-haspopup={true}
+                                                            bubbleEvent={false}
+                                                            className=""
+                                                            data-ouia-component-id="drift-filter-toggle"
+                                                            data-ouia-component-type="PF4/DropdownToggle"
+                                                            data-ouia-safe={true}
+                                                            getMenuRef={[Function]}
+                                                            id="pf-dropdown-toggle-id-0"
+                                                            isActive={false}
+                                                            isDisabled={false}
                                                             isOpen={false}
                                                             isPlain={false}
-                                                            menuAppendTo="inline"
-                                                            onSelect={[Function]}
-                                                            position="left"
-                                                            toggle={
-                                                              <DropdownToggle
-                                                                onToggle={[Function]}
-                                                                ouiaId="state-filter-dropdown-toggle"
-                                                              >
-                                                                View: 
-                                                                Same, Different, Incomplete data
-                                                              </DropdownToggle>
-                                                            }
-                                                          >
-                                                            <div
-                                                              className="pf-c-dropdown"
-                                                              data-ouia-component-id="state-filter-dropdown"
-                                                              data-ouia-component-type="PF4/Dropdown"
-                                                              data-ouia-safe={true}
-                                                            >
-                                                              <DropdownToggle
-                                                                aria-haspopup={true}
-                                                                getMenuRef={[Function]}
-                                                                id="pf-dropdown-toggle-id-5"
-                                                                isOpen={false}
-                                                                isPlain={false}
-                                                                key=".0"
-                                                                onEnter={[Function]}
-                                                                onToggle={[Function]}
-                                                                ouiaId="state-filter-dropdown-toggle"
-                                                                parentRef={
-                                                                  Object {
-                                                                    "current": <div
-                                                                      class="pf-c-dropdown"
-                                                                      data-ouia-component-id="state-filter-dropdown"
-                                                                      data-ouia-component-type="PF4/Dropdown"
-                                                                      data-ouia-safe="true"
-                                                                    >
-                                                                      <button
-                                                                        aria-expanded="false"
-                                                                        aria-haspopup="true"
-                                                                        class="pf-c-dropdown__toggle"
-                                                                        data-ouia-component-id="state-filter-dropdown-toggle"
-                                                                        data-ouia-component-type="PF4/DropdownToggle"
-                                                                        data-ouia-safe="true"
-                                                                        id="pf-dropdown-toggle-id-5"
-                                                                        type="button"
-                                                                      >
-                                                                        <span
-                                                                          class="pf-c-dropdown__toggle-text"
-                                                                        >
-                                                                          View: 
-                                                                          Same, Different, Incomplete data
-                                                                        </span>
-                                                                        <span
-                                                                          class="pf-c-dropdown__toggle-icon"
-                                                                        >
-                                                                          <svg
-                                                                            aria-hidden="true"
-                                                                            fill="currentColor"
-                                                                            height="1em"
-                                                                            role="img"
-                                                                            style="vertical-align: -0.125em;"
-                                                                            viewBox="0 0 320 512"
-                                                                            width="1em"
-                                                                          >
-                                                                            <path
-                                                                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                                                            />
-                                                                          </svg>
-                                                                        </span>
-                                                                      </button>
-                                                                    </div>,
-                                                                  }
-                                                                }
-                                                              >
-                                                                <Toggle
-                                                                  aria-haspopup={true}
-                                                                  bubbleEvent={false}
-                                                                  className=""
-                                                                  data-ouia-component-id="state-filter-dropdown-toggle"
-                                                                  data-ouia-component-type="PF4/DropdownToggle"
-                                                                  data-ouia-safe={true}
-                                                                  getMenuRef={[Function]}
-                                                                  id="pf-dropdown-toggle-id-5"
-                                                                  isActive={false}
-                                                                  isDisabled={false}
-                                                                  isOpen={false}
-                                                                  isPlain={false}
-                                                                  isPrimary={false}
-                                                                  isSplitButton={false}
-                                                                  onEnter={[Function]}
-                                                                  onToggle={[Function]}
-                                                                  parentRef={
-                                                                    Object {
-                                                                      "current": <div
-                                                                        class="pf-c-dropdown"
-                                                                        data-ouia-component-id="state-filter-dropdown"
-                                                                        data-ouia-component-type="PF4/Dropdown"
-                                                                        data-ouia-safe="true"
-                                                                      >
-                                                                        <button
-                                                                          aria-expanded="false"
-                                                                          aria-haspopup="true"
-                                                                          class="pf-c-dropdown__toggle"
-                                                                          data-ouia-component-id="state-filter-dropdown-toggle"
-                                                                          data-ouia-component-type="PF4/DropdownToggle"
-                                                                          data-ouia-safe="true"
-                                                                          id="pf-dropdown-toggle-id-5"
-                                                                          type="button"
-                                                                        >
-                                                                          <span
-                                                                            class="pf-c-dropdown__toggle-text"
-                                                                          >
-                                                                            View: 
-                                                                            Same, Different, Incomplete data
-                                                                          </span>
-                                                                          <span
-                                                                            class="pf-c-dropdown__toggle-icon"
-                                                                          >
-                                                                            <svg
-                                                                              aria-hidden="true"
-                                                                              fill="currentColor"
-                                                                              height="1em"
-                                                                              role="img"
-                                                                              style="vertical-align: -0.125em;"
-                                                                              viewBox="0 0 320 512"
-                                                                              width="1em"
-                                                                            >
-                                                                              <path
-                                                                                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                                                              />
-                                                                            </svg>
-                                                                          </span>
-                                                                        </button>
-                                                                      </div>,
-                                                                    }
-                                                                  }
+                                                            isPrimary={false}
+                                                            isSplitButton={false}
+                                                            onEnter={[Function]}
+                                                            onToggle={[Function]}
+                                                            parentRef={
+                                                              Object {
+                                                                "current": <div
+                                                                  class="pf-c-dropdown comparison-filter-dropdown-width"
+                                                                  data-ouia-component-id="drift-filter-dropdown"
+                                                                  data-ouia-component-type="PF4/Dropdown"
+                                                                  data-ouia-safe="true"
                                                                 >
                                                                   <button
-                                                                    aria-expanded={false}
-                                                                    aria-haspopup={true}
-                                                                    className="pf-c-dropdown__toggle"
-                                                                    data-ouia-component-id="state-filter-dropdown-toggle"
+                                                                    aria-expanded="false"
+                                                                    aria-haspopup="true"
+                                                                    class="pf-c-dropdown__toggle"
+                                                                    data-ouia-component-id="drift-filter-toggle"
                                                                     data-ouia-component-type="PF4/DropdownToggle"
-                                                                    data-ouia-safe={true}
-                                                                    disabled={false}
-                                                                    id="pf-dropdown-toggle-id-5"
-                                                                    onClick={[Function]}
-                                                                    onKeyDown={[Function]}
+                                                                    data-ouia-safe="true"
+                                                                    id="pf-dropdown-toggle-id-0"
                                                                     type="button"
                                                                   >
                                                                     <span
-                                                                      className="pf-c-dropdown__toggle-text"
-                                                                    >
-                                                                      View: 
-                                                                      Same, Different, Incomplete data
-                                                                    </span>
-                                                                    <span
-                                                                      className="pf-c-dropdown__toggle-icon"
-                                                                    >
-                                                                      <CaretDownIcon
-                                                                        color="currentColor"
-                                                                        noVerticalAlign={false}
-                                                                        size="sm"
-                                                                      >
-                                                                        <svg
-                                                                          aria-hidden={true}
-                                                                          aria-labelledby={null}
-                                                                          fill="currentColor"
-                                                                          height="1em"
-                                                                          role="img"
-                                                                          style={
-                                                                            Object {
-                                                                              "verticalAlign": "-0.125em",
-                                                                            }
-                                                                          }
-                                                                          viewBox="0 0 320 512"
-                                                                          width="1em"
-                                                                        >
-                                                                          <path
-                                                                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                                                          />
-                                                                        </svg>
-                                                                      </CaretDownIcon>
-                                                                    </span>
-                                                                  </button>
-                                                                </Toggle>
-                                                              </DropdownToggle>
-                                                            </div>
-                                                          </DropdownWithContext>
-                                                        </Dropdown>
-                                                      </FilterDropDown>
-                                                    </Connect(FilterDropDown)>
-                                                  </div>
-                                                </ToolbarItem>
-                                                <Portal
-                                                  containerInfo={
-                                                    <div
-                                                      class="pf-c-toolbar__group"
-                                                    >
-                                                      <div
-                                                        class="pf-c-toolbar__item pf-m-chip-group"
-                                                      >
-                                                        <div
-                                                          class="pf-c-chip-group pf-m-category"
-                                                          data-ouia-component-type="PF4/ChipGroup"
-                                                          data-ouia-safe="true"
-                                                        >
-                                                          <div
-                                                            class="pf-c-chip-group__main"
-                                                          >
-                                                            <span
-                                                              aria-hidden="true"
-                                                              class="pf-c-chip-group__label"
-                                                              id="pf-random-id-2"
-                                                            >
-                                                              State
-                                                            </span>
-                                                            <ul
-                                                              aria-labelledby="pf-random-id-2"
-                                                              class="pf-c-chip-group__list"
-                                                              role="list"
-                                                            >
-                                                              <li
-                                                                class="pf-c-chip-group__list-item"
-                                                              >
-                                                                <div
-                                                                  class="pf-c-chip"
-                                                                  data-ouia-component-id="OUIA-Generated-Chip-1"
-                                                                  data-ouia-component-type="PF4/Chip"
-                                                                  data-ouia-safe="true"
-                                                                >
-                                                                  <span
-                                                                    class="pf-c-chip__text"
-                                                                    id="pf-random-id-3"
-                                                                  >
-                                                                    Same
-                                                                  </span>
-                                                                  <button
-                                                                    aria-disabled="false"
-                                                                    aria-label="close"
-                                                                    aria-labelledby="remove_pf-random-id-3 pf-random-id-3"
-                                                                    class="pf-c-button pf-m-plain"
-                                                                    data-ouia-component-id="close"
-                                                                    data-ouia-component-type="PF4/Button"
-                                                                    data-ouia-safe="true"
-                                                                    id="remove_pf-random-id-3"
-                                                                    type="button"
-                                                                  >
-                                                                    <svg
-                                                                      aria-hidden="true"
-                                                                      fill="currentColor"
-                                                                      height="1em"
-                                                                      role="img"
-                                                                      style="vertical-align: -0.125em;"
-                                                                      viewBox="0 0 352 512"
-                                                                      width="1em"
-                                                                    >
-                                                                      <path
-                                                                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                                                                      />
-                                                                    </svg>
-                                                                  </button>
-                                                                </div>
-                                                              </li>
-                                                              <li
-                                                                class="pf-c-chip-group__list-item"
-                                                              >
-                                                                <div
-                                                                  class="pf-c-chip"
-                                                                  data-ouia-component-id="OUIA-Generated-Chip-2"
-                                                                  data-ouia-component-type="PF4/Chip"
-                                                                  data-ouia-safe="true"
-                                                                >
-                                                                  <span
-                                                                    class="pf-c-chip__text"
-                                                                    id="pf-random-id-4"
-                                                                  >
-                                                                    Different
-                                                                  </span>
-                                                                  <button
-                                                                    aria-disabled="false"
-                                                                    aria-label="close"
-                                                                    aria-labelledby="remove_pf-random-id-4 pf-random-id-4"
-                                                                    class="pf-c-button pf-m-plain"
-                                                                    data-ouia-component-id="close"
-                                                                    data-ouia-component-type="PF4/Button"
-                                                                    data-ouia-safe="true"
-                                                                    id="remove_pf-random-id-4"
-                                                                    type="button"
-                                                                  >
-                                                                    <svg
-                                                                      aria-hidden="true"
-                                                                      fill="currentColor"
-                                                                      height="1em"
-                                                                      role="img"
-                                                                      style="vertical-align: -0.125em;"
-                                                                      viewBox="0 0 352 512"
-                                                                      width="1em"
-                                                                    >
-                                                                      <path
-                                                                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                                                                      />
-                                                                    </svg>
-                                                                  </button>
-                                                                </div>
-                                                              </li>
-                                                              <li
-                                                                class="pf-c-chip-group__list-item"
-                                                              >
-                                                                <div
-                                                                  class="pf-c-chip"
-                                                                  data-ouia-component-id="OUIA-Generated-Chip-3"
-                                                                  data-ouia-component-type="PF4/Chip"
-                                                                  data-ouia-safe="true"
-                                                                >
-                                                                  <span
-                                                                    class="pf-c-chip__text"
-                                                                    id="pf-random-id-5"
-                                                                  >
-                                                                    Incomplete data
-                                                                  </span>
-                                                                  <button
-                                                                    aria-disabled="false"
-                                                                    aria-label="close"
-                                                                    aria-labelledby="remove_pf-random-id-5 pf-random-id-5"
-                                                                    class="pf-c-button pf-m-plain"
-                                                                    data-ouia-component-id="close"
-                                                                    data-ouia-component-type="PF4/Button"
-                                                                    data-ouia-safe="true"
-                                                                    id="remove_pf-random-id-5"
-                                                                    type="button"
-                                                                  >
-                                                                    <svg
-                                                                      aria-hidden="true"
-                                                                      fill="currentColor"
-                                                                      height="1em"
-                                                                      role="img"
-                                                                      style="vertical-align: -0.125em;"
-                                                                      viewBox="0 0 352 512"
-                                                                      width="1em"
-                                                                    >
-                                                                      <path
-                                                                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                                                                      />
-                                                                    </svg>
-                                                                  </button>
-                                                                </div>
-                                                              </li>
-                                                            </ul>
-                                                          </div>
-                                                          <div
-                                                            class="pf-c-chip-group__close"
-                                                          >
-                                                            <button
-                                                              aria-disabled="false"
-                                                              aria-label="Close chip group"
-                                                              aria-labelledby="remove_group_pf-random-id-2 pf-random-id-2"
-                                                              class="pf-c-button pf-m-plain"
-                                                              data-ouia-component-id="Close chip group"
-                                                              data-ouia-component-type="PF4/Button"
-                                                              data-ouia-safe="true"
-                                                              id="remove_group_pf-random-id-2"
-                                                              type="button"
-                                                            >
-                                                              <svg
-                                                                aria-hidden="true"
-                                                                fill="currentColor"
-                                                                height="1em"
-                                                                role="img"
-                                                                style="vertical-align: -0.125em;"
-                                                                viewBox="0 0 512 512"
-                                                                width="1em"
-                                                              >
-                                                                <path
-                                                                  d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
-                                                                />
-                                                              </svg>
-                                                            </button>
-                                                          </div>
-                                                        </div>
-                                                      </div>
-                                                    </div>
-                                                  }
-                                                >
-                                                  <ToolbarItem
-                                                    variant="chip-group"
-                                                  >
-                                                    <div
-                                                      className="pf-c-toolbar__item pf-m-chip-group"
-                                                    >
-                                                      <ChipGroup
-                                                        aria-label="Chip group category"
-                                                        categoryName="State"
-                                                        closeBtnAriaLabel="Close chip group"
-                                                        collapsedText="\${remaining} more"
-                                                        defaultIsOpen={false}
-                                                        expandedText="Show Less"
-                                                        isClosable={true}
-                                                        key="State"
-                                                        numChips={3}
-                                                        onClick={[Function]}
-                                                        onOverflowChipClick={[Function]}
-                                                        tooltipPosition="top"
-                                                      >
-                                                        <GenerateId
-                                                          prefix="pf-random-id-"
-                                                        >
-                                                          <div
-                                                            className="pf-c-chip-group pf-m-category"
-                                                            data-ouia-component-type="PF4/ChipGroup"
-                                                            data-ouia-safe={true}
-                                                          >
-                                                            <div
-                                                              className="pf-c-chip-group__main"
-                                                            >
-                                                              <span
-                                                                aria-hidden="true"
-                                                                className="pf-c-chip-group__label"
-                                                                id="pf-random-id-2"
-                                                              >
-                                                                State
-                                                              </span>
-                                                              <ul
-                                                                aria-labelledby="pf-random-id-2"
-                                                                className="pf-c-chip-group__list"
-                                                                role="list"
-                                                              >
-                                                                <li
-                                                                  className="pf-c-chip-group__list-item"
-                                                                  key="0"
-                                                                >
-                                                                  <Chip
-                                                                    className=""
-                                                                    closeBtnAriaLabel="close"
-                                                                    component="div"
-                                                                    isOverflowChip={false}
-                                                                    isReadOnly={false}
-                                                                    key=".$Same"
-                                                                    onClick={[Function]}
-                                                                    tooltipPosition="top"
-                                                                  >
-                                                                    <GenerateId
-                                                                      prefix="pf-random-id-"
-                                                                    >
-                                                                      <div
-                                                                        className="pf-c-chip"
-                                                                        data-ouia-component-id="OUIA-Generated-Chip-1"
-                                                                        data-ouia-component-type="PF4/Chip"
-                                                                        data-ouia-safe={true}
-                                                                      >
-                                                                        <span
-                                                                          className="pf-c-chip__text"
-                                                                          id="pf-random-id-3"
-                                                                        >
-                                                                          Same
-                                                                        </span>
-                                                                        <Button
-                                                                          aria-label="close"
-                                                                          aria-labelledby="remove_pf-random-id-3 pf-random-id-3"
-                                                                          id="remove_pf-random-id-3"
-                                                                          onClick={[Function]}
-                                                                          ouiaId="close"
-                                                                          variant="plain"
-                                                                        >
-                                                                          <ButtonBase
-                                                                            aria-label="close"
-                                                                            aria-labelledby="remove_pf-random-id-3 pf-random-id-3"
-                                                                            id="remove_pf-random-id-3"
-                                                                            innerRef={null}
-                                                                            onClick={[Function]}
-                                                                            ouiaId="close"
-                                                                            variant="plain"
-                                                                          >
-                                                                            <button
-                                                                              aria-disabled={false}
-                                                                              aria-label="close"
-                                                                              aria-labelledby="remove_pf-random-id-3 pf-random-id-3"
-                                                                              className="pf-c-button pf-m-plain"
-                                                                              data-ouia-component-id="close"
-                                                                              data-ouia-component-type="PF4/Button"
-                                                                              data-ouia-safe={true}
-                                                                              disabled={false}
-                                                                              id="remove_pf-random-id-3"
-                                                                              onClick={[Function]}
-                                                                              role={null}
-                                                                              type="button"
-                                                                            >
-                                                                              <TimesIcon
-                                                                                aria-hidden="true"
-                                                                                color="currentColor"
-                                                                                noVerticalAlign={false}
-                                                                                size="sm"
-                                                                              >
-                                                                                <svg
-                                                                                  aria-hidden="true"
-                                                                                  aria-labelledby={null}
-                                                                                  fill="currentColor"
-                                                                                  height="1em"
-                                                                                  role="img"
-                                                                                  style={
-                                                                                    Object {
-                                                                                      "verticalAlign": "-0.125em",
-                                                                                    }
-                                                                                  }
-                                                                                  viewBox="0 0 352 512"
-                                                                                  width="1em"
-                                                                                >
-                                                                                  <path
-                                                                                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                                                                                  />
-                                                                                </svg>
-                                                                              </TimesIcon>
-                                                                            </button>
-                                                                          </ButtonBase>
-                                                                        </Button>
-                                                                      </div>
-                                                                    </GenerateId>
-                                                                  </Chip>
-                                                                </li>
-                                                                <li
-                                                                  className="pf-c-chip-group__list-item"
-                                                                  key="1"
-                                                                >
-                                                                  <Chip
-                                                                    className=""
-                                                                    closeBtnAriaLabel="close"
-                                                                    component="div"
-                                                                    isOverflowChip={false}
-                                                                    isReadOnly={false}
-                                                                    key=".$Different"
-                                                                    onClick={[Function]}
-                                                                    tooltipPosition="top"
-                                                                  >
-                                                                    <GenerateId
-                                                                      prefix="pf-random-id-"
-                                                                    >
-                                                                      <div
-                                                                        className="pf-c-chip"
-                                                                        data-ouia-component-id="OUIA-Generated-Chip-2"
-                                                                        data-ouia-component-type="PF4/Chip"
-                                                                        data-ouia-safe={true}
-                                                                      >
-                                                                        <span
-                                                                          className="pf-c-chip__text"
-                                                                          id="pf-random-id-4"
-                                                                        >
-                                                                          Different
-                                                                        </span>
-                                                                        <Button
-                                                                          aria-label="close"
-                                                                          aria-labelledby="remove_pf-random-id-4 pf-random-id-4"
-                                                                          id="remove_pf-random-id-4"
-                                                                          onClick={[Function]}
-                                                                          ouiaId="close"
-                                                                          variant="plain"
-                                                                        >
-                                                                          <ButtonBase
-                                                                            aria-label="close"
-                                                                            aria-labelledby="remove_pf-random-id-4 pf-random-id-4"
-                                                                            id="remove_pf-random-id-4"
-                                                                            innerRef={null}
-                                                                            onClick={[Function]}
-                                                                            ouiaId="close"
-                                                                            variant="plain"
-                                                                          >
-                                                                            <button
-                                                                              aria-disabled={false}
-                                                                              aria-label="close"
-                                                                              aria-labelledby="remove_pf-random-id-4 pf-random-id-4"
-                                                                              className="pf-c-button pf-m-plain"
-                                                                              data-ouia-component-id="close"
-                                                                              data-ouia-component-type="PF4/Button"
-                                                                              data-ouia-safe={true}
-                                                                              disabled={false}
-                                                                              id="remove_pf-random-id-4"
-                                                                              onClick={[Function]}
-                                                                              role={null}
-                                                                              type="button"
-                                                                            >
-                                                                              <TimesIcon
-                                                                                aria-hidden="true"
-                                                                                color="currentColor"
-                                                                                noVerticalAlign={false}
-                                                                                size="sm"
-                                                                              >
-                                                                                <svg
-                                                                                  aria-hidden="true"
-                                                                                  aria-labelledby={null}
-                                                                                  fill="currentColor"
-                                                                                  height="1em"
-                                                                                  role="img"
-                                                                                  style={
-                                                                                    Object {
-                                                                                      "verticalAlign": "-0.125em",
-                                                                                    }
-                                                                                  }
-                                                                                  viewBox="0 0 352 512"
-                                                                                  width="1em"
-                                                                                >
-                                                                                  <path
-                                                                                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                                                                                  />
-                                                                                </svg>
-                                                                              </TimesIcon>
-                                                                            </button>
-                                                                          </ButtonBase>
-                                                                        </Button>
-                                                                      </div>
-                                                                    </GenerateId>
-                                                                  </Chip>
-                                                                </li>
-                                                                <li
-                                                                  className="pf-c-chip-group__list-item"
-                                                                  key="2"
-                                                                >
-                                                                  <Chip
-                                                                    className=""
-                                                                    closeBtnAriaLabel="close"
-                                                                    component="div"
-                                                                    isOverflowChip={false}
-                                                                    isReadOnly={false}
-                                                                    key=".$Incomplete data"
-                                                                    onClick={[Function]}
-                                                                    tooltipPosition="top"
-                                                                  >
-                                                                    <GenerateId
-                                                                      prefix="pf-random-id-"
-                                                                    >
-                                                                      <div
-                                                                        className="pf-c-chip"
-                                                                        data-ouia-component-id="OUIA-Generated-Chip-3"
-                                                                        data-ouia-component-type="PF4/Chip"
-                                                                        data-ouia-safe={true}
-                                                                      >
-                                                                        <span
-                                                                          className="pf-c-chip__text"
-                                                                          id="pf-random-id-5"
-                                                                        >
-                                                                          Incomplete data
-                                                                        </span>
-                                                                        <Button
-                                                                          aria-label="close"
-                                                                          aria-labelledby="remove_pf-random-id-5 pf-random-id-5"
-                                                                          id="remove_pf-random-id-5"
-                                                                          onClick={[Function]}
-                                                                          ouiaId="close"
-                                                                          variant="plain"
-                                                                        >
-                                                                          <ButtonBase
-                                                                            aria-label="close"
-                                                                            aria-labelledby="remove_pf-random-id-5 pf-random-id-5"
-                                                                            id="remove_pf-random-id-5"
-                                                                            innerRef={null}
-                                                                            onClick={[Function]}
-                                                                            ouiaId="close"
-                                                                            variant="plain"
-                                                                          >
-                                                                            <button
-                                                                              aria-disabled={false}
-                                                                              aria-label="close"
-                                                                              aria-labelledby="remove_pf-random-id-5 pf-random-id-5"
-                                                                              className="pf-c-button pf-m-plain"
-                                                                              data-ouia-component-id="close"
-                                                                              data-ouia-component-type="PF4/Button"
-                                                                              data-ouia-safe={true}
-                                                                              disabled={false}
-                                                                              id="remove_pf-random-id-5"
-                                                                              onClick={[Function]}
-                                                                              role={null}
-                                                                              type="button"
-                                                                            >
-                                                                              <TimesIcon
-                                                                                aria-hidden="true"
-                                                                                color="currentColor"
-                                                                                noVerticalAlign={false}
-                                                                                size="sm"
-                                                                              >
-                                                                                <svg
-                                                                                  aria-hidden="true"
-                                                                                  aria-labelledby={null}
-                                                                                  fill="currentColor"
-                                                                                  height="1em"
-                                                                                  role="img"
-                                                                                  style={
-                                                                                    Object {
-                                                                                      "verticalAlign": "-0.125em",
-                                                                                    }
-                                                                                  }
-                                                                                  viewBox="0 0 352 512"
-                                                                                  width="1em"
-                                                                                >
-                                                                                  <path
-                                                                                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                                                                                  />
-                                                                                </svg>
-                                                                              </TimesIcon>
-                                                                            </button>
-                                                                          </ButtonBase>
-                                                                        </Button>
-                                                                      </div>
-                                                                    </GenerateId>
-                                                                  </Chip>
-                                                                </li>
-                                                              </ul>
-                                                            </div>
-                                                            <div
-                                                              className="pf-c-chip-group__close"
-                                                            >
-                                                              <Button
-                                                                aria-label="Close chip group"
-                                                                aria-labelledby="remove_group_pf-random-id-2 pf-random-id-2"
-                                                                id="remove_group_pf-random-id-2"
-                                                                onClick={[Function]}
-                                                                ouiaId="Close chip group"
-                                                                variant="plain"
-                                                              >
-                                                                <ButtonBase
-                                                                  aria-label="Close chip group"
-                                                                  aria-labelledby="remove_group_pf-random-id-2 pf-random-id-2"
-                                                                  id="remove_group_pf-random-id-2"
-                                                                  innerRef={null}
-                                                                  onClick={[Function]}
-                                                                  ouiaId="Close chip group"
-                                                                  variant="plain"
-                                                                >
-                                                                  <button
-                                                                    aria-disabled={false}
-                                                                    aria-label="Close chip group"
-                                                                    aria-labelledby="remove_group_pf-random-id-2 pf-random-id-2"
-                                                                    className="pf-c-button pf-m-plain"
-                                                                    data-ouia-component-id="Close chip group"
-                                                                    data-ouia-component-type="PF4/Button"
-                                                                    data-ouia-safe={true}
-                                                                    disabled={false}
-                                                                    id="remove_group_pf-random-id-2"
-                                                                    onClick={[Function]}
-                                                                    role={null}
-                                                                    type="button"
-                                                                  >
-                                                                    <TimesCircleIcon
-                                                                      aria-hidden="true"
-                                                                      color="currentColor"
-                                                                      noVerticalAlign={false}
-                                                                      size="sm"
+                                                                      class="pf-c-dropdown__toggle-image"
                                                                     >
                                                                       <svg
                                                                         aria-hidden="true"
-                                                                        aria-labelledby={null}
                                                                         fill="currentColor"
                                                                         height="1em"
                                                                         role="img"
-                                                                        style={
-                                                                          Object {
-                                                                            "verticalAlign": "-0.125em",
-                                                                          }
-                                                                        }
+                                                                        style="vertical-align: -0.125em;"
                                                                         viewBox="0 0 512 512"
                                                                         width="1em"
                                                                       >
                                                                         <path
-                                                                          d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
+                                                                          d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
                                                                         />
                                                                       </svg>
-                                                                    </TimesCircleIcon>
+                                                                    </span>
+                                                                    <span
+                                                                      class="pf-c-dropdown__toggle-text"
+                                                                    >
+                                                                      Fact name
+                                                                    </span>
+                                                                    <span
+                                                                      class="pf-c-dropdown__toggle-icon"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden="true"
+                                                                        fill="currentColor"
+                                                                        height="1em"
+                                                                        role="img"
+                                                                        style="vertical-align: -0.125em;"
+                                                                        viewBox="0 0 320 512"
+                                                                        width="1em"
+                                                                      >
+                                                                        <path
+                                                                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                                                        />
+                                                                      </svg>
+                                                                    </span>
                                                                   </button>
-                                                                </ButtonBase>
-                                                              </Button>
+                                                                </div>,
+                                                              }
+                                                            }
+                                                          >
+                                                            <button
+                                                              aria-expanded={false}
+                                                              aria-haspopup={true}
+                                                              className="pf-c-dropdown__toggle"
+                                                              data-ouia-component-id="drift-filter-toggle"
+                                                              data-ouia-component-type="PF4/DropdownToggle"
+                                                              data-ouia-safe={true}
+                                                              disabled={false}
+                                                              id="pf-dropdown-toggle-id-0"
+                                                              onClick={[Function]}
+                                                              onKeyDown={[Function]}
+                                                              type="button"
+                                                            >
+                                                              <span
+                                                                className="pf-c-dropdown__toggle-image"
+                                                              >
+                                                                <FilterIcon
+                                                                  color="currentColor"
+                                                                  noVerticalAlign={false}
+                                                                  size="sm"
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden={true}
+                                                                    aria-labelledby={null}
+                                                                    fill="currentColor"
+                                                                    height="1em"
+                                                                    role="img"
+                                                                    style={
+                                                                      Object {
+                                                                        "verticalAlign": "-0.125em",
+                                                                      }
+                                                                    }
+                                                                    viewBox="0 0 512 512"
+                                                                    width="1em"
+                                                                  >
+                                                                    <path
+                                                                      d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
+                                                                    />
+                                                                  </svg>
+                                                                </FilterIcon>
+                                                              </span>
+                                                              <span
+                                                                className="pf-c-dropdown__toggle-text"
+                                                              >
+                                                                Fact name
+                                                              </span>
+                                                              <span
+                                                                className="pf-c-dropdown__toggle-icon"
+                                                              >
+                                                                <CaretDownIcon
+                                                                  color="currentColor"
+                                                                  noVerticalAlign={false}
+                                                                  size="sm"
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden={true}
+                                                                    aria-labelledby={null}
+                                                                    fill="currentColor"
+                                                                    height="1em"
+                                                                    role="img"
+                                                                    style={
+                                                                      Object {
+                                                                        "verticalAlign": "-0.125em",
+                                                                      }
+                                                                    }
+                                                                    viewBox="0 0 320 512"
+                                                                    width="1em"
+                                                                  >
+                                                                    <path
+                                                                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                                                    />
+                                                                  </svg>
+                                                                </CaretDownIcon>
+                                                              </span>
+                                                            </button>
+                                                          </Toggle>
+                                                        </DropdownToggle>
+                                                      </div>
+                                                    </DropdownWithContext>
+                                                  </Dropdown>
+                                                </DriftFilterDropdown>
+                                                <DriftFilterValue
+                                                  activeFactFilters={Array []}
+                                                  factFilter=""
+                                                  filterByFact={[Function]}
+                                                  filterType="Fact name"
+                                                  handleFactFilter={[Function]}
+                                                  removeChip={[Function]}
+                                                  setHistory={[Function]}
+                                                  stateFilters={
+                                                    Array [
+                                                      Object {
+                                                        "display": "Same",
+                                                        "filter": "SAME",
+                                                        "selected": true,
+                                                      },
+                                                      Object {
+                                                        "display": "Different",
+                                                        "filter": "DIFFERENT",
+                                                        "selected": true,
+                                                      },
+                                                      Object {
+                                                        "display": "Incomplete data",
+                                                        "filter": "INCOMPLETE_DATA",
+                                                        "selected": true,
+                                                      },
+                                                    ]
+                                                  }
+                                                >
+                                                  <ToolbarFilter
+                                                    categoryName="Fact name"
+                                                    chips={Array []}
+                                                    deleteChip={[Function]}
+                                                    deleteChipGroup={[Function]}
+                                                    showToolbarItem={true}
+                                                  >
+                                                    <ToolbarItem>
+                                                      <div
+                                                        className="pf-c-toolbar__item"
+                                                      >
+                                                        <SearchBar
+                                                          activeFactFilters={Array []}
+                                                          factFilter=""
+                                                          filterByFact={[Function]}
+                                                          handleFactFilter={[Function]}
+                                                          setHistory={[Function]}
+                                                        >
+                                                          <Form>
+                                                            <form
+                                                              className="pf-c-form"
+                                                              noValidate={true}
+                                                            >
+                                                              <FormGroup
+                                                                fieldId="filter"
+                                                                isRequired={true}
+                                                                onKeyPress={[Function]}
+                                                                type="text"
+                                                              >
+                                                                <div
+                                                                  className="pf-c-form__group"
+                                                                  onKeyPress={[Function]}
+                                                                  type="text"
+                                                                >
+                                                                  <div
+                                                                    className="pf-c-form__group-control"
+                                                                  >
+                                                                    <TextInput
+                                                                      aria-label="filter by fact"
+                                                                      data-ouia-component-id="fact-filter-input-comparison"
+                                                                      data-ouia-component-type="PF4/TextInput"
+                                                                      id="filterByFact"
+                                                                      onChange={[Function]}
+                                                                      placeholder="Filter by fact"
+                                                                      value=""
+                                                                    >
+                                                                      <TextInputBase
+                                                                        aria-label="filter by fact"
+                                                                        className=""
+                                                                        data-ouia-component-id="fact-filter-input-comparison"
+                                                                        data-ouia-component-type="PF4/TextInput"
+                                                                        id="filterByFact"
+                                                                        innerRef={null}
+                                                                        isDisabled={false}
+                                                                        isLeftTruncated={false}
+                                                                        isReadOnly={false}
+                                                                        isRequired={false}
+                                                                        onChange={[Function]}
+                                                                        ouiaSafe={true}
+                                                                        placeholder="Filter by fact"
+                                                                        type="text"
+                                                                        validated="default"
+                                                                        value=""
+                                                                      >
+                                                                        <input
+                                                                          aria-invalid={false}
+                                                                          aria-label="filter by fact"
+                                                                          className="pf-c-form-control"
+                                                                          data-ouia-component-id="OUIA-Generated-TextInputBase-2"
+                                                                          data-ouia-component-type="PF4/TextInput"
+                                                                          data-ouia-safe={true}
+                                                                          disabled={false}
+                                                                          id="filterByFact"
+                                                                          onBlur={[Function]}
+                                                                          onChange={[Function]}
+                                                                          onFocus={[Function]}
+                                                                          placeholder="Filter by fact"
+                                                                          readOnly={false}
+                                                                          required={false}
+                                                                          type="text"
+                                                                          value=""
+                                                                        />
+                                                                      </TextInputBase>
+                                                                    </TextInput>
+                                                                  </div>
+                                                                </div>
+                                                              </FormGroup>
+                                                            </form>
+                                                          </Form>
+                                                        </SearchBar>
+                                                      </div>
+                                                    </ToolbarItem>
+                                                    <Portal
+                                                      containerInfo={
+                                                        <div
+                                                          class="pf-c-toolbar__group"
+                                                        >
+                                                          <div
+                                                            class="pf-c-toolbar__item pf-m-chip-group"
+                                                          >
+                                                            <div
+                                                              class="pf-c-chip-group pf-m-category"
+                                                              data-ouia-component-type="PF4/ChipGroup"
+                                                              data-ouia-safe="true"
+                                                            >
+                                                              <div
+                                                                class="pf-c-chip-group__main"
+                                                              >
+                                                                <span
+                                                                  aria-hidden="true"
+                                                                  class="pf-c-chip-group__label"
+                                                                  id="pf-random-id-2"
+                                                                >
+                                                                  State
+                                                                </span>
+                                                                <ul
+                                                                  aria-labelledby="pf-random-id-2"
+                                                                  class="pf-c-chip-group__list"
+                                                                  role="list"
+                                                                >
+                                                                  <li
+                                                                    class="pf-c-chip-group__list-item"
+                                                                  >
+                                                                    <div
+                                                                      class="pf-c-chip"
+                                                                      data-ouia-component-id="OUIA-Generated-Chip-1"
+                                                                      data-ouia-component-type="PF4/Chip"
+                                                                      data-ouia-safe="true"
+                                                                    >
+                                                                      <span
+                                                                        class="pf-c-chip__text"
+                                                                        id="pf-random-id-3"
+                                                                      >
+                                                                        Same
+                                                                      </span>
+                                                                      <button
+                                                                        aria-disabled="false"
+                                                                        aria-label="close"
+                                                                        aria-labelledby="remove_pf-random-id-3 pf-random-id-3"
+                                                                        class="pf-c-button pf-m-plain"
+                                                                        data-ouia-component-id="close"
+                                                                        data-ouia-component-type="PF4/Button"
+                                                                        data-ouia-safe="true"
+                                                                        id="remove_pf-random-id-3"
+                                                                        type="button"
+                                                                      >
+                                                                        <svg
+                                                                          aria-hidden="true"
+                                                                          fill="currentColor"
+                                                                          height="1em"
+                                                                          role="img"
+                                                                          style="vertical-align: -0.125em;"
+                                                                          viewBox="0 0 352 512"
+                                                                          width="1em"
+                                                                        >
+                                                                          <path
+                                                                            d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                                                          />
+                                                                        </svg>
+                                                                      </button>
+                                                                    </div>
+                                                                  </li>
+                                                                  <li
+                                                                    class="pf-c-chip-group__list-item"
+                                                                  >
+                                                                    <div
+                                                                      class="pf-c-chip"
+                                                                      data-ouia-component-id="OUIA-Generated-Chip-2"
+                                                                      data-ouia-component-type="PF4/Chip"
+                                                                      data-ouia-safe="true"
+                                                                    >
+                                                                      <span
+                                                                        class="pf-c-chip__text"
+                                                                        id="pf-random-id-4"
+                                                                      >
+                                                                        Different
+                                                                      </span>
+                                                                      <button
+                                                                        aria-disabled="false"
+                                                                        aria-label="close"
+                                                                        aria-labelledby="remove_pf-random-id-4 pf-random-id-4"
+                                                                        class="pf-c-button pf-m-plain"
+                                                                        data-ouia-component-id="close"
+                                                                        data-ouia-component-type="PF4/Button"
+                                                                        data-ouia-safe="true"
+                                                                        id="remove_pf-random-id-4"
+                                                                        type="button"
+                                                                      >
+                                                                        <svg
+                                                                          aria-hidden="true"
+                                                                          fill="currentColor"
+                                                                          height="1em"
+                                                                          role="img"
+                                                                          style="vertical-align: -0.125em;"
+                                                                          viewBox="0 0 352 512"
+                                                                          width="1em"
+                                                                        >
+                                                                          <path
+                                                                            d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                                                          />
+                                                                        </svg>
+                                                                      </button>
+                                                                    </div>
+                                                                  </li>
+                                                                  <li
+                                                                    class="pf-c-chip-group__list-item"
+                                                                  >
+                                                                    <div
+                                                                      class="pf-c-chip"
+                                                                      data-ouia-component-id="OUIA-Generated-Chip-3"
+                                                                      data-ouia-component-type="PF4/Chip"
+                                                                      data-ouia-safe="true"
+                                                                    >
+                                                                      <span
+                                                                        class="pf-c-chip__text"
+                                                                        id="pf-random-id-5"
+                                                                      >
+                                                                        Incomplete data
+                                                                      </span>
+                                                                      <button
+                                                                        aria-disabled="false"
+                                                                        aria-label="close"
+                                                                        aria-labelledby="remove_pf-random-id-5 pf-random-id-5"
+                                                                        class="pf-c-button pf-m-plain"
+                                                                        data-ouia-component-id="close"
+                                                                        data-ouia-component-type="PF4/Button"
+                                                                        data-ouia-safe="true"
+                                                                        id="remove_pf-random-id-5"
+                                                                        type="button"
+                                                                      >
+                                                                        <svg
+                                                                          aria-hidden="true"
+                                                                          fill="currentColor"
+                                                                          height="1em"
+                                                                          role="img"
+                                                                          style="vertical-align: -0.125em;"
+                                                                          viewBox="0 0 352 512"
+                                                                          width="1em"
+                                                                        >
+                                                                          <path
+                                                                            d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                                                          />
+                                                                        </svg>
+                                                                      </button>
+                                                                    </div>
+                                                                  </li>
+                                                                </ul>
+                                                              </div>
+                                                              <div
+                                                                class="pf-c-chip-group__close"
+                                                              >
+                                                                <button
+                                                                  aria-disabled="false"
+                                                                  aria-label="Close chip group"
+                                                                  aria-labelledby="remove_group_pf-random-id-2 pf-random-id-2"
+                                                                  class="pf-c-button pf-m-plain"
+                                                                  data-ouia-component-id="Close chip group"
+                                                                  data-ouia-component-type="PF4/Button"
+                                                                  data-ouia-safe="true"
+                                                                  id="remove_group_pf-random-id-2"
+                                                                  type="button"
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden="true"
+                                                                    fill="currentColor"
+                                                                    height="1em"
+                                                                    role="img"
+                                                                    style="vertical-align: -0.125em;"
+                                                                    viewBox="0 0 512 512"
+                                                                    width="1em"
+                                                                  >
+                                                                    <path
+                                                                      d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
+                                                                    />
+                                                                  </svg>
+                                                                </button>
+                                                              </div>
                                                             </div>
                                                           </div>
-                                                        </GenerateId>
-                                                      </ChipGroup>
-                                                    </div>
-                                                  </ToolbarItem>
-                                                </Portal>
-                                              </ToolbarFilter>
-                                            </div>
-                                          </ToolbarGroupWithRef>
-                                        </ForwardRef>
+                                                        </div>
+                                                      }
+                                                    />
+                                                  </ToolbarFilter>
+                                                  <ToolbarFilter
+                                                    categoryName="State"
+                                                    chips={
+                                                      Array [
+                                                        "Same",
+                                                        "Different",
+                                                        "Incomplete data",
+                                                      ]
+                                                    }
+                                                    deleteChip={[Function]}
+                                                    deleteChipGroup={[Function]}
+                                                    showToolbarItem={true}
+                                                  >
+                                                    <ToolbarItem>
+                                                      <div
+                                                        className="pf-c-toolbar__item"
+                                                      />
+                                                    </ToolbarItem>
+                                                    <Portal
+                                                      containerInfo={
+                                                        <div
+                                                          class="pf-c-toolbar__group"
+                                                        >
+                                                          <div
+                                                            class="pf-c-toolbar__item pf-m-chip-group"
+                                                          >
+                                                            <div
+                                                              class="pf-c-chip-group pf-m-category"
+                                                              data-ouia-component-type="PF4/ChipGroup"
+                                                              data-ouia-safe="true"
+                                                            >
+                                                              <div
+                                                                class="pf-c-chip-group__main"
+                                                              >
+                                                                <span
+                                                                  aria-hidden="true"
+                                                                  class="pf-c-chip-group__label"
+                                                                  id="pf-random-id-2"
+                                                                >
+                                                                  State
+                                                                </span>
+                                                                <ul
+                                                                  aria-labelledby="pf-random-id-2"
+                                                                  class="pf-c-chip-group__list"
+                                                                  role="list"
+                                                                >
+                                                                  <li
+                                                                    class="pf-c-chip-group__list-item"
+                                                                  >
+                                                                    <div
+                                                                      class="pf-c-chip"
+                                                                      data-ouia-component-id="OUIA-Generated-Chip-1"
+                                                                      data-ouia-component-type="PF4/Chip"
+                                                                      data-ouia-safe="true"
+                                                                    >
+                                                                      <span
+                                                                        class="pf-c-chip__text"
+                                                                        id="pf-random-id-3"
+                                                                      >
+                                                                        Same
+                                                                      </span>
+                                                                      <button
+                                                                        aria-disabled="false"
+                                                                        aria-label="close"
+                                                                        aria-labelledby="remove_pf-random-id-3 pf-random-id-3"
+                                                                        class="pf-c-button pf-m-plain"
+                                                                        data-ouia-component-id="close"
+                                                                        data-ouia-component-type="PF4/Button"
+                                                                        data-ouia-safe="true"
+                                                                        id="remove_pf-random-id-3"
+                                                                        type="button"
+                                                                      >
+                                                                        <svg
+                                                                          aria-hidden="true"
+                                                                          fill="currentColor"
+                                                                          height="1em"
+                                                                          role="img"
+                                                                          style="vertical-align: -0.125em;"
+                                                                          viewBox="0 0 352 512"
+                                                                          width="1em"
+                                                                        >
+                                                                          <path
+                                                                            d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                                                          />
+                                                                        </svg>
+                                                                      </button>
+                                                                    </div>
+                                                                  </li>
+                                                                  <li
+                                                                    class="pf-c-chip-group__list-item"
+                                                                  >
+                                                                    <div
+                                                                      class="pf-c-chip"
+                                                                      data-ouia-component-id="OUIA-Generated-Chip-2"
+                                                                      data-ouia-component-type="PF4/Chip"
+                                                                      data-ouia-safe="true"
+                                                                    >
+                                                                      <span
+                                                                        class="pf-c-chip__text"
+                                                                        id="pf-random-id-4"
+                                                                      >
+                                                                        Different
+                                                                      </span>
+                                                                      <button
+                                                                        aria-disabled="false"
+                                                                        aria-label="close"
+                                                                        aria-labelledby="remove_pf-random-id-4 pf-random-id-4"
+                                                                        class="pf-c-button pf-m-plain"
+                                                                        data-ouia-component-id="close"
+                                                                        data-ouia-component-type="PF4/Button"
+                                                                        data-ouia-safe="true"
+                                                                        id="remove_pf-random-id-4"
+                                                                        type="button"
+                                                                      >
+                                                                        <svg
+                                                                          aria-hidden="true"
+                                                                          fill="currentColor"
+                                                                          height="1em"
+                                                                          role="img"
+                                                                          style="vertical-align: -0.125em;"
+                                                                          viewBox="0 0 352 512"
+                                                                          width="1em"
+                                                                        >
+                                                                          <path
+                                                                            d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                                                          />
+                                                                        </svg>
+                                                                      </button>
+                                                                    </div>
+                                                                  </li>
+                                                                  <li
+                                                                    class="pf-c-chip-group__list-item"
+                                                                  >
+                                                                    <div
+                                                                      class="pf-c-chip"
+                                                                      data-ouia-component-id="OUIA-Generated-Chip-3"
+                                                                      data-ouia-component-type="PF4/Chip"
+                                                                      data-ouia-safe="true"
+                                                                    >
+                                                                      <span
+                                                                        class="pf-c-chip__text"
+                                                                        id="pf-random-id-5"
+                                                                      >
+                                                                        Incomplete data
+                                                                      </span>
+                                                                      <button
+                                                                        aria-disabled="false"
+                                                                        aria-label="close"
+                                                                        aria-labelledby="remove_pf-random-id-5 pf-random-id-5"
+                                                                        class="pf-c-button pf-m-plain"
+                                                                        data-ouia-component-id="close"
+                                                                        data-ouia-component-type="PF4/Button"
+                                                                        data-ouia-safe="true"
+                                                                        id="remove_pf-random-id-5"
+                                                                        type="button"
+                                                                      >
+                                                                        <svg
+                                                                          aria-hidden="true"
+                                                                          fill="currentColor"
+                                                                          height="1em"
+                                                                          role="img"
+                                                                          style="vertical-align: -0.125em;"
+                                                                          viewBox="0 0 352 512"
+                                                                          width="1em"
+                                                                        >
+                                                                          <path
+                                                                            d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                                                          />
+                                                                        </svg>
+                                                                      </button>
+                                                                    </div>
+                                                                  </li>
+                                                                </ul>
+                                                              </div>
+                                                              <div
+                                                                class="pf-c-chip-group__close"
+                                                              >
+                                                                <button
+                                                                  aria-disabled="false"
+                                                                  aria-label="Close chip group"
+                                                                  aria-labelledby="remove_group_pf-random-id-2 pf-random-id-2"
+                                                                  class="pf-c-button pf-m-plain"
+                                                                  data-ouia-component-id="Close chip group"
+                                                                  data-ouia-component-type="PF4/Button"
+                                                                  data-ouia-safe="true"
+                                                                  id="remove_group_pf-random-id-2"
+                                                                  type="button"
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden="true"
+                                                                    fill="currentColor"
+                                                                    height="1em"
+                                                                    role="img"
+                                                                    style="vertical-align: -0.125em;"
+                                                                    viewBox="0 0 512 512"
+                                                                    width="1em"
+                                                                  >
+                                                                    <path
+                                                                      d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
+                                                                    />
+                                                                  </svg>
+                                                                </button>
+                                                              </div>
+                                                            </div>
+                                                          </div>
+                                                        </div>
+                                                      }
+                                                    >
+                                                      <ToolbarItem
+                                                        variant="chip-group"
+                                                      >
+                                                        <div
+                                                          className="pf-c-toolbar__item pf-m-chip-group"
+                                                        >
+                                                          <ChipGroup
+                                                            aria-label="Chip group category"
+                                                            categoryName="State"
+                                                            closeBtnAriaLabel="Close chip group"
+                                                            collapsedText="\${remaining} more"
+                                                            defaultIsOpen={false}
+                                                            expandedText="Show Less"
+                                                            isClosable={true}
+                                                            key="State"
+                                                            numChips={3}
+                                                            onClick={[Function]}
+                                                            onOverflowChipClick={[Function]}
+                                                            tooltipPosition="top"
+                                                          >
+                                                            <GenerateId
+                                                              prefix="pf-random-id-"
+                                                            >
+                                                              <div
+                                                                className="pf-c-chip-group pf-m-category"
+                                                                data-ouia-component-type="PF4/ChipGroup"
+                                                                data-ouia-safe={true}
+                                                              >
+                                                                <div
+                                                                  className="pf-c-chip-group__main"
+                                                                >
+                                                                  <span
+                                                                    aria-hidden="true"
+                                                                    className="pf-c-chip-group__label"
+                                                                    id="pf-random-id-2"
+                                                                  >
+                                                                    State
+                                                                  </span>
+                                                                  <ul
+                                                                    aria-labelledby="pf-random-id-2"
+                                                                    className="pf-c-chip-group__list"
+                                                                    role="list"
+                                                                  >
+                                                                    <li
+                                                                      className="pf-c-chip-group__list-item"
+                                                                      key="0"
+                                                                    >
+                                                                      <Chip
+                                                                        className=""
+                                                                        closeBtnAriaLabel="close"
+                                                                        component="div"
+                                                                        isOverflowChip={false}
+                                                                        isReadOnly={false}
+                                                                        key=".$Same"
+                                                                        onClick={[Function]}
+                                                                        tooltipPosition="top"
+                                                                      >
+                                                                        <GenerateId
+                                                                          prefix="pf-random-id-"
+                                                                        >
+                                                                          <div
+                                                                            className="pf-c-chip"
+                                                                            data-ouia-component-id="OUIA-Generated-Chip-1"
+                                                                            data-ouia-component-type="PF4/Chip"
+                                                                            data-ouia-safe={true}
+                                                                          >
+                                                                            <span
+                                                                              className="pf-c-chip__text"
+                                                                              id="pf-random-id-3"
+                                                                            >
+                                                                              Same
+                                                                            </span>
+                                                                            <Button
+                                                                              aria-label="close"
+                                                                              aria-labelledby="remove_pf-random-id-3 pf-random-id-3"
+                                                                              id="remove_pf-random-id-3"
+                                                                              onClick={[Function]}
+                                                                              ouiaId="close"
+                                                                              variant="plain"
+                                                                            >
+                                                                              <ButtonBase
+                                                                                aria-label="close"
+                                                                                aria-labelledby="remove_pf-random-id-3 pf-random-id-3"
+                                                                                id="remove_pf-random-id-3"
+                                                                                innerRef={null}
+                                                                                onClick={[Function]}
+                                                                                ouiaId="close"
+                                                                                variant="plain"
+                                                                              >
+                                                                                <button
+                                                                                  aria-disabled={false}
+                                                                                  aria-label="close"
+                                                                                  aria-labelledby="remove_pf-random-id-3 pf-random-id-3"
+                                                                                  className="pf-c-button pf-m-plain"
+                                                                                  data-ouia-component-id="close"
+                                                                                  data-ouia-component-type="PF4/Button"
+                                                                                  data-ouia-safe={true}
+                                                                                  disabled={false}
+                                                                                  id="remove_pf-random-id-3"
+                                                                                  onClick={[Function]}
+                                                                                  role={null}
+                                                                                  type="button"
+                                                                                >
+                                                                                  <TimesIcon
+                                                                                    aria-hidden="true"
+                                                                                    color="currentColor"
+                                                                                    noVerticalAlign={false}
+                                                                                    size="sm"
+                                                                                  >
+                                                                                    <svg
+                                                                                      aria-hidden="true"
+                                                                                      aria-labelledby={null}
+                                                                                      fill="currentColor"
+                                                                                      height="1em"
+                                                                                      role="img"
+                                                                                      style={
+                                                                                        Object {
+                                                                                          "verticalAlign": "-0.125em",
+                                                                                        }
+                                                                                      }
+                                                                                      viewBox="0 0 352 512"
+                                                                                      width="1em"
+                                                                                    >
+                                                                                      <path
+                                                                                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                                                                      />
+                                                                                    </svg>
+                                                                                  </TimesIcon>
+                                                                                </button>
+                                                                              </ButtonBase>
+                                                                            </Button>
+                                                                          </div>
+                                                                        </GenerateId>
+                                                                      </Chip>
+                                                                    </li>
+                                                                    <li
+                                                                      className="pf-c-chip-group__list-item"
+                                                                      key="1"
+                                                                    >
+                                                                      <Chip
+                                                                        className=""
+                                                                        closeBtnAriaLabel="close"
+                                                                        component="div"
+                                                                        isOverflowChip={false}
+                                                                        isReadOnly={false}
+                                                                        key=".$Different"
+                                                                        onClick={[Function]}
+                                                                        tooltipPosition="top"
+                                                                      >
+                                                                        <GenerateId
+                                                                          prefix="pf-random-id-"
+                                                                        >
+                                                                          <div
+                                                                            className="pf-c-chip"
+                                                                            data-ouia-component-id="OUIA-Generated-Chip-2"
+                                                                            data-ouia-component-type="PF4/Chip"
+                                                                            data-ouia-safe={true}
+                                                                          >
+                                                                            <span
+                                                                              className="pf-c-chip__text"
+                                                                              id="pf-random-id-4"
+                                                                            >
+                                                                              Different
+                                                                            </span>
+                                                                            <Button
+                                                                              aria-label="close"
+                                                                              aria-labelledby="remove_pf-random-id-4 pf-random-id-4"
+                                                                              id="remove_pf-random-id-4"
+                                                                              onClick={[Function]}
+                                                                              ouiaId="close"
+                                                                              variant="plain"
+                                                                            >
+                                                                              <ButtonBase
+                                                                                aria-label="close"
+                                                                                aria-labelledby="remove_pf-random-id-4 pf-random-id-4"
+                                                                                id="remove_pf-random-id-4"
+                                                                                innerRef={null}
+                                                                                onClick={[Function]}
+                                                                                ouiaId="close"
+                                                                                variant="plain"
+                                                                              >
+                                                                                <button
+                                                                                  aria-disabled={false}
+                                                                                  aria-label="close"
+                                                                                  aria-labelledby="remove_pf-random-id-4 pf-random-id-4"
+                                                                                  className="pf-c-button pf-m-plain"
+                                                                                  data-ouia-component-id="close"
+                                                                                  data-ouia-component-type="PF4/Button"
+                                                                                  data-ouia-safe={true}
+                                                                                  disabled={false}
+                                                                                  id="remove_pf-random-id-4"
+                                                                                  onClick={[Function]}
+                                                                                  role={null}
+                                                                                  type="button"
+                                                                                >
+                                                                                  <TimesIcon
+                                                                                    aria-hidden="true"
+                                                                                    color="currentColor"
+                                                                                    noVerticalAlign={false}
+                                                                                    size="sm"
+                                                                                  >
+                                                                                    <svg
+                                                                                      aria-hidden="true"
+                                                                                      aria-labelledby={null}
+                                                                                      fill="currentColor"
+                                                                                      height="1em"
+                                                                                      role="img"
+                                                                                      style={
+                                                                                        Object {
+                                                                                          "verticalAlign": "-0.125em",
+                                                                                        }
+                                                                                      }
+                                                                                      viewBox="0 0 352 512"
+                                                                                      width="1em"
+                                                                                    >
+                                                                                      <path
+                                                                                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                                                                      />
+                                                                                    </svg>
+                                                                                  </TimesIcon>
+                                                                                </button>
+                                                                              </ButtonBase>
+                                                                            </Button>
+                                                                          </div>
+                                                                        </GenerateId>
+                                                                      </Chip>
+                                                                    </li>
+                                                                    <li
+                                                                      className="pf-c-chip-group__list-item"
+                                                                      key="2"
+                                                                    >
+                                                                      <Chip
+                                                                        className=""
+                                                                        closeBtnAriaLabel="close"
+                                                                        component="div"
+                                                                        isOverflowChip={false}
+                                                                        isReadOnly={false}
+                                                                        key=".$Incomplete data"
+                                                                        onClick={[Function]}
+                                                                        tooltipPosition="top"
+                                                                      >
+                                                                        <GenerateId
+                                                                          prefix="pf-random-id-"
+                                                                        >
+                                                                          <div
+                                                                            className="pf-c-chip"
+                                                                            data-ouia-component-id="OUIA-Generated-Chip-3"
+                                                                            data-ouia-component-type="PF4/Chip"
+                                                                            data-ouia-safe={true}
+                                                                          >
+                                                                            <span
+                                                                              className="pf-c-chip__text"
+                                                                              id="pf-random-id-5"
+                                                                            >
+                                                                              Incomplete data
+                                                                            </span>
+                                                                            <Button
+                                                                              aria-label="close"
+                                                                              aria-labelledby="remove_pf-random-id-5 pf-random-id-5"
+                                                                              id="remove_pf-random-id-5"
+                                                                              onClick={[Function]}
+                                                                              ouiaId="close"
+                                                                              variant="plain"
+                                                                            >
+                                                                              <ButtonBase
+                                                                                aria-label="close"
+                                                                                aria-labelledby="remove_pf-random-id-5 pf-random-id-5"
+                                                                                id="remove_pf-random-id-5"
+                                                                                innerRef={null}
+                                                                                onClick={[Function]}
+                                                                                ouiaId="close"
+                                                                                variant="plain"
+                                                                              >
+                                                                                <button
+                                                                                  aria-disabled={false}
+                                                                                  aria-label="close"
+                                                                                  aria-labelledby="remove_pf-random-id-5 pf-random-id-5"
+                                                                                  className="pf-c-button pf-m-plain"
+                                                                                  data-ouia-component-id="close"
+                                                                                  data-ouia-component-type="PF4/Button"
+                                                                                  data-ouia-safe={true}
+                                                                                  disabled={false}
+                                                                                  id="remove_pf-random-id-5"
+                                                                                  onClick={[Function]}
+                                                                                  role={null}
+                                                                                  type="button"
+                                                                                >
+                                                                                  <TimesIcon
+                                                                                    aria-hidden="true"
+                                                                                    color="currentColor"
+                                                                                    noVerticalAlign={false}
+                                                                                    size="sm"
+                                                                                  >
+                                                                                    <svg
+                                                                                      aria-hidden="true"
+                                                                                      aria-labelledby={null}
+                                                                                      fill="currentColor"
+                                                                                      height="1em"
+                                                                                      role="img"
+                                                                                      style={
+                                                                                        Object {
+                                                                                          "verticalAlign": "-0.125em",
+                                                                                        }
+                                                                                      }
+                                                                                      viewBox="0 0 352 512"
+                                                                                      width="1em"
+                                                                                    >
+                                                                                      <path
+                                                                                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                                                                      />
+                                                                                    </svg>
+                                                                                  </TimesIcon>
+                                                                                </button>
+                                                                              </ButtonBase>
+                                                                            </Button>
+                                                                          </div>
+                                                                        </GenerateId>
+                                                                      </Chip>
+                                                                    </li>
+                                                                  </ul>
+                                                                </div>
+                                                                <div
+                                                                  className="pf-c-chip-group__close"
+                                                                >
+                                                                  <Button
+                                                                    aria-label="Close chip group"
+                                                                    aria-labelledby="remove_group_pf-random-id-2 pf-random-id-2"
+                                                                    id="remove_group_pf-random-id-2"
+                                                                    onClick={[Function]}
+                                                                    ouiaId="Close chip group"
+                                                                    variant="plain"
+                                                                  >
+                                                                    <ButtonBase
+                                                                      aria-label="Close chip group"
+                                                                      aria-labelledby="remove_group_pf-random-id-2 pf-random-id-2"
+                                                                      id="remove_group_pf-random-id-2"
+                                                                      innerRef={null}
+                                                                      onClick={[Function]}
+                                                                      ouiaId="Close chip group"
+                                                                      variant="plain"
+                                                                    >
+                                                                      <button
+                                                                        aria-disabled={false}
+                                                                        aria-label="Close chip group"
+                                                                        aria-labelledby="remove_group_pf-random-id-2 pf-random-id-2"
+                                                                        className="pf-c-button pf-m-plain"
+                                                                        data-ouia-component-id="Close chip group"
+                                                                        data-ouia-component-type="PF4/Button"
+                                                                        data-ouia-safe={true}
+                                                                        disabled={false}
+                                                                        id="remove_group_pf-random-id-2"
+                                                                        onClick={[Function]}
+                                                                        role={null}
+                                                                        type="button"
+                                                                      >
+                                                                        <TimesCircleIcon
+                                                                          aria-hidden="true"
+                                                                          color="currentColor"
+                                                                          noVerticalAlign={false}
+                                                                          size="sm"
+                                                                        >
+                                                                          <svg
+                                                                            aria-hidden="true"
+                                                                            aria-labelledby={null}
+                                                                            fill="currentColor"
+                                                                            height="1em"
+                                                                            role="img"
+                                                                            style={
+                                                                              Object {
+                                                                                "verticalAlign": "-0.125em",
+                                                                              }
+                                                                            }
+                                                                            viewBox="0 0 512 512"
+                                                                            width="1em"
+                                                                          >
+                                                                            <path
+                                                                              d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
+                                                                            />
+                                                                          </svg>
+                                                                        </TimesCircleIcon>
+                                                                      </button>
+                                                                    </ButtonBase>
+                                                                  </Button>
+                                                                </div>
+                                                              </div>
+                                                            </GenerateId>
+                                                          </ChipGroup>
+                                                        </div>
+                                                      </ToolbarItem>
+                                                    </Portal>
+                                                  </ToolbarFilter>
+                                                </DriftFilterValue>
+                                              </div>
+                                            </ToolbarGroupWithRef>
+                                          </ForwardRef>
+                                        </DriftFilter>
                                         <ForwardRef
                                           variant="button-group"
                                         >
@@ -5011,1245 +5051,1285 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                       <div
                                         className="pf-c-toolbar__content-section"
                                       >
-                                        <ForwardRef
-                                          variant="filter-group"
+                                        <DriftFilter
+                                          activeFactFilters={Array []}
+                                          factFilter=""
+                                          filterByFact={[Function]}
+                                          handleFactFilter={[Function]}
+                                          removeChip={[Function]}
+                                          setHistory={[Function]}
+                                          stateFilters={
+                                            Array [
+                                              Object {
+                                                "display": "Same",
+                                                "filter": "SAME",
+                                                "selected": true,
+                                              },
+                                              Object {
+                                                "display": "Different",
+                                                "filter": "DIFFERENT",
+                                                "selected": true,
+                                              },
+                                              Object {
+                                                "display": "Incomplete data",
+                                                "filter": "INCOMPLETE_DATA",
+                                                "selected": true,
+                                              },
+                                            ]
+                                          }
                                         >
-                                          <ToolbarGroupWithRef
-                                            innerRef={null}
+                                          <ForwardRef
                                             variant="filter-group"
                                           >
-                                            <div
-                                              className="pf-c-toolbar__group pf-m-filter-group"
+                                            <ToolbarGroupWithRef
+                                              innerRef={null}
+                                              variant="filter-group"
                                             >
-                                              <ToolbarFilter
-                                                categoryName="Fact name"
-                                                chips={Array []}
-                                                deleteChip={[Function]}
-                                                deleteChipGroup={[Function]}
-                                                showToolbarItem={true}
+                                              <div
+                                                className="pf-c-toolbar__group pf-m-filter-group"
                                               >
-                                                <ToolbarItem>
-                                                  <div
-                                                    className="pf-c-toolbar__item"
-                                                  >
-                                                    <SearchBar
-                                                      activeFactFilters={Array []}
-                                                      factFilter=""
-                                                      filterByFact={[Function]}
-                                                      handleFactFilter={[Function]}
-                                                      setHistory={[Function]}
-                                                    >
-                                                      <Form>
-                                                        <form
-                                                          className="pf-c-form"
-                                                          noValidate={true}
+                                                <DriftFilterDropdown
+                                                  filterType="Fact name"
+                                                  toggleFilterType={[Function]}
+                                                >
+                                                  <Dropdown
+                                                    className="comparison-filter-dropdown-width"
+                                                    dropdownItems={
+                                                      Array [
+                                                        <DropdownItem
+                                                          data-ouia-component-id="fact-name-filter"
+                                                          onClick={[Function]}
                                                         >
-                                                          <FormGroup
-                                                            fieldId="filter"
-                                                            isRequired={true}
-                                                            onKeyPress={[Function]}
-                                                            type="text"
+                                                          Fact name
+                                                        </DropdownItem>,
+                                                        <DropdownItem
+                                                          data-ouia-component-id="state-filter"
+                                                          onClick={[Function]}
+                                                        >
+                                                          State
+                                                        </DropdownItem>,
+                                                      ]
+                                                    }
+                                                    isOpen={false}
+                                                    ouiaId="drift-filter-dropdown"
+                                                    toggle={
+                                                      <DropdownToggle
+                                                        icon={
+                                                          <FilterIcon
+                                                            color="currentColor"
+                                                            noVerticalAlign={false}
+                                                            size="sm"
+                                                          />
+                                                        }
+                                                        onToggle={[Function]}
+                                                        ouiaId="drift-filter-toggle"
+                                                      >
+                                                        Fact name
+                                                      </DropdownToggle>
+                                                    }
+                                                  >
+                                                    <DropdownWithContext
+                                                      autoFocus={true}
+                                                      className="comparison-filter-dropdown-width"
+                                                      direction="down"
+                                                      dropdownItems={
+                                                        Array [
+                                                          <DropdownItem
+                                                            data-ouia-component-id="fact-name-filter"
+                                                            onClick={[Function]}
                                                           >
-                                                            <div
-                                                              className="pf-c-form__group"
-                                                              onKeyPress={[Function]}
-                                                              type="text"
-                                                            >
-                                                              <div
-                                                                className="pf-c-form__group-control"
-                                                              >
-                                                                <TextInput
-                                                                  aria-label="filter by fact"
-                                                                  data-ouia-component-id="fact-filter-input-comparison"
-                                                                  data-ouia-component-type="PF4/TextInput"
-                                                                  id="filterByFact"
-                                                                  onChange={[Function]}
-                                                                  placeholder="Filter by fact"
-                                                                  value=""
-                                                                >
-                                                                  <TextInputBase
-                                                                    aria-label="filter by fact"
-                                                                    className=""
-                                                                    data-ouia-component-id="fact-filter-input-comparison"
-                                                                    data-ouia-component-type="PF4/TextInput"
-                                                                    id="filterByFact"
-                                                                    innerRef={null}
-                                                                    isDisabled={false}
-                                                                    isLeftTruncated={false}
-                                                                    isReadOnly={false}
-                                                                    isRequired={false}
-                                                                    onChange={[Function]}
-                                                                    ouiaSafe={true}
-                                                                    placeholder="Filter by fact"
-                                                                    type="text"
-                                                                    validated="default"
-                                                                    value=""
-                                                                  >
-                                                                    <input
-                                                                      aria-invalid={false}
-                                                                      aria-label="filter by fact"
-                                                                      className="pf-c-form-control"
-                                                                      data-ouia-component-id="OUIA-Generated-TextInputBase-4"
-                                                                      data-ouia-component-type="PF4/TextInput"
-                                                                      data-ouia-safe={true}
-                                                                      disabled={false}
-                                                                      id="filterByFact"
-                                                                      onBlur={[Function]}
-                                                                      onChange={[Function]}
-                                                                      onFocus={[Function]}
-                                                                      placeholder="Filter by fact"
-                                                                      readOnly={false}
-                                                                      required={false}
-                                                                      type="text"
-                                                                      value=""
-                                                                    />
-                                                                  </TextInputBase>
-                                                                </TextInput>
-                                                              </div>
-                                                            </div>
-                                                          </FormGroup>
-                                                        </form>
-                                                      </Form>
-                                                    </SearchBar>
-                                                  </div>
-                                                </ToolbarItem>
-                                                <Portal
-                                                  containerInfo={
-                                                    <div
-                                                      class="pf-c-toolbar__group"
+                                                            Fact name
+                                                          </DropdownItem>,
+                                                          <DropdownItem
+                                                            data-ouia-component-id="state-filter"
+                                                            onClick={[Function]}
+                                                          >
+                                                            State
+                                                          </DropdownItem>,
+                                                        ]
+                                                      }
+                                                      isGrouped={false}
+                                                      isOpen={false}
+                                                      isPlain={false}
+                                                      menuAppendTo="inline"
+                                                      onSelect={[Function]}
+                                                      position="left"
+                                                      toggle={
+                                                        <DropdownToggle
+                                                          icon={
+                                                            <FilterIcon
+                                                              color="currentColor"
+                                                              noVerticalAlign={false}
+                                                              size="sm"
+                                                            />
+                                                          }
+                                                          onToggle={[Function]}
+                                                          ouiaId="drift-filter-toggle"
+                                                        >
+                                                          Fact name
+                                                        </DropdownToggle>
+                                                      }
                                                     >
                                                       <div
-                                                        class="pf-c-toolbar__item pf-m-chip-group"
+                                                        className="pf-c-dropdown comparison-filter-dropdown-width"
+                                                        data-ouia-component-id="drift-filter-dropdown"
+                                                        data-ouia-component-type="PF4/Dropdown"
+                                                        data-ouia-safe={true}
                                                       >
-                                                        <div
-                                                          class="pf-c-chip-group pf-m-category"
-                                                          data-ouia-component-type="PF4/ChipGroup"
-                                                          data-ouia-safe="true"
-                                                        >
-                                                          <div
-                                                            class="pf-c-chip-group__main"
-                                                          >
-                                                            <span
-                                                              aria-hidden="true"
-                                                              class="pf-c-chip-group__label"
-                                                              id="pf-random-id-8"
-                                                            >
-                                                              State
-                                                            </span>
-                                                            <ul
-                                                              aria-labelledby="pf-random-id-8"
-                                                              class="pf-c-chip-group__list"
-                                                              role="list"
-                                                            >
-                                                              <li
-                                                                class="pf-c-chip-group__list-item"
-                                                              >
-                                                                <div
-                                                                  class="pf-c-chip"
-                                                                  data-ouia-component-id="OUIA-Generated-Chip-4"
-                                                                  data-ouia-component-type="PF4/Chip"
-                                                                  data-ouia-safe="true"
-                                                                >
-                                                                  <span
-                                                                    class="pf-c-chip__text"
-                                                                    id="pf-random-id-9"
-                                                                  >
-                                                                    Same
-                                                                  </span>
-                                                                  <button
-                                                                    aria-disabled="false"
-                                                                    aria-label="close"
-                                                                    aria-labelledby="remove_pf-random-id-9 pf-random-id-9"
-                                                                    class="pf-c-button pf-m-plain"
-                                                                    data-ouia-component-id="close"
-                                                                    data-ouia-component-type="PF4/Button"
-                                                                    data-ouia-safe="true"
-                                                                    id="remove_pf-random-id-9"
-                                                                    type="button"
-                                                                  >
-                                                                    <svg
-                                                                      aria-hidden="true"
-                                                                      fill="currentColor"
-                                                                      height="1em"
-                                                                      role="img"
-                                                                      style="vertical-align: -0.125em;"
-                                                                      viewBox="0 0 352 512"
-                                                                      width="1em"
-                                                                    >
-                                                                      <path
-                                                                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                                                                      />
-                                                                    </svg>
-                                                                  </button>
-                                                                </div>
-                                                              </li>
-                                                              <li
-                                                                class="pf-c-chip-group__list-item"
-                                                              >
-                                                                <div
-                                                                  class="pf-c-chip"
-                                                                  data-ouia-component-id="OUIA-Generated-Chip-5"
-                                                                  data-ouia-component-type="PF4/Chip"
-                                                                  data-ouia-safe="true"
-                                                                >
-                                                                  <span
-                                                                    class="pf-c-chip__text"
-                                                                    id="pf-random-id-10"
-                                                                  >
-                                                                    Different
-                                                                  </span>
-                                                                  <button
-                                                                    aria-disabled="false"
-                                                                    aria-label="close"
-                                                                    aria-labelledby="remove_pf-random-id-10 pf-random-id-10"
-                                                                    class="pf-c-button pf-m-plain"
-                                                                    data-ouia-component-id="close"
-                                                                    data-ouia-component-type="PF4/Button"
-                                                                    data-ouia-safe="true"
-                                                                    id="remove_pf-random-id-10"
-                                                                    type="button"
-                                                                  >
-                                                                    <svg
-                                                                      aria-hidden="true"
-                                                                      fill="currentColor"
-                                                                      height="1em"
-                                                                      role="img"
-                                                                      style="vertical-align: -0.125em;"
-                                                                      viewBox="0 0 352 512"
-                                                                      width="1em"
-                                                                    >
-                                                                      <path
-                                                                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                                                                      />
-                                                                    </svg>
-                                                                  </button>
-                                                                </div>
-                                                              </li>
-                                                              <li
-                                                                class="pf-c-chip-group__list-item"
-                                                              >
-                                                                <div
-                                                                  class="pf-c-chip"
-                                                                  data-ouia-component-id="OUIA-Generated-Chip-6"
-                                                                  data-ouia-component-type="PF4/Chip"
-                                                                  data-ouia-safe="true"
-                                                                >
-                                                                  <span
-                                                                    class="pf-c-chip__text"
-                                                                    id="pf-random-id-11"
-                                                                  >
-                                                                    Incomplete data
-                                                                  </span>
-                                                                  <button
-                                                                    aria-disabled="false"
-                                                                    aria-label="close"
-                                                                    aria-labelledby="remove_pf-random-id-11 pf-random-id-11"
-                                                                    class="pf-c-button pf-m-plain"
-                                                                    data-ouia-component-id="close"
-                                                                    data-ouia-component-type="PF4/Button"
-                                                                    data-ouia-safe="true"
-                                                                    id="remove_pf-random-id-11"
-                                                                    type="button"
-                                                                  >
-                                                                    <svg
-                                                                      aria-hidden="true"
-                                                                      fill="currentColor"
-                                                                      height="1em"
-                                                                      role="img"
-                                                                      style="vertical-align: -0.125em;"
-                                                                      viewBox="0 0 352 512"
-                                                                      width="1em"
-                                                                    >
-                                                                      <path
-                                                                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                                                                      />
-                                                                    </svg>
-                                                                  </button>
-                                                                </div>
-                                                              </li>
-                                                            </ul>
-                                                          </div>
-                                                          <div
-                                                            class="pf-c-chip-group__close"
-                                                          >
-                                                            <button
-                                                              aria-disabled="false"
-                                                              aria-label="Close chip group"
-                                                              aria-labelledby="remove_group_pf-random-id-8 pf-random-id-8"
-                                                              class="pf-c-button pf-m-plain"
-                                                              data-ouia-component-id="Close chip group"
-                                                              data-ouia-component-type="PF4/Button"
-                                                              data-ouia-safe="true"
-                                                              id="remove_group_pf-random-id-8"
-                                                              type="button"
-                                                            >
-                                                              <svg
-                                                                aria-hidden="true"
-                                                                fill="currentColor"
-                                                                height="1em"
-                                                                role="img"
-                                                                style="vertical-align: -0.125em;"
-                                                                viewBox="0 0 512 512"
-                                                                width="1em"
-                                                              >
-                                                                <path
-                                                                  d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
-                                                                />
-                                                              </svg>
-                                                            </button>
-                                                          </div>
-                                                        </div>
-                                                      </div>
-                                                    </div>
-                                                  }
-                                                />
-                                              </ToolbarFilter>
-                                              <ToolbarFilter
-                                                categoryName="State"
-                                                chips={
-                                                  Array [
-                                                    "Same",
-                                                    "Different",
-                                                    "Incomplete data",
-                                                  ]
-                                                }
-                                                deleteChip={[Function]}
-                                                deleteChipGroup={[Function]}
-                                                showToolbarItem={true}
-                                              >
-                                                <ToolbarItem>
-                                                  <div
-                                                    className="pf-c-toolbar__item"
-                                                  >
-                                                    <Connect(FilterDropDown)
-                                                      setHistory={[Function]}
-                                                    >
-                                                      <FilterDropDown
-                                                        addStateFilter={[Function]}
-                                                        setHistory={[Function]}
-                                                        stateFilters={
-                                                          Array [
-                                                            Object {
-                                                              "display": "Same",
-                                                              "filter": "SAME",
-                                                              "selected": true,
-                                                            },
-                                                            Object {
-                                                              "display": "Different",
-                                                              "filter": "DIFFERENT",
-                                                              "selected": true,
-                                                            },
-                                                            Object {
-                                                              "display": "Incomplete data",
-                                                              "filter": "INCOMPLETE_DATA",
-                                                              "selected": true,
-                                                            },
-                                                          ]
-                                                        }
-                                                        toggleDropDown={[Function]}
-                                                      >
-                                                        <Dropdown
-                                                          dropdownItems={
-                                                            Array [
-                                                              <DropdownItem
-                                                                data-ouia-component-id="state-filter-option-Same"
-                                                              >
-                                                                <Checkbox
-                                                                  className=""
-                                                                  data-ouia-component-id="state-filter-option-checkbox-Same"
-                                                                  data-ouia-component-type="PF4/Checkbox"
-                                                                  id="Same"
-                                                                  isChecked={true}
-                                                                  isDisabled={false}
-                                                                  isValid={true}
-                                                                  label="Same"
-                                                                  onChange={[Function]}
-                                                                  ouiaSafe={true}
-                                                                />
-                                                              </DropdownItem>,
-                                                              <DropdownItem
-                                                                data-ouia-component-id="state-filter-option-Different"
-                                                              >
-                                                                <Checkbox
-                                                                  className=""
-                                                                  data-ouia-component-id="state-filter-option-checkbox-Different"
-                                                                  data-ouia-component-type="PF4/Checkbox"
-                                                                  id="Different"
-                                                                  isChecked={true}
-                                                                  isDisabled={false}
-                                                                  isValid={true}
-                                                                  label="Different"
-                                                                  onChange={[Function]}
-                                                                  ouiaSafe={true}
-                                                                />
-                                                              </DropdownItem>,
-                                                              <DropdownItem
-                                                                data-ouia-component-id="state-filter-option-Incomplete data"
-                                                              >
-                                                                <Checkbox
-                                                                  className=""
-                                                                  data-ouia-component-id="state-filter-option-checkbox-Incomplete data"
-                                                                  data-ouia-component-type="PF4/Checkbox"
-                                                                  id="Incomplete data"
-                                                                  isChecked={true}
-                                                                  isDisabled={false}
-                                                                  isValid={true}
-                                                                  label="Incomplete data"
-                                                                  onChange={[Function]}
-                                                                  ouiaSafe={true}
-                                                                />
-                                                              </DropdownItem>,
-                                                            ]
+                                                        <DropdownToggle
+                                                          aria-haspopup={true}
+                                                          getMenuRef={[Function]}
+                                                          icon={
+                                                            <FilterIcon
+                                                              color="currentColor"
+                                                              noVerticalAlign={false}
+                                                              size="sm"
+                                                            />
                                                           }
-                                                          ouiaId="state-filter-dropdown"
-                                                          toggle={
-                                                            <DropdownToggle
-                                                              onToggle={[Function]}
-                                                              ouiaId="state-filter-dropdown-toggle"
-                                                            >
-                                                              View: 
-                                                              Same, Different, Incomplete data
-                                                            </DropdownToggle>
-                                                          }
-                                                        >
-                                                          <DropdownWithContext
-                                                            autoFocus={true}
-                                                            className=""
-                                                            direction="down"
-                                                            dropdownItems={
-                                                              Array [
-                                                                <DropdownItem
-                                                                  data-ouia-component-id="state-filter-option-Same"
+                                                          id="pf-dropdown-toggle-id-5"
+                                                          isOpen={false}
+                                                          isPlain={false}
+                                                          key=".0"
+                                                          onEnter={[Function]}
+                                                          onToggle={[Function]}
+                                                          ouiaId="drift-filter-toggle"
+                                                          parentRef={
+                                                            Object {
+                                                              "current": <div
+                                                                class="pf-c-dropdown comparison-filter-dropdown-width"
+                                                                data-ouia-component-id="drift-filter-dropdown"
+                                                                data-ouia-component-type="PF4/Dropdown"
+                                                                data-ouia-safe="true"
+                                                              >
+                                                                <button
+                                                                  aria-expanded="false"
+                                                                  aria-haspopup="true"
+                                                                  class="pf-c-dropdown__toggle"
+                                                                  data-ouia-component-id="drift-filter-toggle"
+                                                                  data-ouia-component-type="PF4/DropdownToggle"
+                                                                  data-ouia-safe="true"
+                                                                  id="pf-dropdown-toggle-id-5"
+                                                                  type="button"
                                                                 >
-                                                                  <Checkbox
-                                                                    className=""
-                                                                    data-ouia-component-id="state-filter-option-checkbox-Same"
-                                                                    data-ouia-component-type="PF4/Checkbox"
-                                                                    id="Same"
-                                                                    isChecked={true}
-                                                                    isDisabled={false}
-                                                                    isValid={true}
-                                                                    label="Same"
-                                                                    onChange={[Function]}
-                                                                    ouiaSafe={true}
-                                                                  />
-                                                                </DropdownItem>,
-                                                                <DropdownItem
-                                                                  data-ouia-component-id="state-filter-option-Different"
-                                                                >
-                                                                  <Checkbox
-                                                                    className=""
-                                                                    data-ouia-component-id="state-filter-option-checkbox-Different"
-                                                                    data-ouia-component-type="PF4/Checkbox"
-                                                                    id="Different"
-                                                                    isChecked={true}
-                                                                    isDisabled={false}
-                                                                    isValid={true}
-                                                                    label="Different"
-                                                                    onChange={[Function]}
-                                                                    ouiaSafe={true}
-                                                                  />
-                                                                </DropdownItem>,
-                                                                <DropdownItem
-                                                                  data-ouia-component-id="state-filter-option-Incomplete data"
-                                                                >
-                                                                  <Checkbox
-                                                                    className=""
-                                                                    data-ouia-component-id="state-filter-option-checkbox-Incomplete data"
-                                                                    data-ouia-component-type="PF4/Checkbox"
-                                                                    id="Incomplete data"
-                                                                    isChecked={true}
-                                                                    isDisabled={false}
-                                                                    isValid={true}
-                                                                    label="Incomplete data"
-                                                                    onChange={[Function]}
-                                                                    ouiaSafe={true}
-                                                                  />
-                                                                </DropdownItem>,
-                                                              ]
+                                                                  <span
+                                                                    class="pf-c-dropdown__toggle-image"
+                                                                  >
+                                                                    <svg
+                                                                      aria-hidden="true"
+                                                                      fill="currentColor"
+                                                                      height="1em"
+                                                                      role="img"
+                                                                      style="vertical-align: -0.125em;"
+                                                                      viewBox="0 0 512 512"
+                                                                      width="1em"
+                                                                    >
+                                                                      <path
+                                                                        d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
+                                                                      />
+                                                                    </svg>
+                                                                  </span>
+                                                                  <span
+                                                                    class="pf-c-dropdown__toggle-text"
+                                                                  >
+                                                                    Fact name
+                                                                  </span>
+                                                                  <span
+                                                                    class="pf-c-dropdown__toggle-icon"
+                                                                  >
+                                                                    <svg
+                                                                      aria-hidden="true"
+                                                                      fill="currentColor"
+                                                                      height="1em"
+                                                                      role="img"
+                                                                      style="vertical-align: -0.125em;"
+                                                                      viewBox="0 0 320 512"
+                                                                      width="1em"
+                                                                    >
+                                                                      <path
+                                                                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                                                      />
+                                                                    </svg>
+                                                                  </span>
+                                                                </button>
+                                                              </div>,
                                                             }
-                                                            isGrouped={false}
+                                                          }
+                                                        >
+                                                          <Toggle
+                                                            aria-haspopup={true}
+                                                            bubbleEvent={false}
+                                                            className=""
+                                                            data-ouia-component-id="drift-filter-toggle"
+                                                            data-ouia-component-type="PF4/DropdownToggle"
+                                                            data-ouia-safe={true}
+                                                            getMenuRef={[Function]}
+                                                            id="pf-dropdown-toggle-id-5"
+                                                            isActive={false}
+                                                            isDisabled={false}
                                                             isOpen={false}
                                                             isPlain={false}
-                                                            menuAppendTo="inline"
-                                                            onSelect={[Function]}
-                                                            position="left"
-                                                            toggle={
-                                                              <DropdownToggle
-                                                                onToggle={[Function]}
-                                                                ouiaId="state-filter-dropdown-toggle"
-                                                              >
-                                                                View: 
-                                                                Same, Different, Incomplete data
-                                                              </DropdownToggle>
-                                                            }
-                                                          >
-                                                            <div
-                                                              className="pf-c-dropdown"
-                                                              data-ouia-component-id="state-filter-dropdown"
-                                                              data-ouia-component-type="PF4/Dropdown"
-                                                              data-ouia-safe={true}
-                                                            >
-                                                              <DropdownToggle
-                                                                aria-haspopup={true}
-                                                                getMenuRef={[Function]}
-                                                                id="pf-dropdown-toggle-id-11"
-                                                                isOpen={false}
-                                                                isPlain={false}
-                                                                key=".0"
-                                                                onEnter={[Function]}
-                                                                onToggle={[Function]}
-                                                                ouiaId="state-filter-dropdown-toggle"
-                                                                parentRef={
-                                                                  Object {
-                                                                    "current": <div
-                                                                      class="pf-c-dropdown"
-                                                                      data-ouia-component-id="state-filter-dropdown"
-                                                                      data-ouia-component-type="PF4/Dropdown"
-                                                                      data-ouia-safe="true"
-                                                                    >
-                                                                      <button
-                                                                        aria-expanded="false"
-                                                                        aria-haspopup="true"
-                                                                        class="pf-c-dropdown__toggle"
-                                                                        data-ouia-component-id="state-filter-dropdown-toggle"
-                                                                        data-ouia-component-type="PF4/DropdownToggle"
-                                                                        data-ouia-safe="true"
-                                                                        id="pf-dropdown-toggle-id-11"
-                                                                        type="button"
-                                                                      >
-                                                                        <span
-                                                                          class="pf-c-dropdown__toggle-text"
-                                                                        >
-                                                                          View: 
-                                                                          Same, Different, Incomplete data
-                                                                        </span>
-                                                                        <span
-                                                                          class="pf-c-dropdown__toggle-icon"
-                                                                        >
-                                                                          <svg
-                                                                            aria-hidden="true"
-                                                                            fill="currentColor"
-                                                                            height="1em"
-                                                                            role="img"
-                                                                            style="vertical-align: -0.125em;"
-                                                                            viewBox="0 0 320 512"
-                                                                            width="1em"
-                                                                          >
-                                                                            <path
-                                                                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                                                            />
-                                                                          </svg>
-                                                                        </span>
-                                                                      </button>
-                                                                    </div>,
-                                                                  }
-                                                                }
-                                                              >
-                                                                <Toggle
-                                                                  aria-haspopup={true}
-                                                                  bubbleEvent={false}
-                                                                  className=""
-                                                                  data-ouia-component-id="state-filter-dropdown-toggle"
-                                                                  data-ouia-component-type="PF4/DropdownToggle"
-                                                                  data-ouia-safe={true}
-                                                                  getMenuRef={[Function]}
-                                                                  id="pf-dropdown-toggle-id-11"
-                                                                  isActive={false}
-                                                                  isDisabled={false}
-                                                                  isOpen={false}
-                                                                  isPlain={false}
-                                                                  isPrimary={false}
-                                                                  isSplitButton={false}
-                                                                  onEnter={[Function]}
-                                                                  onToggle={[Function]}
-                                                                  parentRef={
-                                                                    Object {
-                                                                      "current": <div
-                                                                        class="pf-c-dropdown"
-                                                                        data-ouia-component-id="state-filter-dropdown"
-                                                                        data-ouia-component-type="PF4/Dropdown"
-                                                                        data-ouia-safe="true"
-                                                                      >
-                                                                        <button
-                                                                          aria-expanded="false"
-                                                                          aria-haspopup="true"
-                                                                          class="pf-c-dropdown__toggle"
-                                                                          data-ouia-component-id="state-filter-dropdown-toggle"
-                                                                          data-ouia-component-type="PF4/DropdownToggle"
-                                                                          data-ouia-safe="true"
-                                                                          id="pf-dropdown-toggle-id-11"
-                                                                          type="button"
-                                                                        >
-                                                                          <span
-                                                                            class="pf-c-dropdown__toggle-text"
-                                                                          >
-                                                                            View: 
-                                                                            Same, Different, Incomplete data
-                                                                          </span>
-                                                                          <span
-                                                                            class="pf-c-dropdown__toggle-icon"
-                                                                          >
-                                                                            <svg
-                                                                              aria-hidden="true"
-                                                                              fill="currentColor"
-                                                                              height="1em"
-                                                                              role="img"
-                                                                              style="vertical-align: -0.125em;"
-                                                                              viewBox="0 0 320 512"
-                                                                              width="1em"
-                                                                            >
-                                                                              <path
-                                                                                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                                                              />
-                                                                            </svg>
-                                                                          </span>
-                                                                        </button>
-                                                                      </div>,
-                                                                    }
-                                                                  }
+                                                            isPrimary={false}
+                                                            isSplitButton={false}
+                                                            onEnter={[Function]}
+                                                            onToggle={[Function]}
+                                                            parentRef={
+                                                              Object {
+                                                                "current": <div
+                                                                  class="pf-c-dropdown comparison-filter-dropdown-width"
+                                                                  data-ouia-component-id="drift-filter-dropdown"
+                                                                  data-ouia-component-type="PF4/Dropdown"
+                                                                  data-ouia-safe="true"
                                                                 >
                                                                   <button
-                                                                    aria-expanded={false}
-                                                                    aria-haspopup={true}
-                                                                    className="pf-c-dropdown__toggle"
-                                                                    data-ouia-component-id="state-filter-dropdown-toggle"
+                                                                    aria-expanded="false"
+                                                                    aria-haspopup="true"
+                                                                    class="pf-c-dropdown__toggle"
+                                                                    data-ouia-component-id="drift-filter-toggle"
                                                                     data-ouia-component-type="PF4/DropdownToggle"
-                                                                    data-ouia-safe={true}
-                                                                    disabled={false}
-                                                                    id="pf-dropdown-toggle-id-11"
-                                                                    onClick={[Function]}
-                                                                    onKeyDown={[Function]}
+                                                                    data-ouia-safe="true"
+                                                                    id="pf-dropdown-toggle-id-5"
                                                                     type="button"
                                                                   >
                                                                     <span
-                                                                      className="pf-c-dropdown__toggle-text"
-                                                                    >
-                                                                      View: 
-                                                                      Same, Different, Incomplete data
-                                                                    </span>
-                                                                    <span
-                                                                      className="pf-c-dropdown__toggle-icon"
-                                                                    >
-                                                                      <CaretDownIcon
-                                                                        color="currentColor"
-                                                                        noVerticalAlign={false}
-                                                                        size="sm"
-                                                                      >
-                                                                        <svg
-                                                                          aria-hidden={true}
-                                                                          aria-labelledby={null}
-                                                                          fill="currentColor"
-                                                                          height="1em"
-                                                                          role="img"
-                                                                          style={
-                                                                            Object {
-                                                                              "verticalAlign": "-0.125em",
-                                                                            }
-                                                                          }
-                                                                          viewBox="0 0 320 512"
-                                                                          width="1em"
-                                                                        >
-                                                                          <path
-                                                                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                                                          />
-                                                                        </svg>
-                                                                      </CaretDownIcon>
-                                                                    </span>
-                                                                  </button>
-                                                                </Toggle>
-                                                              </DropdownToggle>
-                                                            </div>
-                                                          </DropdownWithContext>
-                                                        </Dropdown>
-                                                      </FilterDropDown>
-                                                    </Connect(FilterDropDown)>
-                                                  </div>
-                                                </ToolbarItem>
-                                                <Portal
-                                                  containerInfo={
-                                                    <div
-                                                      class="pf-c-toolbar__group"
-                                                    >
-                                                      <div
-                                                        class="pf-c-toolbar__item pf-m-chip-group"
-                                                      >
-                                                        <div
-                                                          class="pf-c-chip-group pf-m-category"
-                                                          data-ouia-component-type="PF4/ChipGroup"
-                                                          data-ouia-safe="true"
-                                                        >
-                                                          <div
-                                                            class="pf-c-chip-group__main"
-                                                          >
-                                                            <span
-                                                              aria-hidden="true"
-                                                              class="pf-c-chip-group__label"
-                                                              id="pf-random-id-8"
-                                                            >
-                                                              State
-                                                            </span>
-                                                            <ul
-                                                              aria-labelledby="pf-random-id-8"
-                                                              class="pf-c-chip-group__list"
-                                                              role="list"
-                                                            >
-                                                              <li
-                                                                class="pf-c-chip-group__list-item"
-                                                              >
-                                                                <div
-                                                                  class="pf-c-chip"
-                                                                  data-ouia-component-id="OUIA-Generated-Chip-4"
-                                                                  data-ouia-component-type="PF4/Chip"
-                                                                  data-ouia-safe="true"
-                                                                >
-                                                                  <span
-                                                                    class="pf-c-chip__text"
-                                                                    id="pf-random-id-9"
-                                                                  >
-                                                                    Same
-                                                                  </span>
-                                                                  <button
-                                                                    aria-disabled="false"
-                                                                    aria-label="close"
-                                                                    aria-labelledby="remove_pf-random-id-9 pf-random-id-9"
-                                                                    class="pf-c-button pf-m-plain"
-                                                                    data-ouia-component-id="close"
-                                                                    data-ouia-component-type="PF4/Button"
-                                                                    data-ouia-safe="true"
-                                                                    id="remove_pf-random-id-9"
-                                                                    type="button"
-                                                                  >
-                                                                    <svg
-                                                                      aria-hidden="true"
-                                                                      fill="currentColor"
-                                                                      height="1em"
-                                                                      role="img"
-                                                                      style="vertical-align: -0.125em;"
-                                                                      viewBox="0 0 352 512"
-                                                                      width="1em"
-                                                                    >
-                                                                      <path
-                                                                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                                                                      />
-                                                                    </svg>
-                                                                  </button>
-                                                                </div>
-                                                              </li>
-                                                              <li
-                                                                class="pf-c-chip-group__list-item"
-                                                              >
-                                                                <div
-                                                                  class="pf-c-chip"
-                                                                  data-ouia-component-id="OUIA-Generated-Chip-5"
-                                                                  data-ouia-component-type="PF4/Chip"
-                                                                  data-ouia-safe="true"
-                                                                >
-                                                                  <span
-                                                                    class="pf-c-chip__text"
-                                                                    id="pf-random-id-10"
-                                                                  >
-                                                                    Different
-                                                                  </span>
-                                                                  <button
-                                                                    aria-disabled="false"
-                                                                    aria-label="close"
-                                                                    aria-labelledby="remove_pf-random-id-10 pf-random-id-10"
-                                                                    class="pf-c-button pf-m-plain"
-                                                                    data-ouia-component-id="close"
-                                                                    data-ouia-component-type="PF4/Button"
-                                                                    data-ouia-safe="true"
-                                                                    id="remove_pf-random-id-10"
-                                                                    type="button"
-                                                                  >
-                                                                    <svg
-                                                                      aria-hidden="true"
-                                                                      fill="currentColor"
-                                                                      height="1em"
-                                                                      role="img"
-                                                                      style="vertical-align: -0.125em;"
-                                                                      viewBox="0 0 352 512"
-                                                                      width="1em"
-                                                                    >
-                                                                      <path
-                                                                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                                                                      />
-                                                                    </svg>
-                                                                  </button>
-                                                                </div>
-                                                              </li>
-                                                              <li
-                                                                class="pf-c-chip-group__list-item"
-                                                              >
-                                                                <div
-                                                                  class="pf-c-chip"
-                                                                  data-ouia-component-id="OUIA-Generated-Chip-6"
-                                                                  data-ouia-component-type="PF4/Chip"
-                                                                  data-ouia-safe="true"
-                                                                >
-                                                                  <span
-                                                                    class="pf-c-chip__text"
-                                                                    id="pf-random-id-11"
-                                                                  >
-                                                                    Incomplete data
-                                                                  </span>
-                                                                  <button
-                                                                    aria-disabled="false"
-                                                                    aria-label="close"
-                                                                    aria-labelledby="remove_pf-random-id-11 pf-random-id-11"
-                                                                    class="pf-c-button pf-m-plain"
-                                                                    data-ouia-component-id="close"
-                                                                    data-ouia-component-type="PF4/Button"
-                                                                    data-ouia-safe="true"
-                                                                    id="remove_pf-random-id-11"
-                                                                    type="button"
-                                                                  >
-                                                                    <svg
-                                                                      aria-hidden="true"
-                                                                      fill="currentColor"
-                                                                      height="1em"
-                                                                      role="img"
-                                                                      style="vertical-align: -0.125em;"
-                                                                      viewBox="0 0 352 512"
-                                                                      width="1em"
-                                                                    >
-                                                                      <path
-                                                                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                                                                      />
-                                                                    </svg>
-                                                                  </button>
-                                                                </div>
-                                                              </li>
-                                                            </ul>
-                                                          </div>
-                                                          <div
-                                                            class="pf-c-chip-group__close"
-                                                          >
-                                                            <button
-                                                              aria-disabled="false"
-                                                              aria-label="Close chip group"
-                                                              aria-labelledby="remove_group_pf-random-id-8 pf-random-id-8"
-                                                              class="pf-c-button pf-m-plain"
-                                                              data-ouia-component-id="Close chip group"
-                                                              data-ouia-component-type="PF4/Button"
-                                                              data-ouia-safe="true"
-                                                              id="remove_group_pf-random-id-8"
-                                                              type="button"
-                                                            >
-                                                              <svg
-                                                                aria-hidden="true"
-                                                                fill="currentColor"
-                                                                height="1em"
-                                                                role="img"
-                                                                style="vertical-align: -0.125em;"
-                                                                viewBox="0 0 512 512"
-                                                                width="1em"
-                                                              >
-                                                                <path
-                                                                  d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
-                                                                />
-                                                              </svg>
-                                                            </button>
-                                                          </div>
-                                                        </div>
-                                                      </div>
-                                                    </div>
-                                                  }
-                                                >
-                                                  <ToolbarItem
-                                                    variant="chip-group"
-                                                  >
-                                                    <div
-                                                      className="pf-c-toolbar__item pf-m-chip-group"
-                                                    >
-                                                      <ChipGroup
-                                                        aria-label="Chip group category"
-                                                        categoryName="State"
-                                                        closeBtnAriaLabel="Close chip group"
-                                                        collapsedText="\${remaining} more"
-                                                        defaultIsOpen={false}
-                                                        expandedText="Show Less"
-                                                        isClosable={true}
-                                                        key="State"
-                                                        numChips={3}
-                                                        onClick={[Function]}
-                                                        onOverflowChipClick={[Function]}
-                                                        tooltipPosition="top"
-                                                      >
-                                                        <GenerateId
-                                                          prefix="pf-random-id-"
-                                                        >
-                                                          <div
-                                                            className="pf-c-chip-group pf-m-category"
-                                                            data-ouia-component-type="PF4/ChipGroup"
-                                                            data-ouia-safe={true}
-                                                          >
-                                                            <div
-                                                              className="pf-c-chip-group__main"
-                                                            >
-                                                              <span
-                                                                aria-hidden="true"
-                                                                className="pf-c-chip-group__label"
-                                                                id="pf-random-id-8"
-                                                              >
-                                                                State
-                                                              </span>
-                                                              <ul
-                                                                aria-labelledby="pf-random-id-8"
-                                                                className="pf-c-chip-group__list"
-                                                                role="list"
-                                                              >
-                                                                <li
-                                                                  className="pf-c-chip-group__list-item"
-                                                                  key="0"
-                                                                >
-                                                                  <Chip
-                                                                    className=""
-                                                                    closeBtnAriaLabel="close"
-                                                                    component="div"
-                                                                    isOverflowChip={false}
-                                                                    isReadOnly={false}
-                                                                    key=".$Same"
-                                                                    onClick={[Function]}
-                                                                    tooltipPosition="top"
-                                                                  >
-                                                                    <GenerateId
-                                                                      prefix="pf-random-id-"
-                                                                    >
-                                                                      <div
-                                                                        className="pf-c-chip"
-                                                                        data-ouia-component-id="OUIA-Generated-Chip-4"
-                                                                        data-ouia-component-type="PF4/Chip"
-                                                                        data-ouia-safe={true}
-                                                                      >
-                                                                        <span
-                                                                          className="pf-c-chip__text"
-                                                                          id="pf-random-id-9"
-                                                                        >
-                                                                          Same
-                                                                        </span>
-                                                                        <Button
-                                                                          aria-label="close"
-                                                                          aria-labelledby="remove_pf-random-id-9 pf-random-id-9"
-                                                                          id="remove_pf-random-id-9"
-                                                                          onClick={[Function]}
-                                                                          ouiaId="close"
-                                                                          variant="plain"
-                                                                        >
-                                                                          <ButtonBase
-                                                                            aria-label="close"
-                                                                            aria-labelledby="remove_pf-random-id-9 pf-random-id-9"
-                                                                            id="remove_pf-random-id-9"
-                                                                            innerRef={null}
-                                                                            onClick={[Function]}
-                                                                            ouiaId="close"
-                                                                            variant="plain"
-                                                                          >
-                                                                            <button
-                                                                              aria-disabled={false}
-                                                                              aria-label="close"
-                                                                              aria-labelledby="remove_pf-random-id-9 pf-random-id-9"
-                                                                              className="pf-c-button pf-m-plain"
-                                                                              data-ouia-component-id="close"
-                                                                              data-ouia-component-type="PF4/Button"
-                                                                              data-ouia-safe={true}
-                                                                              disabled={false}
-                                                                              id="remove_pf-random-id-9"
-                                                                              onClick={[Function]}
-                                                                              role={null}
-                                                                              type="button"
-                                                                            >
-                                                                              <TimesIcon
-                                                                                aria-hidden="true"
-                                                                                color="currentColor"
-                                                                                noVerticalAlign={false}
-                                                                                size="sm"
-                                                                              >
-                                                                                <svg
-                                                                                  aria-hidden="true"
-                                                                                  aria-labelledby={null}
-                                                                                  fill="currentColor"
-                                                                                  height="1em"
-                                                                                  role="img"
-                                                                                  style={
-                                                                                    Object {
-                                                                                      "verticalAlign": "-0.125em",
-                                                                                    }
-                                                                                  }
-                                                                                  viewBox="0 0 352 512"
-                                                                                  width="1em"
-                                                                                >
-                                                                                  <path
-                                                                                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                                                                                  />
-                                                                                </svg>
-                                                                              </TimesIcon>
-                                                                            </button>
-                                                                          </ButtonBase>
-                                                                        </Button>
-                                                                      </div>
-                                                                    </GenerateId>
-                                                                  </Chip>
-                                                                </li>
-                                                                <li
-                                                                  className="pf-c-chip-group__list-item"
-                                                                  key="1"
-                                                                >
-                                                                  <Chip
-                                                                    className=""
-                                                                    closeBtnAriaLabel="close"
-                                                                    component="div"
-                                                                    isOverflowChip={false}
-                                                                    isReadOnly={false}
-                                                                    key=".$Different"
-                                                                    onClick={[Function]}
-                                                                    tooltipPosition="top"
-                                                                  >
-                                                                    <GenerateId
-                                                                      prefix="pf-random-id-"
-                                                                    >
-                                                                      <div
-                                                                        className="pf-c-chip"
-                                                                        data-ouia-component-id="OUIA-Generated-Chip-5"
-                                                                        data-ouia-component-type="PF4/Chip"
-                                                                        data-ouia-safe={true}
-                                                                      >
-                                                                        <span
-                                                                          className="pf-c-chip__text"
-                                                                          id="pf-random-id-10"
-                                                                        >
-                                                                          Different
-                                                                        </span>
-                                                                        <Button
-                                                                          aria-label="close"
-                                                                          aria-labelledby="remove_pf-random-id-10 pf-random-id-10"
-                                                                          id="remove_pf-random-id-10"
-                                                                          onClick={[Function]}
-                                                                          ouiaId="close"
-                                                                          variant="plain"
-                                                                        >
-                                                                          <ButtonBase
-                                                                            aria-label="close"
-                                                                            aria-labelledby="remove_pf-random-id-10 pf-random-id-10"
-                                                                            id="remove_pf-random-id-10"
-                                                                            innerRef={null}
-                                                                            onClick={[Function]}
-                                                                            ouiaId="close"
-                                                                            variant="plain"
-                                                                          >
-                                                                            <button
-                                                                              aria-disabled={false}
-                                                                              aria-label="close"
-                                                                              aria-labelledby="remove_pf-random-id-10 pf-random-id-10"
-                                                                              className="pf-c-button pf-m-plain"
-                                                                              data-ouia-component-id="close"
-                                                                              data-ouia-component-type="PF4/Button"
-                                                                              data-ouia-safe={true}
-                                                                              disabled={false}
-                                                                              id="remove_pf-random-id-10"
-                                                                              onClick={[Function]}
-                                                                              role={null}
-                                                                              type="button"
-                                                                            >
-                                                                              <TimesIcon
-                                                                                aria-hidden="true"
-                                                                                color="currentColor"
-                                                                                noVerticalAlign={false}
-                                                                                size="sm"
-                                                                              >
-                                                                                <svg
-                                                                                  aria-hidden="true"
-                                                                                  aria-labelledby={null}
-                                                                                  fill="currentColor"
-                                                                                  height="1em"
-                                                                                  role="img"
-                                                                                  style={
-                                                                                    Object {
-                                                                                      "verticalAlign": "-0.125em",
-                                                                                    }
-                                                                                  }
-                                                                                  viewBox="0 0 352 512"
-                                                                                  width="1em"
-                                                                                >
-                                                                                  <path
-                                                                                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                                                                                  />
-                                                                                </svg>
-                                                                              </TimesIcon>
-                                                                            </button>
-                                                                          </ButtonBase>
-                                                                        </Button>
-                                                                      </div>
-                                                                    </GenerateId>
-                                                                  </Chip>
-                                                                </li>
-                                                                <li
-                                                                  className="pf-c-chip-group__list-item"
-                                                                  key="2"
-                                                                >
-                                                                  <Chip
-                                                                    className=""
-                                                                    closeBtnAriaLabel="close"
-                                                                    component="div"
-                                                                    isOverflowChip={false}
-                                                                    isReadOnly={false}
-                                                                    key=".$Incomplete data"
-                                                                    onClick={[Function]}
-                                                                    tooltipPosition="top"
-                                                                  >
-                                                                    <GenerateId
-                                                                      prefix="pf-random-id-"
-                                                                    >
-                                                                      <div
-                                                                        className="pf-c-chip"
-                                                                        data-ouia-component-id="OUIA-Generated-Chip-6"
-                                                                        data-ouia-component-type="PF4/Chip"
-                                                                        data-ouia-safe={true}
-                                                                      >
-                                                                        <span
-                                                                          className="pf-c-chip__text"
-                                                                          id="pf-random-id-11"
-                                                                        >
-                                                                          Incomplete data
-                                                                        </span>
-                                                                        <Button
-                                                                          aria-label="close"
-                                                                          aria-labelledby="remove_pf-random-id-11 pf-random-id-11"
-                                                                          id="remove_pf-random-id-11"
-                                                                          onClick={[Function]}
-                                                                          ouiaId="close"
-                                                                          variant="plain"
-                                                                        >
-                                                                          <ButtonBase
-                                                                            aria-label="close"
-                                                                            aria-labelledby="remove_pf-random-id-11 pf-random-id-11"
-                                                                            id="remove_pf-random-id-11"
-                                                                            innerRef={null}
-                                                                            onClick={[Function]}
-                                                                            ouiaId="close"
-                                                                            variant="plain"
-                                                                          >
-                                                                            <button
-                                                                              aria-disabled={false}
-                                                                              aria-label="close"
-                                                                              aria-labelledby="remove_pf-random-id-11 pf-random-id-11"
-                                                                              className="pf-c-button pf-m-plain"
-                                                                              data-ouia-component-id="close"
-                                                                              data-ouia-component-type="PF4/Button"
-                                                                              data-ouia-safe={true}
-                                                                              disabled={false}
-                                                                              id="remove_pf-random-id-11"
-                                                                              onClick={[Function]}
-                                                                              role={null}
-                                                                              type="button"
-                                                                            >
-                                                                              <TimesIcon
-                                                                                aria-hidden="true"
-                                                                                color="currentColor"
-                                                                                noVerticalAlign={false}
-                                                                                size="sm"
-                                                                              >
-                                                                                <svg
-                                                                                  aria-hidden="true"
-                                                                                  aria-labelledby={null}
-                                                                                  fill="currentColor"
-                                                                                  height="1em"
-                                                                                  role="img"
-                                                                                  style={
-                                                                                    Object {
-                                                                                      "verticalAlign": "-0.125em",
-                                                                                    }
-                                                                                  }
-                                                                                  viewBox="0 0 352 512"
-                                                                                  width="1em"
-                                                                                >
-                                                                                  <path
-                                                                                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                                                                                  />
-                                                                                </svg>
-                                                                              </TimesIcon>
-                                                                            </button>
-                                                                          </ButtonBase>
-                                                                        </Button>
-                                                                      </div>
-                                                                    </GenerateId>
-                                                                  </Chip>
-                                                                </li>
-                                                              </ul>
-                                                            </div>
-                                                            <div
-                                                              className="pf-c-chip-group__close"
-                                                            >
-                                                              <Button
-                                                                aria-label="Close chip group"
-                                                                aria-labelledby="remove_group_pf-random-id-8 pf-random-id-8"
-                                                                id="remove_group_pf-random-id-8"
-                                                                onClick={[Function]}
-                                                                ouiaId="Close chip group"
-                                                                variant="plain"
-                                                              >
-                                                                <ButtonBase
-                                                                  aria-label="Close chip group"
-                                                                  aria-labelledby="remove_group_pf-random-id-8 pf-random-id-8"
-                                                                  id="remove_group_pf-random-id-8"
-                                                                  innerRef={null}
-                                                                  onClick={[Function]}
-                                                                  ouiaId="Close chip group"
-                                                                  variant="plain"
-                                                                >
-                                                                  <button
-                                                                    aria-disabled={false}
-                                                                    aria-label="Close chip group"
-                                                                    aria-labelledby="remove_group_pf-random-id-8 pf-random-id-8"
-                                                                    className="pf-c-button pf-m-plain"
-                                                                    data-ouia-component-id="Close chip group"
-                                                                    data-ouia-component-type="PF4/Button"
-                                                                    data-ouia-safe={true}
-                                                                    disabled={false}
-                                                                    id="remove_group_pf-random-id-8"
-                                                                    onClick={[Function]}
-                                                                    role={null}
-                                                                    type="button"
-                                                                  >
-                                                                    <TimesCircleIcon
-                                                                      aria-hidden="true"
-                                                                      color="currentColor"
-                                                                      noVerticalAlign={false}
-                                                                      size="sm"
+                                                                      class="pf-c-dropdown__toggle-image"
                                                                     >
                                                                       <svg
                                                                         aria-hidden="true"
-                                                                        aria-labelledby={null}
                                                                         fill="currentColor"
                                                                         height="1em"
                                                                         role="img"
-                                                                        style={
-                                                                          Object {
-                                                                            "verticalAlign": "-0.125em",
-                                                                          }
-                                                                        }
+                                                                        style="vertical-align: -0.125em;"
                                                                         viewBox="0 0 512 512"
                                                                         width="1em"
                                                                       >
                                                                         <path
-                                                                          d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
+                                                                          d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
                                                                         />
                                                                       </svg>
-                                                                    </TimesCircleIcon>
+                                                                    </span>
+                                                                    <span
+                                                                      class="pf-c-dropdown__toggle-text"
+                                                                    >
+                                                                      Fact name
+                                                                    </span>
+                                                                    <span
+                                                                      class="pf-c-dropdown__toggle-icon"
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden="true"
+                                                                        fill="currentColor"
+                                                                        height="1em"
+                                                                        role="img"
+                                                                        style="vertical-align: -0.125em;"
+                                                                        viewBox="0 0 320 512"
+                                                                        width="1em"
+                                                                      >
+                                                                        <path
+                                                                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                                                        />
+                                                                      </svg>
+                                                                    </span>
                                                                   </button>
-                                                                </ButtonBase>
-                                                              </Button>
+                                                                </div>,
+                                                              }
+                                                            }
+                                                          >
+                                                            <button
+                                                              aria-expanded={false}
+                                                              aria-haspopup={true}
+                                                              className="pf-c-dropdown__toggle"
+                                                              data-ouia-component-id="drift-filter-toggle"
+                                                              data-ouia-component-type="PF4/DropdownToggle"
+                                                              data-ouia-safe={true}
+                                                              disabled={false}
+                                                              id="pf-dropdown-toggle-id-5"
+                                                              onClick={[Function]}
+                                                              onKeyDown={[Function]}
+                                                              type="button"
+                                                            >
+                                                              <span
+                                                                className="pf-c-dropdown__toggle-image"
+                                                              >
+                                                                <FilterIcon
+                                                                  color="currentColor"
+                                                                  noVerticalAlign={false}
+                                                                  size="sm"
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden={true}
+                                                                    aria-labelledby={null}
+                                                                    fill="currentColor"
+                                                                    height="1em"
+                                                                    role="img"
+                                                                    style={
+                                                                      Object {
+                                                                        "verticalAlign": "-0.125em",
+                                                                      }
+                                                                    }
+                                                                    viewBox="0 0 512 512"
+                                                                    width="1em"
+                                                                  >
+                                                                    <path
+                                                                      d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
+                                                                    />
+                                                                  </svg>
+                                                                </FilterIcon>
+                                                              </span>
+                                                              <span
+                                                                className="pf-c-dropdown__toggle-text"
+                                                              >
+                                                                Fact name
+                                                              </span>
+                                                              <span
+                                                                className="pf-c-dropdown__toggle-icon"
+                                                              >
+                                                                <CaretDownIcon
+                                                                  color="currentColor"
+                                                                  noVerticalAlign={false}
+                                                                  size="sm"
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden={true}
+                                                                    aria-labelledby={null}
+                                                                    fill="currentColor"
+                                                                    height="1em"
+                                                                    role="img"
+                                                                    style={
+                                                                      Object {
+                                                                        "verticalAlign": "-0.125em",
+                                                                      }
+                                                                    }
+                                                                    viewBox="0 0 320 512"
+                                                                    width="1em"
+                                                                  >
+                                                                    <path
+                                                                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                                                    />
+                                                                  </svg>
+                                                                </CaretDownIcon>
+                                                              </span>
+                                                            </button>
+                                                          </Toggle>
+                                                        </DropdownToggle>
+                                                      </div>
+                                                    </DropdownWithContext>
+                                                  </Dropdown>
+                                                </DriftFilterDropdown>
+                                                <DriftFilterValue
+                                                  activeFactFilters={Array []}
+                                                  factFilter=""
+                                                  filterByFact={[Function]}
+                                                  filterType="Fact name"
+                                                  handleFactFilter={[Function]}
+                                                  removeChip={[Function]}
+                                                  setHistory={[Function]}
+                                                  stateFilters={
+                                                    Array [
+                                                      Object {
+                                                        "display": "Same",
+                                                        "filter": "SAME",
+                                                        "selected": true,
+                                                      },
+                                                      Object {
+                                                        "display": "Different",
+                                                        "filter": "DIFFERENT",
+                                                        "selected": true,
+                                                      },
+                                                      Object {
+                                                        "display": "Incomplete data",
+                                                        "filter": "INCOMPLETE_DATA",
+                                                        "selected": true,
+                                                      },
+                                                    ]
+                                                  }
+                                                >
+                                                  <ToolbarFilter
+                                                    categoryName="Fact name"
+                                                    chips={Array []}
+                                                    deleteChip={[Function]}
+                                                    deleteChipGroup={[Function]}
+                                                    showToolbarItem={true}
+                                                  >
+                                                    <ToolbarItem>
+                                                      <div
+                                                        className="pf-c-toolbar__item"
+                                                      >
+                                                        <SearchBar
+                                                          activeFactFilters={Array []}
+                                                          factFilter=""
+                                                          filterByFact={[Function]}
+                                                          handleFactFilter={[Function]}
+                                                          setHistory={[Function]}
+                                                        >
+                                                          <Form>
+                                                            <form
+                                                              className="pf-c-form"
+                                                              noValidate={true}
+                                                            >
+                                                              <FormGroup
+                                                                fieldId="filter"
+                                                                isRequired={true}
+                                                                onKeyPress={[Function]}
+                                                                type="text"
+                                                              >
+                                                                <div
+                                                                  className="pf-c-form__group"
+                                                                  onKeyPress={[Function]}
+                                                                  type="text"
+                                                                >
+                                                                  <div
+                                                                    className="pf-c-form__group-control"
+                                                                  >
+                                                                    <TextInput
+                                                                      aria-label="filter by fact"
+                                                                      data-ouia-component-id="fact-filter-input-comparison"
+                                                                      data-ouia-component-type="PF4/TextInput"
+                                                                      id="filterByFact"
+                                                                      onChange={[Function]}
+                                                                      placeholder="Filter by fact"
+                                                                      value=""
+                                                                    >
+                                                                      <TextInputBase
+                                                                        aria-label="filter by fact"
+                                                                        className=""
+                                                                        data-ouia-component-id="fact-filter-input-comparison"
+                                                                        data-ouia-component-type="PF4/TextInput"
+                                                                        id="filterByFact"
+                                                                        innerRef={null}
+                                                                        isDisabled={false}
+                                                                        isLeftTruncated={false}
+                                                                        isReadOnly={false}
+                                                                        isRequired={false}
+                                                                        onChange={[Function]}
+                                                                        ouiaSafe={true}
+                                                                        placeholder="Filter by fact"
+                                                                        type="text"
+                                                                        validated="default"
+                                                                        value=""
+                                                                      >
+                                                                        <input
+                                                                          aria-invalid={false}
+                                                                          aria-label="filter by fact"
+                                                                          className="pf-c-form-control"
+                                                                          data-ouia-component-id="OUIA-Generated-TextInputBase-4"
+                                                                          data-ouia-component-type="PF4/TextInput"
+                                                                          data-ouia-safe={true}
+                                                                          disabled={false}
+                                                                          id="filterByFact"
+                                                                          onBlur={[Function]}
+                                                                          onChange={[Function]}
+                                                                          onFocus={[Function]}
+                                                                          placeholder="Filter by fact"
+                                                                          readOnly={false}
+                                                                          required={false}
+                                                                          type="text"
+                                                                          value=""
+                                                                        />
+                                                                      </TextInputBase>
+                                                                    </TextInput>
+                                                                  </div>
+                                                                </div>
+                                                              </FormGroup>
+                                                            </form>
+                                                          </Form>
+                                                        </SearchBar>
+                                                      </div>
+                                                    </ToolbarItem>
+                                                    <Portal
+                                                      containerInfo={
+                                                        <div
+                                                          class="pf-c-toolbar__group"
+                                                        >
+                                                          <div
+                                                            class="pf-c-toolbar__item pf-m-chip-group"
+                                                          >
+                                                            <div
+                                                              class="pf-c-chip-group pf-m-category"
+                                                              data-ouia-component-type="PF4/ChipGroup"
+                                                              data-ouia-safe="true"
+                                                            >
+                                                              <div
+                                                                class="pf-c-chip-group__main"
+                                                              >
+                                                                <span
+                                                                  aria-hidden="true"
+                                                                  class="pf-c-chip-group__label"
+                                                                  id="pf-random-id-8"
+                                                                >
+                                                                  State
+                                                                </span>
+                                                                <ul
+                                                                  aria-labelledby="pf-random-id-8"
+                                                                  class="pf-c-chip-group__list"
+                                                                  role="list"
+                                                                >
+                                                                  <li
+                                                                    class="pf-c-chip-group__list-item"
+                                                                  >
+                                                                    <div
+                                                                      class="pf-c-chip"
+                                                                      data-ouia-component-id="OUIA-Generated-Chip-4"
+                                                                      data-ouia-component-type="PF4/Chip"
+                                                                      data-ouia-safe="true"
+                                                                    >
+                                                                      <span
+                                                                        class="pf-c-chip__text"
+                                                                        id="pf-random-id-9"
+                                                                      >
+                                                                        Same
+                                                                      </span>
+                                                                      <button
+                                                                        aria-disabled="false"
+                                                                        aria-label="close"
+                                                                        aria-labelledby="remove_pf-random-id-9 pf-random-id-9"
+                                                                        class="pf-c-button pf-m-plain"
+                                                                        data-ouia-component-id="close"
+                                                                        data-ouia-component-type="PF4/Button"
+                                                                        data-ouia-safe="true"
+                                                                        id="remove_pf-random-id-9"
+                                                                        type="button"
+                                                                      >
+                                                                        <svg
+                                                                          aria-hidden="true"
+                                                                          fill="currentColor"
+                                                                          height="1em"
+                                                                          role="img"
+                                                                          style="vertical-align: -0.125em;"
+                                                                          viewBox="0 0 352 512"
+                                                                          width="1em"
+                                                                        >
+                                                                          <path
+                                                                            d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                                                          />
+                                                                        </svg>
+                                                                      </button>
+                                                                    </div>
+                                                                  </li>
+                                                                  <li
+                                                                    class="pf-c-chip-group__list-item"
+                                                                  >
+                                                                    <div
+                                                                      class="pf-c-chip"
+                                                                      data-ouia-component-id="OUIA-Generated-Chip-5"
+                                                                      data-ouia-component-type="PF4/Chip"
+                                                                      data-ouia-safe="true"
+                                                                    >
+                                                                      <span
+                                                                        class="pf-c-chip__text"
+                                                                        id="pf-random-id-10"
+                                                                      >
+                                                                        Different
+                                                                      </span>
+                                                                      <button
+                                                                        aria-disabled="false"
+                                                                        aria-label="close"
+                                                                        aria-labelledby="remove_pf-random-id-10 pf-random-id-10"
+                                                                        class="pf-c-button pf-m-plain"
+                                                                        data-ouia-component-id="close"
+                                                                        data-ouia-component-type="PF4/Button"
+                                                                        data-ouia-safe="true"
+                                                                        id="remove_pf-random-id-10"
+                                                                        type="button"
+                                                                      >
+                                                                        <svg
+                                                                          aria-hidden="true"
+                                                                          fill="currentColor"
+                                                                          height="1em"
+                                                                          role="img"
+                                                                          style="vertical-align: -0.125em;"
+                                                                          viewBox="0 0 352 512"
+                                                                          width="1em"
+                                                                        >
+                                                                          <path
+                                                                            d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                                                          />
+                                                                        </svg>
+                                                                      </button>
+                                                                    </div>
+                                                                  </li>
+                                                                  <li
+                                                                    class="pf-c-chip-group__list-item"
+                                                                  >
+                                                                    <div
+                                                                      class="pf-c-chip"
+                                                                      data-ouia-component-id="OUIA-Generated-Chip-6"
+                                                                      data-ouia-component-type="PF4/Chip"
+                                                                      data-ouia-safe="true"
+                                                                    >
+                                                                      <span
+                                                                        class="pf-c-chip__text"
+                                                                        id="pf-random-id-11"
+                                                                      >
+                                                                        Incomplete data
+                                                                      </span>
+                                                                      <button
+                                                                        aria-disabled="false"
+                                                                        aria-label="close"
+                                                                        aria-labelledby="remove_pf-random-id-11 pf-random-id-11"
+                                                                        class="pf-c-button pf-m-plain"
+                                                                        data-ouia-component-id="close"
+                                                                        data-ouia-component-type="PF4/Button"
+                                                                        data-ouia-safe="true"
+                                                                        id="remove_pf-random-id-11"
+                                                                        type="button"
+                                                                      >
+                                                                        <svg
+                                                                          aria-hidden="true"
+                                                                          fill="currentColor"
+                                                                          height="1em"
+                                                                          role="img"
+                                                                          style="vertical-align: -0.125em;"
+                                                                          viewBox="0 0 352 512"
+                                                                          width="1em"
+                                                                        >
+                                                                          <path
+                                                                            d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                                                          />
+                                                                        </svg>
+                                                                      </button>
+                                                                    </div>
+                                                                  </li>
+                                                                </ul>
+                                                              </div>
+                                                              <div
+                                                                class="pf-c-chip-group__close"
+                                                              >
+                                                                <button
+                                                                  aria-disabled="false"
+                                                                  aria-label="Close chip group"
+                                                                  aria-labelledby="remove_group_pf-random-id-8 pf-random-id-8"
+                                                                  class="pf-c-button pf-m-plain"
+                                                                  data-ouia-component-id="Close chip group"
+                                                                  data-ouia-component-type="PF4/Button"
+                                                                  data-ouia-safe="true"
+                                                                  id="remove_group_pf-random-id-8"
+                                                                  type="button"
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden="true"
+                                                                    fill="currentColor"
+                                                                    height="1em"
+                                                                    role="img"
+                                                                    style="vertical-align: -0.125em;"
+                                                                    viewBox="0 0 512 512"
+                                                                    width="1em"
+                                                                  >
+                                                                    <path
+                                                                      d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
+                                                                    />
+                                                                  </svg>
+                                                                </button>
+                                                              </div>
                                                             </div>
                                                           </div>
-                                                        </GenerateId>
-                                                      </ChipGroup>
-                                                    </div>
-                                                  </ToolbarItem>
-                                                </Portal>
-                                              </ToolbarFilter>
-                                            </div>
-                                          </ToolbarGroupWithRef>
-                                        </ForwardRef>
+                                                        </div>
+                                                      }
+                                                    />
+                                                  </ToolbarFilter>
+                                                  <ToolbarFilter
+                                                    categoryName="State"
+                                                    chips={
+                                                      Array [
+                                                        "Same",
+                                                        "Different",
+                                                        "Incomplete data",
+                                                      ]
+                                                    }
+                                                    deleteChip={[Function]}
+                                                    deleteChipGroup={[Function]}
+                                                    showToolbarItem={true}
+                                                  >
+                                                    <ToolbarItem>
+                                                      <div
+                                                        className="pf-c-toolbar__item"
+                                                      />
+                                                    </ToolbarItem>
+                                                    <Portal
+                                                      containerInfo={
+                                                        <div
+                                                          class="pf-c-toolbar__group"
+                                                        >
+                                                          <div
+                                                            class="pf-c-toolbar__item pf-m-chip-group"
+                                                          >
+                                                            <div
+                                                              class="pf-c-chip-group pf-m-category"
+                                                              data-ouia-component-type="PF4/ChipGroup"
+                                                              data-ouia-safe="true"
+                                                            >
+                                                              <div
+                                                                class="pf-c-chip-group__main"
+                                                              >
+                                                                <span
+                                                                  aria-hidden="true"
+                                                                  class="pf-c-chip-group__label"
+                                                                  id="pf-random-id-8"
+                                                                >
+                                                                  State
+                                                                </span>
+                                                                <ul
+                                                                  aria-labelledby="pf-random-id-8"
+                                                                  class="pf-c-chip-group__list"
+                                                                  role="list"
+                                                                >
+                                                                  <li
+                                                                    class="pf-c-chip-group__list-item"
+                                                                  >
+                                                                    <div
+                                                                      class="pf-c-chip"
+                                                                      data-ouia-component-id="OUIA-Generated-Chip-4"
+                                                                      data-ouia-component-type="PF4/Chip"
+                                                                      data-ouia-safe="true"
+                                                                    >
+                                                                      <span
+                                                                        class="pf-c-chip__text"
+                                                                        id="pf-random-id-9"
+                                                                      >
+                                                                        Same
+                                                                      </span>
+                                                                      <button
+                                                                        aria-disabled="false"
+                                                                        aria-label="close"
+                                                                        aria-labelledby="remove_pf-random-id-9 pf-random-id-9"
+                                                                        class="pf-c-button pf-m-plain"
+                                                                        data-ouia-component-id="close"
+                                                                        data-ouia-component-type="PF4/Button"
+                                                                        data-ouia-safe="true"
+                                                                        id="remove_pf-random-id-9"
+                                                                        type="button"
+                                                                      >
+                                                                        <svg
+                                                                          aria-hidden="true"
+                                                                          fill="currentColor"
+                                                                          height="1em"
+                                                                          role="img"
+                                                                          style="vertical-align: -0.125em;"
+                                                                          viewBox="0 0 352 512"
+                                                                          width="1em"
+                                                                        >
+                                                                          <path
+                                                                            d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                                                          />
+                                                                        </svg>
+                                                                      </button>
+                                                                    </div>
+                                                                  </li>
+                                                                  <li
+                                                                    class="pf-c-chip-group__list-item"
+                                                                  >
+                                                                    <div
+                                                                      class="pf-c-chip"
+                                                                      data-ouia-component-id="OUIA-Generated-Chip-5"
+                                                                      data-ouia-component-type="PF4/Chip"
+                                                                      data-ouia-safe="true"
+                                                                    >
+                                                                      <span
+                                                                        class="pf-c-chip__text"
+                                                                        id="pf-random-id-10"
+                                                                      >
+                                                                        Different
+                                                                      </span>
+                                                                      <button
+                                                                        aria-disabled="false"
+                                                                        aria-label="close"
+                                                                        aria-labelledby="remove_pf-random-id-10 pf-random-id-10"
+                                                                        class="pf-c-button pf-m-plain"
+                                                                        data-ouia-component-id="close"
+                                                                        data-ouia-component-type="PF4/Button"
+                                                                        data-ouia-safe="true"
+                                                                        id="remove_pf-random-id-10"
+                                                                        type="button"
+                                                                      >
+                                                                        <svg
+                                                                          aria-hidden="true"
+                                                                          fill="currentColor"
+                                                                          height="1em"
+                                                                          role="img"
+                                                                          style="vertical-align: -0.125em;"
+                                                                          viewBox="0 0 352 512"
+                                                                          width="1em"
+                                                                        >
+                                                                          <path
+                                                                            d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                                                          />
+                                                                        </svg>
+                                                                      </button>
+                                                                    </div>
+                                                                  </li>
+                                                                  <li
+                                                                    class="pf-c-chip-group__list-item"
+                                                                  >
+                                                                    <div
+                                                                      class="pf-c-chip"
+                                                                      data-ouia-component-id="OUIA-Generated-Chip-6"
+                                                                      data-ouia-component-type="PF4/Chip"
+                                                                      data-ouia-safe="true"
+                                                                    >
+                                                                      <span
+                                                                        class="pf-c-chip__text"
+                                                                        id="pf-random-id-11"
+                                                                      >
+                                                                        Incomplete data
+                                                                      </span>
+                                                                      <button
+                                                                        aria-disabled="false"
+                                                                        aria-label="close"
+                                                                        aria-labelledby="remove_pf-random-id-11 pf-random-id-11"
+                                                                        class="pf-c-button pf-m-plain"
+                                                                        data-ouia-component-id="close"
+                                                                        data-ouia-component-type="PF4/Button"
+                                                                        data-ouia-safe="true"
+                                                                        id="remove_pf-random-id-11"
+                                                                        type="button"
+                                                                      >
+                                                                        <svg
+                                                                          aria-hidden="true"
+                                                                          fill="currentColor"
+                                                                          height="1em"
+                                                                          role="img"
+                                                                          style="vertical-align: -0.125em;"
+                                                                          viewBox="0 0 352 512"
+                                                                          width="1em"
+                                                                        >
+                                                                          <path
+                                                                            d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                                                          />
+                                                                        </svg>
+                                                                      </button>
+                                                                    </div>
+                                                                  </li>
+                                                                </ul>
+                                                              </div>
+                                                              <div
+                                                                class="pf-c-chip-group__close"
+                                                              >
+                                                                <button
+                                                                  aria-disabled="false"
+                                                                  aria-label="Close chip group"
+                                                                  aria-labelledby="remove_group_pf-random-id-8 pf-random-id-8"
+                                                                  class="pf-c-button pf-m-plain"
+                                                                  data-ouia-component-id="Close chip group"
+                                                                  data-ouia-component-type="PF4/Button"
+                                                                  data-ouia-safe="true"
+                                                                  id="remove_group_pf-random-id-8"
+                                                                  type="button"
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden="true"
+                                                                    fill="currentColor"
+                                                                    height="1em"
+                                                                    role="img"
+                                                                    style="vertical-align: -0.125em;"
+                                                                    viewBox="0 0 512 512"
+                                                                    width="1em"
+                                                                  >
+                                                                    <path
+                                                                      d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
+                                                                    />
+                                                                  </svg>
+                                                                </button>
+                                                              </div>
+                                                            </div>
+                                                          </div>
+                                                        </div>
+                                                      }
+                                                    >
+                                                      <ToolbarItem
+                                                        variant="chip-group"
+                                                      >
+                                                        <div
+                                                          className="pf-c-toolbar__item pf-m-chip-group"
+                                                        >
+                                                          <ChipGroup
+                                                            aria-label="Chip group category"
+                                                            categoryName="State"
+                                                            closeBtnAriaLabel="Close chip group"
+                                                            collapsedText="\${remaining} more"
+                                                            defaultIsOpen={false}
+                                                            expandedText="Show Less"
+                                                            isClosable={true}
+                                                            key="State"
+                                                            numChips={3}
+                                                            onClick={[Function]}
+                                                            onOverflowChipClick={[Function]}
+                                                            tooltipPosition="top"
+                                                          >
+                                                            <GenerateId
+                                                              prefix="pf-random-id-"
+                                                            >
+                                                              <div
+                                                                className="pf-c-chip-group pf-m-category"
+                                                                data-ouia-component-type="PF4/ChipGroup"
+                                                                data-ouia-safe={true}
+                                                              >
+                                                                <div
+                                                                  className="pf-c-chip-group__main"
+                                                                >
+                                                                  <span
+                                                                    aria-hidden="true"
+                                                                    className="pf-c-chip-group__label"
+                                                                    id="pf-random-id-8"
+                                                                  >
+                                                                    State
+                                                                  </span>
+                                                                  <ul
+                                                                    aria-labelledby="pf-random-id-8"
+                                                                    className="pf-c-chip-group__list"
+                                                                    role="list"
+                                                                  >
+                                                                    <li
+                                                                      className="pf-c-chip-group__list-item"
+                                                                      key="0"
+                                                                    >
+                                                                      <Chip
+                                                                        className=""
+                                                                        closeBtnAriaLabel="close"
+                                                                        component="div"
+                                                                        isOverflowChip={false}
+                                                                        isReadOnly={false}
+                                                                        key=".$Same"
+                                                                        onClick={[Function]}
+                                                                        tooltipPosition="top"
+                                                                      >
+                                                                        <GenerateId
+                                                                          prefix="pf-random-id-"
+                                                                        >
+                                                                          <div
+                                                                            className="pf-c-chip"
+                                                                            data-ouia-component-id="OUIA-Generated-Chip-4"
+                                                                            data-ouia-component-type="PF4/Chip"
+                                                                            data-ouia-safe={true}
+                                                                          >
+                                                                            <span
+                                                                              className="pf-c-chip__text"
+                                                                              id="pf-random-id-9"
+                                                                            >
+                                                                              Same
+                                                                            </span>
+                                                                            <Button
+                                                                              aria-label="close"
+                                                                              aria-labelledby="remove_pf-random-id-9 pf-random-id-9"
+                                                                              id="remove_pf-random-id-9"
+                                                                              onClick={[Function]}
+                                                                              ouiaId="close"
+                                                                              variant="plain"
+                                                                            >
+                                                                              <ButtonBase
+                                                                                aria-label="close"
+                                                                                aria-labelledby="remove_pf-random-id-9 pf-random-id-9"
+                                                                                id="remove_pf-random-id-9"
+                                                                                innerRef={null}
+                                                                                onClick={[Function]}
+                                                                                ouiaId="close"
+                                                                                variant="plain"
+                                                                              >
+                                                                                <button
+                                                                                  aria-disabled={false}
+                                                                                  aria-label="close"
+                                                                                  aria-labelledby="remove_pf-random-id-9 pf-random-id-9"
+                                                                                  className="pf-c-button pf-m-plain"
+                                                                                  data-ouia-component-id="close"
+                                                                                  data-ouia-component-type="PF4/Button"
+                                                                                  data-ouia-safe={true}
+                                                                                  disabled={false}
+                                                                                  id="remove_pf-random-id-9"
+                                                                                  onClick={[Function]}
+                                                                                  role={null}
+                                                                                  type="button"
+                                                                                >
+                                                                                  <TimesIcon
+                                                                                    aria-hidden="true"
+                                                                                    color="currentColor"
+                                                                                    noVerticalAlign={false}
+                                                                                    size="sm"
+                                                                                  >
+                                                                                    <svg
+                                                                                      aria-hidden="true"
+                                                                                      aria-labelledby={null}
+                                                                                      fill="currentColor"
+                                                                                      height="1em"
+                                                                                      role="img"
+                                                                                      style={
+                                                                                        Object {
+                                                                                          "verticalAlign": "-0.125em",
+                                                                                        }
+                                                                                      }
+                                                                                      viewBox="0 0 352 512"
+                                                                                      width="1em"
+                                                                                    >
+                                                                                      <path
+                                                                                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                                                                      />
+                                                                                    </svg>
+                                                                                  </TimesIcon>
+                                                                                </button>
+                                                                              </ButtonBase>
+                                                                            </Button>
+                                                                          </div>
+                                                                        </GenerateId>
+                                                                      </Chip>
+                                                                    </li>
+                                                                    <li
+                                                                      className="pf-c-chip-group__list-item"
+                                                                      key="1"
+                                                                    >
+                                                                      <Chip
+                                                                        className=""
+                                                                        closeBtnAriaLabel="close"
+                                                                        component="div"
+                                                                        isOverflowChip={false}
+                                                                        isReadOnly={false}
+                                                                        key=".$Different"
+                                                                        onClick={[Function]}
+                                                                        tooltipPosition="top"
+                                                                      >
+                                                                        <GenerateId
+                                                                          prefix="pf-random-id-"
+                                                                        >
+                                                                          <div
+                                                                            className="pf-c-chip"
+                                                                            data-ouia-component-id="OUIA-Generated-Chip-5"
+                                                                            data-ouia-component-type="PF4/Chip"
+                                                                            data-ouia-safe={true}
+                                                                          >
+                                                                            <span
+                                                                              className="pf-c-chip__text"
+                                                                              id="pf-random-id-10"
+                                                                            >
+                                                                              Different
+                                                                            </span>
+                                                                            <Button
+                                                                              aria-label="close"
+                                                                              aria-labelledby="remove_pf-random-id-10 pf-random-id-10"
+                                                                              id="remove_pf-random-id-10"
+                                                                              onClick={[Function]}
+                                                                              ouiaId="close"
+                                                                              variant="plain"
+                                                                            >
+                                                                              <ButtonBase
+                                                                                aria-label="close"
+                                                                                aria-labelledby="remove_pf-random-id-10 pf-random-id-10"
+                                                                                id="remove_pf-random-id-10"
+                                                                                innerRef={null}
+                                                                                onClick={[Function]}
+                                                                                ouiaId="close"
+                                                                                variant="plain"
+                                                                              >
+                                                                                <button
+                                                                                  aria-disabled={false}
+                                                                                  aria-label="close"
+                                                                                  aria-labelledby="remove_pf-random-id-10 pf-random-id-10"
+                                                                                  className="pf-c-button pf-m-plain"
+                                                                                  data-ouia-component-id="close"
+                                                                                  data-ouia-component-type="PF4/Button"
+                                                                                  data-ouia-safe={true}
+                                                                                  disabled={false}
+                                                                                  id="remove_pf-random-id-10"
+                                                                                  onClick={[Function]}
+                                                                                  role={null}
+                                                                                  type="button"
+                                                                                >
+                                                                                  <TimesIcon
+                                                                                    aria-hidden="true"
+                                                                                    color="currentColor"
+                                                                                    noVerticalAlign={false}
+                                                                                    size="sm"
+                                                                                  >
+                                                                                    <svg
+                                                                                      aria-hidden="true"
+                                                                                      aria-labelledby={null}
+                                                                                      fill="currentColor"
+                                                                                      height="1em"
+                                                                                      role="img"
+                                                                                      style={
+                                                                                        Object {
+                                                                                          "verticalAlign": "-0.125em",
+                                                                                        }
+                                                                                      }
+                                                                                      viewBox="0 0 352 512"
+                                                                                      width="1em"
+                                                                                    >
+                                                                                      <path
+                                                                                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                                                                      />
+                                                                                    </svg>
+                                                                                  </TimesIcon>
+                                                                                </button>
+                                                                              </ButtonBase>
+                                                                            </Button>
+                                                                          </div>
+                                                                        </GenerateId>
+                                                                      </Chip>
+                                                                    </li>
+                                                                    <li
+                                                                      className="pf-c-chip-group__list-item"
+                                                                      key="2"
+                                                                    >
+                                                                      <Chip
+                                                                        className=""
+                                                                        closeBtnAriaLabel="close"
+                                                                        component="div"
+                                                                        isOverflowChip={false}
+                                                                        isReadOnly={false}
+                                                                        key=".$Incomplete data"
+                                                                        onClick={[Function]}
+                                                                        tooltipPosition="top"
+                                                                      >
+                                                                        <GenerateId
+                                                                          prefix="pf-random-id-"
+                                                                        >
+                                                                          <div
+                                                                            className="pf-c-chip"
+                                                                            data-ouia-component-id="OUIA-Generated-Chip-6"
+                                                                            data-ouia-component-type="PF4/Chip"
+                                                                            data-ouia-safe={true}
+                                                                          >
+                                                                            <span
+                                                                              className="pf-c-chip__text"
+                                                                              id="pf-random-id-11"
+                                                                            >
+                                                                              Incomplete data
+                                                                            </span>
+                                                                            <Button
+                                                                              aria-label="close"
+                                                                              aria-labelledby="remove_pf-random-id-11 pf-random-id-11"
+                                                                              id="remove_pf-random-id-11"
+                                                                              onClick={[Function]}
+                                                                              ouiaId="close"
+                                                                              variant="plain"
+                                                                            >
+                                                                              <ButtonBase
+                                                                                aria-label="close"
+                                                                                aria-labelledby="remove_pf-random-id-11 pf-random-id-11"
+                                                                                id="remove_pf-random-id-11"
+                                                                                innerRef={null}
+                                                                                onClick={[Function]}
+                                                                                ouiaId="close"
+                                                                                variant="plain"
+                                                                              >
+                                                                                <button
+                                                                                  aria-disabled={false}
+                                                                                  aria-label="close"
+                                                                                  aria-labelledby="remove_pf-random-id-11 pf-random-id-11"
+                                                                                  className="pf-c-button pf-m-plain"
+                                                                                  data-ouia-component-id="close"
+                                                                                  data-ouia-component-type="PF4/Button"
+                                                                                  data-ouia-safe={true}
+                                                                                  disabled={false}
+                                                                                  id="remove_pf-random-id-11"
+                                                                                  onClick={[Function]}
+                                                                                  role={null}
+                                                                                  type="button"
+                                                                                >
+                                                                                  <TimesIcon
+                                                                                    aria-hidden="true"
+                                                                                    color="currentColor"
+                                                                                    noVerticalAlign={false}
+                                                                                    size="sm"
+                                                                                  >
+                                                                                    <svg
+                                                                                      aria-hidden="true"
+                                                                                      aria-labelledby={null}
+                                                                                      fill="currentColor"
+                                                                                      height="1em"
+                                                                                      role="img"
+                                                                                      style={
+                                                                                        Object {
+                                                                                          "verticalAlign": "-0.125em",
+                                                                                        }
+                                                                                      }
+                                                                                      viewBox="0 0 352 512"
+                                                                                      width="1em"
+                                                                                    >
+                                                                                      <path
+                                                                                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                                                                      />
+                                                                                    </svg>
+                                                                                  </TimesIcon>
+                                                                                </button>
+                                                                              </ButtonBase>
+                                                                            </Button>
+                                                                          </div>
+                                                                        </GenerateId>
+                                                                      </Chip>
+                                                                    </li>
+                                                                  </ul>
+                                                                </div>
+                                                                <div
+                                                                  className="pf-c-chip-group__close"
+                                                                >
+                                                                  <Button
+                                                                    aria-label="Close chip group"
+                                                                    aria-labelledby="remove_group_pf-random-id-8 pf-random-id-8"
+                                                                    id="remove_group_pf-random-id-8"
+                                                                    onClick={[Function]}
+                                                                    ouiaId="Close chip group"
+                                                                    variant="plain"
+                                                                  >
+                                                                    <ButtonBase
+                                                                      aria-label="Close chip group"
+                                                                      aria-labelledby="remove_group_pf-random-id-8 pf-random-id-8"
+                                                                      id="remove_group_pf-random-id-8"
+                                                                      innerRef={null}
+                                                                      onClick={[Function]}
+                                                                      ouiaId="Close chip group"
+                                                                      variant="plain"
+                                                                    >
+                                                                      <button
+                                                                        aria-disabled={false}
+                                                                        aria-label="Close chip group"
+                                                                        aria-labelledby="remove_group_pf-random-id-8 pf-random-id-8"
+                                                                        className="pf-c-button pf-m-plain"
+                                                                        data-ouia-component-id="Close chip group"
+                                                                        data-ouia-component-type="PF4/Button"
+                                                                        data-ouia-safe={true}
+                                                                        disabled={false}
+                                                                        id="remove_group_pf-random-id-8"
+                                                                        onClick={[Function]}
+                                                                        role={null}
+                                                                        type="button"
+                                                                      >
+                                                                        <TimesCircleIcon
+                                                                          aria-hidden="true"
+                                                                          color="currentColor"
+                                                                          noVerticalAlign={false}
+                                                                          size="sm"
+                                                                        >
+                                                                          <svg
+                                                                            aria-hidden="true"
+                                                                            aria-labelledby={null}
+                                                                            fill="currentColor"
+                                                                            height="1em"
+                                                                            role="img"
+                                                                            style={
+                                                                              Object {
+                                                                                "verticalAlign": "-0.125em",
+                                                                              }
+                                                                            }
+                                                                            viewBox="0 0 512 512"
+                                                                            width="1em"
+                                                                          >
+                                                                            <path
+                                                                              d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
+                                                                            />
+                                                                          </svg>
+                                                                        </TimesCircleIcon>
+                                                                      </button>
+                                                                    </ButtonBase>
+                                                                  </Button>
+                                                                </div>
+                                                              </div>
+                                                            </GenerateId>
+                                                          </ChipGroup>
+                                                        </div>
+                                                      </ToolbarItem>
+                                                    </Portal>
+                                                  </ToolbarFilter>
+                                                </DriftFilterValue>
+                                              </div>
+                                            </ToolbarGroupWithRef>
+                                          </ForwardRef>
+                                        </DriftFilter>
                                         <ForwardRef
                                           variant="button-group"
                                         >
@@ -6436,7 +6516,7 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                                           <DropdownToggle
                                                             aria-haspopup={true}
                                                             getMenuRef={[Function]}
-                                                            id="pf-dropdown-toggle-id-7"
+                                                            id="pf-dropdown-toggle-id-6"
                                                             isOpen={false}
                                                             isPlain={true}
                                                             key=".0"
@@ -6458,7 +6538,7 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                                                     data-ouia-component-id="export-dropdown-comparison-toggle"
                                                                     data-ouia-component-type="PF4/DropdownToggle"
                                                                     data-ouia-safe="true"
-                                                                    id="pf-dropdown-toggle-id-7"
+                                                                    id="pf-dropdown-toggle-id-6"
                                                                     type="button"
                                                                   >
                                                                     <span>
@@ -6491,7 +6571,7 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                                               data-ouia-component-type="PF4/DropdownToggle"
                                                               data-ouia-safe={true}
                                                               getMenuRef={[Function]}
-                                                              id="pf-dropdown-toggle-id-7"
+                                                              id="pf-dropdown-toggle-id-6"
                                                               isActive={false}
                                                               isDisabled={false}
                                                               isOpen={false}
@@ -6515,7 +6595,7 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                                                       data-ouia-component-id="export-dropdown-comparison-toggle"
                                                                       data-ouia-component-type="PF4/DropdownToggle"
                                                                       data-ouia-safe="true"
-                                                                      id="pf-dropdown-toggle-id-7"
+                                                                      id="pf-dropdown-toggle-id-6"
                                                                       type="button"
                                                                     >
                                                                       <span>
@@ -6547,7 +6627,7 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                                                 data-ouia-component-type="PF4/DropdownToggle"
                                                                 data-ouia-safe={true}
                                                                 disabled={false}
-                                                                id="pf-dropdown-toggle-id-7"
+                                                                id="pf-dropdown-toggle-id-6"
                                                                 onClick={[Function]}
                                                                 onKeyDown={[Function]}
                                                                 type="button"
@@ -6693,7 +6773,7 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                                             data-ouia-component-id="clear-comparison-dropdown-toggle"
                                                             data-ouia-component-type="PF4/DropdownToggle"
                                                             getMenuRef={[Function]}
-                                                            id="pf-dropdown-toggle-id-8"
+                                                            id="pf-dropdown-toggle-id-7"
                                                             isOpen={false}
                                                             isPlain={true}
                                                             key=".0"
@@ -6717,7 +6797,7 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                                                     class="pf-c-dropdown__toggle pf-m-plain"
                                                                     data-ouia-component-id="clear-comparison-dropdown-toggle"
                                                                     data-ouia-component-type="PF4/DropdownToggle"
-                                                                    id="pf-dropdown-toggle-id-8"
+                                                                    id="pf-dropdown-toggle-id-7"
                                                                     type="button"
                                                                   >
                                                                     <svg
@@ -6746,7 +6826,7 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                                               data-ouia-component-id="clear-comparison-dropdown-toggle"
                                                               data-ouia-component-type="PF4/DropdownToggle"
                                                               getMenuRef={[Function]}
-                                                              id="pf-dropdown-toggle-id-8"
+                                                              id="pf-dropdown-toggle-id-7"
                                                               isActive={false}
                                                               isDisabled={false}
                                                               isOpen={false}
@@ -6773,7 +6853,7 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                                                       class="pf-c-dropdown__toggle pf-m-plain"
                                                                       data-ouia-component-id="clear-comparison-dropdown-toggle"
                                                                       data-ouia-component-type="PF4/DropdownToggle"
-                                                                      id="pf-dropdown-toggle-id-8"
+                                                                      id="pf-dropdown-toggle-id-7"
                                                                       type="button"
                                                                     >
                                                                       <svg
@@ -6802,7 +6882,7 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                                                 data-ouia-component-id="clear-comparison-dropdown-toggle"
                                                                 data-ouia-component-type="PF4/DropdownToggle"
                                                                 disabled={false}
-                                                                id="pf-dropdown-toggle-id-8"
+                                                                id="pf-dropdown-toggle-id-7"
                                                                 onClick={[Function]}
                                                                 onKeyDown={[Function]}
                                                                 type="button"
@@ -7084,7 +7164,7 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                                           aria-haspopup={true}
                                                           firstIndex={0}
                                                           getMenuRef={[Function]}
-                                                          id="pf-dropdown-toggle-id-9"
+                                                          id="pf-dropdown-toggle-id-8"
                                                           isDisabled={false}
                                                           isOpen={false}
                                                           isPlain={true}
@@ -8674,7 +8754,7 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                                         aria-haspopup={true}
                                                         firstIndex={0}
                                                         getMenuRef={[Function]}
-                                                        id="pf-dropdown-toggle-id-10"
+                                                        id="pf-dropdown-toggle-id-9"
                                                         isDisabled={false}
                                                         isOpen={false}
                                                         isPlain={true}


### PR DESCRIPTION
Before, the comparison table filter had a fact name search filter and a state dropdown filter that were static in the toolbar. This PR adds a dropdown to select the type of filter you'd like to use (Fact name or state) and switches between the previously mentioned search filter and state dropdown filter depending on your dropdown selection.

To test:
- Go to drift app
- Click "Add to comparison" button (ensure you have at least one system or baseline)
- Select at least one system or baseline to create a comparison and click "Submit"

Test the filters and chips to ensure that filters are properly added and removed. Don't forget to test the feature when filtering by fact name that allows you to type a fact name filter and press enter. This allows to effectively set a filter and type in additional fact name filters. This filter acts as an OR filter. Filtering with "dog" and "cat" will give you facts that contain "dog" OR "cat".

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
