### PR TITLE
[DRFT-1007] Fix fact type filters in url

### DIFF
--- a/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
+++ b/src/SmartComponents/DriftPage/DriftTable/DriftTable.js
@@ -183,16 +183,22 @@ export class DriftTable extends Component {
         }
     }
 
-    addFilters(newFilters, filters, addFunction) {
+    addFilters(newFilters, filters, addFunction, type) {
         if (newFilters?.length > 0) {
             filters.forEach(function(filter) {
                 let x = { ...filter };
 
                 if (newFilters?.includes(filter.filter.toLowerCase())) {
                     x.selected = false;
+                    
+                    if (type === 'fact') {
+                        addFunction(x);
+                    }
                 }
 
-                addFunction(x);
+                if (type === 'state') {
+                    addFunction(x);
+                }
             });
         }
     }
@@ -208,8 +214,8 @@ export class DriftTable extends Component {
         let newStateFilters = searchParams.get('filter[state]')?.split(',');
         let newFactTypeFilters = searchParams.get('filter[show]')?.split(',');
 
-        this.addFilters(newStateFilters, stateFilters, addStateFilter);
-        this.addFilters(newFactTypeFilters, factTypeFilters, toggleFactTypeFilter);
+        this.addFilters(newStateFilters, stateFilters, addStateFilter, 'state');
+        this.addFilters(newFactTypeFilters, factTypeFilters, toggleFactTypeFilter, 'fact');
     }
 
     setSort() {


### PR DESCRIPTION
See #562. That PR was supposed to allow manual fact type filter changes in the url. But it was broken. Adding `&filter[show]=baseline` worked correctly, but if you added `&filter[show]=all` it would reset to show baseline facts only. This PR fixes that.

To test, try setting both `baseline` and `all` in the url and ensure that the table displays the correct filters.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
