### PR TITLE
[DRFT-1007] Set fact type filters in url

### DIFF
--- a/src/SmartComponents/DriftPage/DriftPage.js
+++ b/src/SmartComponents/DriftPage/DriftPage.js
@@ -177,6 +177,8 @@ export class DriftPage extends Component {
                                                 historicalProfiles={ historicalProfiles }
                                                 selectedHSPIds={ selectedHSPIds }
                                                 selectedBaselineIds={ selectedBaselineIds }
+                                                factTypeFilters={ factTypeFilters }
+                                                toggleFactTypeFilter={ toggleFactTypeFilter }
                                             />
                                             { !emptyState && !loading ?
                                                 <Toolbar className="drift-toolbar">

--- a/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
+++ b/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
@@ -183,8 +183,22 @@ export class DriftTable extends Component {
         }
     }
 
+    addFilters(newFilters, filters, addFunction) {
+        if (newFilters?.length > 0) {
+            filters.forEach(function(filter) {
+                let x = { ...filter };
+
+                if (newFilters?.includes(filter.filter.toLowerCase())) {
+                    x.selected = false;
+                }
+
+                addFunction(x);
+            });
+        }
+    }
+
     setFilters() {
-        const { addStateFilter, handleFactFilter, location, stateFilters } = this.props;
+        const { addStateFilter, factTypeFilters, handleFactFilter, location, stateFilters, toggleFactTypeFilter } = this.props;
         let searchParams = new URLSearchParams(location.search);
 
         searchParams.get('filter[name]')?.split(',').forEach(function(factFilter) {
@@ -192,18 +206,10 @@ export class DriftTable extends Component {
         });
 
         let newStateFilters = searchParams.get('filter[state]')?.split(',');
+        let newFactTypeFilters = searchParams.get('filter[show]')?.split(',');
 
-        if (newStateFilters?.length > 0) {
-            stateFilters.forEach(function(stateFilter) {
-                let filter = { ...stateFilter };
-
-                if (newStateFilters?.includes(stateFilter.filter.toLowerCase())) {
-                    filter.selected = false;
-                }
-
-                addStateFilter(filter);
-            });
-        }
+        this.addFilters(newStateFilters, stateFilters, addStateFilter);
+        this.addFilters(newFactTypeFilters, factTypeFilters, toggleFactTypeFilter);
     }
 
     setSort() {
@@ -558,7 +564,9 @@ DriftTable.propTypes = {
     handleBaselineSelection: PropTypes.func,
     handleHSPSelection: PropTypes.func,
     handleSystemSelection: PropTypes.func,
-    hasHSPReadPermissions: PropTypes.bool
+    hasHSPReadPermissions: PropTypes.bool,
+    factTypeFilters: PropTypes.array,
+    toggleFactTypeFilters: PropTypes.func
 };
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(DriftTable));

--- a/src/SmartComponents/DriftPage/__tests__/__snapshots__/DriftPage.tests.js.snap
+++ b/src/SmartComponents/DriftPage/__tests__/__snapshots__/DriftPage.tests.js.snap
@@ -3598,6 +3598,20 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
                             clearComparison={[Function]}
                             error={Object {}}
                             factFilter=""
+                            factTypeFilters={
+                              Array [
+                                Object {
+                                  "display": "All facts",
+                                  "filter": "ALL",
+                                  "selected": true,
+                                },
+                                Object {
+                                  "display": "Baseline facts only",
+                                  "filter": "BASELINE",
+                                  "selected": false,
+                                },
+                              ]
+                            }
                             handleBaselineSelection={[Function]}
                             handleFactFilter={[Function]}
                             handleHSPSelection={[Function]}
@@ -3633,6 +3647,7 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
                               ]
                             }
                             systems={Array []}
+                            toggleFactTypeFilter={[Function]}
                             updateReferenceId={[Function]}
                           >
                             <Connect(DriftTable)
@@ -3642,6 +3657,20 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
                               clearComparison={[Function]}
                               error={Object {}}
                               factFilter=""
+                              factTypeFilters={
+                                Array [
+                                  Object {
+                                    "display": "All facts",
+                                    "filter": "ALL",
+                                    "selected": true,
+                                  },
+                                  Object {
+                                    "display": "Baseline facts only",
+                                    "filter": "BASELINE",
+                                    "selected": false,
+                                  },
+                                ]
+                              }
                               handleBaselineSelection={[Function]}
                               handleFactFilter={[Function]}
                               handleHSPSelection={[Function]}
@@ -3723,6 +3752,7 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
                                 ]
                               }
                               systems={Array []}
+                              toggleFactTypeFilter={[Function]}
                               updateReferenceId={[Function]}
                             >
                               <DriftTable
@@ -3735,6 +3765,20 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
                                 error={Object {}}
                                 expandRow={[Function]}
                                 factFilter=""
+                                factTypeFilters={
+                                  Array [
+                                    Object {
+                                      "display": "All facts",
+                                      "filter": "ALL",
+                                      "selected": true,
+                                    },
+                                    Object {
+                                      "display": "Baseline facts only",
+                                      "filter": "BASELINE",
+                                      "selected": false,
+                                    },
+                                  ]
+                                }
                                 fetchCompare={[Function]}
                                 fullCompareData={Array []}
                                 handleBaselineSelection={[Function]}
@@ -3822,6 +3866,7 @@ exports[`ConnectedDriftPage should render correctly 1`] = `
                                 }
                                 systems={Array []}
                                 toggleFactSort={[Function]}
+                                toggleFactTypeFilter={[Function]}
                                 toggleStateSort={[Function]}
                                 updateReferenceId={[Function]}
                               >
@@ -8587,6 +8632,20 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                               }
                             }
                             factFilter=""
+                            factTypeFilters={
+                              Array [
+                                Object {
+                                  "display": "All facts",
+                                  "filter": "ALL",
+                                  "selected": true,
+                                },
+                                Object {
+                                  "display": "Baseline facts only",
+                                  "filter": "BASELINE",
+                                  "selected": false,
+                                },
+                              ]
+                            }
                             handleBaselineSelection={[Function]}
                             handleFactFilter={[Function]}
                             handleHSPSelection={[Function]}
@@ -8622,6 +8681,7 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                               ]
                             }
                             systems={Array []}
+                            toggleFactTypeFilter={[Function]}
                             updateReferenceId={[Function]}
                           >
                             <Connect(DriftTable)
@@ -8635,6 +8695,20 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                 }
                               }
                               factFilter=""
+                              factTypeFilters={
+                                Array [
+                                  Object {
+                                    "display": "All facts",
+                                    "filter": "ALL",
+                                    "selected": true,
+                                  },
+                                  Object {
+                                    "display": "Baseline facts only",
+                                    "filter": "BASELINE",
+                                    "selected": false,
+                                  },
+                                ]
+                              }
                               handleBaselineSelection={[Function]}
                               handleFactFilter={[Function]}
                               handleHSPSelection={[Function]}
@@ -8716,6 +8790,7 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                 ]
                               }
                               systems={Array []}
+                              toggleFactTypeFilter={[Function]}
                               updateReferenceId={[Function]}
                             >
                               <DriftTable
@@ -8732,6 +8807,20 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                 }
                                 expandRow={[Function]}
                                 factFilter=""
+                                factTypeFilters={
+                                  Array [
+                                    Object {
+                                      "display": "All facts",
+                                      "filter": "ALL",
+                                      "selected": true,
+                                    },
+                                    Object {
+                                      "display": "Baseline facts only",
+                                      "filter": "BASELINE",
+                                      "selected": false,
+                                    },
+                                  ]
+                                }
                                 fetchCompare={[Function]}
                                 fullCompareData={Array []}
                                 handleBaselineSelection={[Function]}
@@ -8819,6 +8908,7 @@ exports[`ConnectedDriftPage should render with error alert 1`] = `
                                 }
                                 systems={Array []}
                                 toggleFactSort={[Function]}
+                                toggleFactTypeFilter={[Function]}
                                 toggleStateSort={[Function]}
                                 updateReferenceId={[Function]}
                               >


### PR DESCRIPTION
To test:
Create a comparison with at least one baseline that has at least one fact
Include the filter in the url for fact type filters `&filter[show]=baseline` like so: https://stage.foo.redhat.com:1337/insights/drift/?baseline_ids=<id>&reference_id=<id>&system_ids=<id>&filter[show]=baseline&filter[state]=same,different,incomplete_data&sort=-state,fact

This should load the comparison with the baseline only fact type filter set.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
