### PR TITLE
[DRFT-995] Include Ansible in workloads filter

### DIFF
--- a/config/setupTests.js
+++ b/config/setupTests.js
@@ -1,6 +1,8 @@
 import { configure, mount, render, shallow } from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+
 configure({ adapter: new Adapter() });
 global.shallow = shallow;
 global.render = render;

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,10 @@
         "@babel/preset-flow": "^7.16.7",
         "@babel/preset-react": "^7.16.7",
         "@redhat-cloud-services/frontend-components-config": "^4.6.1",
+        "@testing-library/dom": "^8.11.3",
+        "@testing-library/jest-dom": "^5.16.2",
+        "@testing-library/react": "^12.1.3",
+        "@testing-library/user-event": "^13.5.0",
         "@wojtekmaj/enzyme-adapter-react-17": "0.6.6",
         "babel-core": "^7.0.0-bridge.0",
         "babel-jest": "^27.5.1",
@@ -4816,6 +4820,218 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.11.3.tgz",
+      "integrity": "sha512-9LId28I+lx70wUiZjLvi1DB/WT2zGOxUh46glrSNMaWVx849kKAluezVzZrXJfTKKoQTmEOutLes/bHg4Bj3aA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^5.0.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.4.4",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@testing-library/dom/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "5.16.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.16.2.tgz",
+      "integrity": "sha512-6ewxs1MXWwsBFZXIk4nKKskWANelkdUehchEOokHsN8X7c2eKXGw+77aRV63UU8f/DTSVUPLaGxdrj4lN7D/ug==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.9.2",
+        "@types/testing-library__jest-dom": "^5.9.1",
+        "aria-query": "^5.0.0",
+        "chalk": "^3.0.0",
+        "css": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.5.6",
+        "lodash": "^4.17.15",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.3.tgz",
+      "integrity": "sha512-oCULRXWRrBtC9m6G/WohPo1GLcLesH7T4fuKzRAKn1CWVu9BzXtqLXDDTA6KhFNNtRwLtfSMr20HFl+Qrdrvmg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^8.0.0",
+        "@types/react-dom": "*"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.5.0.tgz",
+      "integrity": "sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -4824,6 +5040,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.1.18",
@@ -4973,6 +5195,16 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@types/jest": {
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.4.0.tgz",
+      "integrity": "sha512-gHl8XuC1RZ8H2j5sHv/JqsaxXkDDM9iDOgu0Wp8sjs4u/snb2PVehyWXJPr+ORA0RPpgw231mnutWI1+0hgjIQ==",
+      "dev": true,
+      "dependencies": {
+        "jest-diff": "^27.0.0",
+        "pretty-format": "^27.0.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
@@ -5030,6 +5262,15 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/@types/react-dom": {
+      "version": "17.0.11",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.11.tgz",
+      "integrity": "sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/react-redux": {
       "version": "7.1.22",
       "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.22.tgz",
@@ -5069,6 +5310,15 @@
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.8.tgz",
       "integrity": "sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==",
       "dev": true
+    },
+    "node_modules/@types/testing-library__jest-dom": {
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.2.tgz",
+      "integrity": "sha512-vehbtyHUShPxIa9SioxDwCvgxukDMH//icJG90sXQBUm5lJOHLT5kNeU9tnivhnA/TkOFMzGIXN2cTc4hY8/kg==",
+      "dev": true,
+      "dependencies": {
+        "@types/jest": "*"
+      }
     },
     "node_modules/@types/uglify-js": {
       "version": "3.13.1",
@@ -5685,6 +5935,15 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "node_modules/aria-query": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
+      "integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -6013,6 +6272,18 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
+    },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true,
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
     },
     "node_modules/attr-accept": {
       "version": "1.1.3",
@@ -7412,6 +7683,17 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
+      "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "source-map": "^0.6.1",
+        "source-map-resolve": "^0.6.0"
+      }
+    },
     "node_modules/css-functions-list": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.0.0.tgz",
@@ -7522,6 +7804,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
+      "dev": true
+    },
+    "node_modules/css/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/cssesc": {
@@ -7872,6 +8169,12 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.11.tgz",
+      "integrity": "sha512-7X6GvzjYf4yTdRKuCVScV+aA9Fvh5r8WzWrXBH9w82ZWB/eYDMGCnazoC/YAqAzUJWHzLOnZqr46K3iEyUhUvw==",
+      "dev": true
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -13346,6 +13649,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+      "dev": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -16436,6 +16748,17 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-resolve": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+      "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+      "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
+      "dev": true,
+      "dependencies": {
+        "atob": "^2.1.2",
+        "decode-uri-component": "^0.2.0"
       }
     },
     "node_modules/source-map-support": {
@@ -22523,10 +22846,171 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@testing-library/dom": {
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.11.3.tgz",
+      "integrity": "sha512-9LId28I+lx70wUiZjLvi1DB/WT2zGOxUh46glrSNMaWVx849kKAluezVzZrXJfTKKoQTmEOutLes/bHg4Bj3aA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^5.0.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.4.4",
+        "pretty-format": "^27.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@testing-library/jest-dom": {
+      "version": "5.16.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.16.2.tgz",
+      "integrity": "sha512-6ewxs1MXWwsBFZXIk4nKKskWANelkdUehchEOokHsN8X7c2eKXGw+77aRV63UU8f/DTSVUPLaGxdrj4lN7D/ug==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@types/testing-library__jest-dom": "^5.9.1",
+        "aria-query": "^5.0.0",
+        "chalk": "^3.0.0",
+        "css": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.5.6",
+        "lodash": "^4.17.15",
+        "redent": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@testing-library/react": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.3.tgz",
+      "integrity": "sha512-oCULRXWRrBtC9m6G/WohPo1GLcLesH7T4fuKzRAKn1CWVu9BzXtqLXDDTA6KhFNNtRwLtfSMr20HFl+Qrdrvmg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^8.0.0",
+        "@types/react-dom": "*"
+      }
+    },
+    "@testing-library/user-event": {
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.5.0.tgz",
+      "integrity": "sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5"
+      }
+    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "dev": true
+    },
+    "@types/aria-query": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
       "dev": true
     },
     "@types/babel__core": {
@@ -22677,6 +23161,16 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/jest": {
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.4.0.tgz",
+      "integrity": "sha512-gHl8XuC1RZ8H2j5sHv/JqsaxXkDDM9iDOgu0Wp8sjs4u/snb2PVehyWXJPr+ORA0RPpgw231mnutWI1+0hgjIQ==",
+      "dev": true,
+      "requires": {
+        "jest-diff": "^27.0.0",
+        "pretty-format": "^27.0.0"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
@@ -22734,6 +23228,15 @@
         "csstype": "^3.0.2"
       }
     },
+    "@types/react-dom": {
+      "version": "17.0.11",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.11.tgz",
+      "integrity": "sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/react-redux": {
       "version": "7.1.22",
       "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.22.tgz",
@@ -22773,6 +23276,15 @@
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.8.tgz",
       "integrity": "sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==",
       "dev": true
+    },
+    "@types/testing-library__jest-dom": {
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.2.tgz",
+      "integrity": "sha512-vehbtyHUShPxIa9SioxDwCvgxukDMH//icJG90sXQBUm5lJOHLT5kNeU9tnivhnA/TkOFMzGIXN2cTc4hY8/kg==",
+      "dev": true,
+      "requires": {
+        "@types/jest": "*"
+      }
     },
     "@types/uglify-js": {
       "version": "3.13.1",
@@ -23291,6 +23803,12 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "aria-query": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
+      "integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
+      "dev": true
+    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -23529,6 +24047,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
     "attr-accept": {
@@ -24596,6 +25120,25 @@
         "which": "^2.0.1"
       }
     },
+    "css": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
+      "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.4",
+        "source-map": "^0.6.1",
+        "source-map-resolve": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "css-functions-list": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.0.0.tgz",
@@ -24670,6 +25213,12 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
       "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
+      "dev": true
+    },
+    "css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
       "dev": true
     },
     "cssesc": {
@@ -24948,6 +25497,12 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dom-accessibility-api": {
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.11.tgz",
+      "integrity": "sha512-7X6GvzjYf4yTdRKuCVScV+aA9Fvh5r8WzWrXBH9w82ZWB/eYDMGCnazoC/YAqAzUJWHzLOnZqr46K3iEyUhUvw==",
+      "dev": true
     },
     "dom-converter": {
       "version": "0.2.0",
@@ -29030,6 +29585,12 @@
         "yallist": "^4.0.0"
       }
     },
+    "lz-string": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+      "dev": true
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -31372,6 +31933,16 @@
             "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
         }
+      }
+    },
+    "source-map-resolve": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+      "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+      "dev": true,
+      "requires": {
+        "atob": "^2.1.2",
+        "decode-uri-component": "^0.2.0"
       }
     },
     "source-map-support": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "testPathIgnorePatterns": [
       "<rootDir>/.+fixtures.+"
     ],
-    "setupFiles": [
+    "setupFilesAfterEnv": [
       "<rootDir>/config/setupTests.js"
     ],
     "roots": [
@@ -62,6 +62,10 @@
     "@babel/preset-flow": "^7.16.7",
     "@babel/preset-react": "^7.16.7",
     "@redhat-cloud-services/frontend-components-config": "^4.6.1",
+    "@testing-library/dom": "^8.11.3",
+    "@testing-library/jest-dom": "^5.16.2",
+    "@testing-library/react": "^12.1.3",
+    "@testing-library/user-event": "^13.5.0",
     "@wojtekmaj/enzyme-adapter-react-17": "0.6.6",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^27.5.1",

--- a/src/SmartComponents/AddSystemModal/__tests__/AddSystemModal.tests.js
+++ b/src/SmartComponents/AddSystemModal/__tests__/AddSystemModal.tests.js
@@ -9,6 +9,7 @@ import toJson from 'enzyme-to-json';
 import ConnectedAddSystemModal, { AddSystemModal } from '../AddSystemModal';
 import { compareReducerPayload } from '../../modules/__tests__/reducer.fixtures';
 import modalFixtures from '../redux/__tests__/addSystemModalReducer.fixtures';
+import globalFilterAlertFixtures from '../../GlobalFilterAlert/__tests__/GlobalFilterAlert.fixtures';
 
 import { createMiddlewareListener } from '../../../store';
 
@@ -410,17 +411,7 @@ describe('ConnectedAddSystemModal', () => {
     });
 
     it('should render GlobalFilterAlert', () => {
-        initialState.globalFilterState.workloadsFilter = {
-            SAP: {
-                group: {
-                    name: 'Workloads'
-                },
-                item: {
-                    value: 'SAP'
-                }
-            }
-        };
-
+        initialState.globalFilterState.workloadsFilter = globalFilterAlertFixtures.workloadsFilterSAPTrue;
         initialState.globalFilterState.sidsFilter = [ 'AB1', 'XY1' ];
         initialState.globalFilterState.tagsFilter = [
             'patch/rest=patchman-engine', 'patch/dev=patchman-engine', 'insights-client/group=XmygroupX'

--- a/src/SmartComponents/GlobalFilterAlert/GlobalFilterAlert.js
+++ b/src/SmartComponents/GlobalFilterAlert/GlobalFilterAlert.js
@@ -7,12 +7,31 @@ export class GlobalFilterAlert extends Component {
         super(props);
     }
 
+    isFilterSelected = (workloadsFilter) => {
+        return workloadsFilter?.SAP?.isSelected || workloadsFilter['Ansible Automation Platform']?.isSelected;
+    }
+
     buildBody = () => {
         const { sidsFilter, tagsFilter, workloadsFilter } = this.props.globalFilterState;
+        let filters = '';
 
-        let filters = Object.keys(workloadsFilter).length
-            ? 'Workloads: ' + Object.keys(workloadsFilter)[0] + '. '
-            : '';
+        if (this.isFilterSelected(workloadsFilter)) {
+            filters = 'Workloads:';
+            let first = true;
+
+            for (const workload in workloadsFilter) {
+                if (workloadsFilter[workload].isSelected) {
+                    if (!first) {
+                        filters = `${ filters }, ${ workload }`;
+                    } else {
+                        filters = `${ filters } ${ workload }`;
+                        first = false;
+                    }
+                }
+            }
+
+            filters += '. ';
+        }
 
         if (sidsFilter.length) {
             filters += 'SAP ID (SID): ';
@@ -64,7 +83,7 @@ export class GlobalFilterAlert extends Component {
 
         return (
             <React.Fragment>
-                { workloadsFilter.SAP?.isSelected || sidsFilter.length > 0 || tagsFilter.length > 0
+                { this.isFilterSelected(workloadsFilter) || sidsFilter.length > 0 || tagsFilter.length > 0
                     ? <Alert
                         variant='info'
                         title='Your systems are pre-filtered by the global context selector.'

--- a/src/SmartComponents/GlobalFilterAlert/__tests__/GlobalFilterAlert.fixtures.js
+++ b/src/SmartComponents/GlobalFilterAlert/__tests__/GlobalFilterAlert.fixtures.js
@@ -1,0 +1,142 @@
+const workloadsFilterSAPTrue = {
+    SAP: {
+        group: {
+            name: 'Workloads'
+        },
+        item: {
+            value: 'SAP'
+        },
+        isSelected: true
+    }
+};
+
+const workloadsFilterSAPFalse = {
+    SAP: {
+        group: {
+            name: 'Workloads'
+        },
+        item: {
+            value: 'SAP'
+        },
+        isSelected: false
+    }
+};
+
+const workloadsFilterAnsibleTrue = {
+    'Ansible Automation Platform': {
+        group: {
+            name: 'Workloads'
+        },
+        item: {
+            value: 'Ansible Automation Platform'
+        },
+        isSelected: true
+    }
+};
+
+const workloadsFilterAnsibleFalse = {
+    'Ansible Automation Platform': {
+        group: {
+            name: 'Workloads'
+        },
+        item: {
+            value: 'Ansible Automation Platform'
+        },
+        isSelected: false
+    }
+};
+
+const allWorkloadsFiltersTrue = {
+    'Ansible Automation Platform': {
+        group: {
+            name: 'Workloads'
+        },
+        item: {
+            value: 'Ansible Automation Platform'
+        },
+        isSelected: true
+    },
+    SAP: {
+        group: {
+            name: 'Workloads'
+        },
+        item: {
+            value: 'SAP'
+        },
+        isSelected: true
+    }
+};
+
+const allWorkloadsFiltersSAPTrue = {
+    'Ansible Automation Platform': {
+        group: {
+            name: 'Workloads'
+        },
+        item: {
+            value: 'Ansible Automation Platform'
+        },
+        isSelected: false
+    },
+    SAP: {
+        group: {
+            name: 'Workloads'
+        },
+        item: {
+            value: 'SAP'
+        },
+        isSelected: true
+    }
+};
+
+const allWorkloadsFiltersAnsibleTrue = {
+    'Ansible Automation Platform': {
+        group: {
+            name: 'Workloads'
+        },
+        item: {
+            value: 'Ansible Automation Platform'
+        },
+        isSelected: true
+    },
+    SAP: {
+        group: {
+            name: 'Workloads'
+        },
+        item: {
+            value: 'SAP'
+        },
+        isSelected: false
+    }
+};
+
+const allWorkloadsFiltersFalse = {
+    'Ansible Automation Platform': {
+        group: {
+            name: 'Workloads'
+        },
+        item: {
+            value: 'Ansible Automation Platform'
+        },
+        isSelected: false
+    },
+    SAP: {
+        group: {
+            name: 'Workloads'
+        },
+        item: {
+            value: 'SAP'
+        },
+        isSelected: false
+    }
+};
+
+export default {
+    workloadsFilterSAPTrue,
+    workloadsFilterSAPFalse,
+    workloadsFilterAnsibleTrue,
+    workloadsFilterAnsibleFalse,
+    allWorkloadsFiltersTrue,
+    allWorkloadsFiltersSAPTrue,
+    allWorkloadsFiltersAnsibleTrue,
+    allWorkloadsFiltersFalse
+};

--- a/src/SmartComponents/GlobalFilterAlert/__tests__/GlobalFilterAlert.tests.js
+++ b/src/SmartComponents/GlobalFilterAlert/__tests__/GlobalFilterAlert.tests.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-import toJson from 'enzyme-to-json';
+import { render } from '@testing-library/react';
 
 import { GlobalFilterAlert } from '../GlobalFilterAlert';
+import fixtures from './GlobalFilterAlert.fixtures';
 
-describe('GlobalFilterAlert', () => {
+describe('GlobalFilterAlert react-testing-library', () => {
     let props;
 
     beforeEach(() => {
@@ -18,99 +18,109 @@ describe('GlobalFilterAlert', () => {
     });
 
     it('should not render when empty', () => {
-        const wrapper = shallow(
-            <GlobalFilterAlert
-                { ...props }
-            />
-        );
+        const { asFragment } = render(<GlobalFilterAlert { ...props }/>);
 
-        expect(toJson(wrapper)).toMatchSnapshot();
-    });
-
-    it('should not render with all workloads', () => {
-        props.globalFilterState.workloadsFilter = {
-            'All Workloads': {
-                group: {
-                    name: 'Workloads'
-                }
-            }
-        };
-
-        const wrapper = shallow(
-            <GlobalFilterAlert
-                { ...props }
-            />
-        );
-
-        expect(toJson(wrapper)).toMatchSnapshot();
+        expect(asFragment()).toMatchSnapshot();
     });
 
     it('should render with SAP', () => {
-        props.globalFilterState.workloadsFilter = {
-            SAP: {
-                group: {
-                    name: 'Workloads'
-                },
-                item: {
-                    value: 'SAP'
-                },
-                isSelected: true
-            }
-        };
+        props.globalFilterState.workloadsFilter = fixtures.workloadsFilterSAPTrue;
+        const { asFragment } = render(<GlobalFilterAlert { ...props }/>);
 
-        const wrapper = shallow(
-            <GlobalFilterAlert
-                { ...props }
-            />
-        );
-
-        expect(toJson(wrapper)).toMatchSnapshot();
+        expect(asFragment()).toMatchSnapshot();
     });
 
     it('should NOT render with not selected SAP', () => {
-        props.globalFilterState.workloadsFilter = {
-            SAP: {
-                group: {
-                    name: 'Workloads'
-                },
-                item: {
-                    value: 'SAP'
-                },
-                isSelected: false
-            }
-        };
+        props.globalFilterState.workloadsFilter = fixtures.workloadsFilterSAPFalse;
 
-        const wrapper = shallow(
+        const { asFragment } = render(<GlobalFilterAlert { ...props }/>);
+
+        expect(asFragment()).toMatchSnapshot();
+    });
+
+    it('should render with Ansible Automation Platform', () => {
+        props.globalFilterState.workloadsFilter = fixtures.workloadsFilterAnsibleTrue;
+
+        const { asFragment } = render(
             <GlobalFilterAlert
                 { ...props }
             />
         );
 
-        expect(toJson(wrapper)).toMatchSnapshot();
+        expect(asFragment()).toMatchSnapshot();
+    });
+
+    it('should NOT render with Ansible Automation Platform', () => {
+        props.globalFilterState.workloadsFilter = fixtures.workloadsFilterAnsibleFalse;
+
+        const { asFragment } = render(
+            <GlobalFilterAlert
+                { ...props }
+            />
+        );
+
+        expect(asFragment()).toMatchSnapshot();
+    });
+
+    it('should render with SAP with both filters', () => {
+        props.globalFilterState.workloadsFilter = fixtures.allWorkloadsFiltersSAPTrue;
+
+        const { asFragment } = render(
+            <GlobalFilterAlert
+                { ...props }
+            />
+        );
+
+        expect(asFragment()).toMatchSnapshot();
+    });
+
+    it('should render with Ansible Automation Platform with both filters', () => {
+        props.globalFilterState.workloadsFilter = fixtures.allWorkloadsFiltersAnsibleTrue;
+
+        const { asFragment } = render(
+            <GlobalFilterAlert
+                { ...props }
+            />
+        );
+
+        expect(asFragment()).toMatchSnapshot();
+    });
+
+    it('should render with SAP and Ansible Automation Platform', () => {
+        props.globalFilterState.workloadsFilter = fixtures.allWorkloadsFiltersTrue;
+
+        const { asFragment } = render(
+            <GlobalFilterAlert
+                { ...props }
+            />
+        );
+
+        expect(asFragment()).toMatchSnapshot();
+    });
+
+    it('should Not render with SAP and Ansible Automation Platform', () => {
+        props.globalFilterState.workloadsFilter = fixtures.allWorkloadsFiltersFalse;
+
+        const { asFragment } = render(
+            <GlobalFilterAlert
+                { ...props }
+            />
+        );
+
+        expect(asFragment()).toMatchSnapshot();
     });
 
     it('should render with SAP and filters', () => {
-        props.globalFilterState.workloadsFilter = {
-            SAP: {
-                group: {
-                    name: 'Workloads'
-                },
-                item: {
-                    value: 'SAP'
-                },
-                isSelected: true
-            }
-        };
-
+        props.globalFilterState.workloadsFilter = fixtures.workloadsFilterSAPTrue;
         props.globalFilterState.sidsFilter = [ 'AB1', 'XY1' ];
         props.globalFilterState.tagsFilter = [ 'patch/rest=patchman-engine', 'patch/dev=patchman-engine', 'insights-client/group=XmygroupX' ];
 
-        const wrapper = shallow(
+        const { asFragment } = render(
             <GlobalFilterAlert
                 { ...props }
             />
         );
 
-        expect(toJson(wrapper)).toMatchSnapshot();
+        expect(asFragment()).toMatchSnapshot();
     });
 });

--- a/src/SmartComponents/GlobalFilterAlert/__tests__/__snapshots__/GlobalFilterAlert.tests.js.snap
+++ b/src/SmartComponents/GlobalFilterAlert/__tests__/__snapshots__/GlobalFilterAlert.tests.js.snap
@@ -1,35 +1,291 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`GlobalFilterAlert should NOT render with not selected SAP 1`] = `<Fragment />`;
+exports[`GlobalFilterAlert react-testing-library should NOT render with Ansible Automation Platform 1`] = `<DocumentFragment />`;
 
-exports[`GlobalFilterAlert should not render when empty 1`] = `<Fragment />`;
+exports[`GlobalFilterAlert react-testing-library should NOT render with not selected SAP 1`] = `<DocumentFragment />`;
 
-exports[`GlobalFilterAlert should not render with all workloads 1`] = `<Fragment />`;
+exports[`GlobalFilterAlert react-testing-library should Not render with SAP and Ansible Automation Platform 1`] = `<DocumentFragment />`;
 
-exports[`GlobalFilterAlert should render with SAP 1`] = `
-<Fragment>
-  <Alert
-    isInline={true}
-    title="Your systems are pre-filtered by the global context selector."
-    variant="info"
+exports[`GlobalFilterAlert react-testing-library should not render when empty 1`] = `<DocumentFragment />`;
+
+exports[`GlobalFilterAlert react-testing-library should render with Ansible Automation Platform 1`] = `
+<DocumentFragment>
+  <div
+    aria-label="Info Alert"
+    class="pf-c-alert pf-m-inline pf-m-info"
+    data-ouia-component-id="OUIA-Generated-Alert-info-2"
+    data-ouia-component-type="PF4/Alert"
+    data-ouia-safe="true"
   >
-    <p>
-      Workloads: SAP. 
-    </p>
-  </Alert>
-</Fragment>
+    <div
+      class="pf-c-alert__icon"
+    >
+      <svg
+        aria-hidden="true"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 512 512"
+        width="1em"
+      >
+        <path
+          d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+        />
+      </svg>
+    </div>
+    <h4
+      class="pf-c-alert__title"
+    >
+      <span
+        class="pf-u-screen-reader"
+      >
+        Info alert:
+      </span>
+      Your systems are pre-filtered by the global context selector.
+    </h4>
+    <div
+      class="pf-c-alert__description"
+    >
+      <p>
+        Workloads: Ansible Automation Platform. 
+      </p>
+    </div>
+  </div>
+</DocumentFragment>
 `;
 
-exports[`GlobalFilterAlert should render with SAP and filters 1`] = `
-<Fragment>
-  <Alert
-    isInline={true}
-    title="Your systems are pre-filtered by the global context selector."
-    variant="info"
+exports[`GlobalFilterAlert react-testing-library should render with Ansible Automation Platform with both filters 1`] = `
+<DocumentFragment>
+  <div
+    aria-label="Info Alert"
+    class="pf-c-alert pf-m-inline pf-m-info"
+    data-ouia-component-id="OUIA-Generated-Alert-info-4"
+    data-ouia-component-type="PF4/Alert"
+    data-ouia-safe="true"
   >
-    <p>
-      Workloads: SAP. SAP ID (SID): AB1, XY1. Tags: patch: rest=patchman-engine, dev=patchman-engine. insights-client: group=XmygroupX. 
-    </p>
-  </Alert>
-</Fragment>
+    <div
+      class="pf-c-alert__icon"
+    >
+      <svg
+        aria-hidden="true"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 512 512"
+        width="1em"
+      >
+        <path
+          d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+        />
+      </svg>
+    </div>
+    <h4
+      class="pf-c-alert__title"
+    >
+      <span
+        class="pf-u-screen-reader"
+      >
+        Info alert:
+      </span>
+      Your systems are pre-filtered by the global context selector.
+    </h4>
+    <div
+      class="pf-c-alert__description"
+    >
+      <p>
+        Workloads: Ansible Automation Platform. 
+      </p>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`GlobalFilterAlert react-testing-library should render with SAP 1`] = `
+<DocumentFragment>
+  <div
+    aria-label="Info Alert"
+    class="pf-c-alert pf-m-inline pf-m-info"
+    data-ouia-component-id="OUIA-Generated-Alert-info-1"
+    data-ouia-component-type="PF4/Alert"
+    data-ouia-safe="true"
+  >
+    <div
+      class="pf-c-alert__icon"
+    >
+      <svg
+        aria-hidden="true"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 512 512"
+        width="1em"
+      >
+        <path
+          d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+        />
+      </svg>
+    </div>
+    <h4
+      class="pf-c-alert__title"
+    >
+      <span
+        class="pf-u-screen-reader"
+      >
+        Info alert:
+      </span>
+      Your systems are pre-filtered by the global context selector.
+    </h4>
+    <div
+      class="pf-c-alert__description"
+    >
+      <p>
+        Workloads: SAP. 
+      </p>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`GlobalFilterAlert react-testing-library should render with SAP and Ansible Automation Platform 1`] = `
+<DocumentFragment>
+  <div
+    aria-label="Info Alert"
+    class="pf-c-alert pf-m-inline pf-m-info"
+    data-ouia-component-id="OUIA-Generated-Alert-info-5"
+    data-ouia-component-type="PF4/Alert"
+    data-ouia-safe="true"
+  >
+    <div
+      class="pf-c-alert__icon"
+    >
+      <svg
+        aria-hidden="true"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 512 512"
+        width="1em"
+      >
+        <path
+          d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+        />
+      </svg>
+    </div>
+    <h4
+      class="pf-c-alert__title"
+    >
+      <span
+        class="pf-u-screen-reader"
+      >
+        Info alert:
+      </span>
+      Your systems are pre-filtered by the global context selector.
+    </h4>
+    <div
+      class="pf-c-alert__description"
+    >
+      <p>
+        Workloads: Ansible Automation Platform, SAP. 
+      </p>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`GlobalFilterAlert react-testing-library should render with SAP and filters 1`] = `
+<DocumentFragment>
+  <div
+    aria-label="Info Alert"
+    class="pf-c-alert pf-m-inline pf-m-info"
+    data-ouia-component-id="OUIA-Generated-Alert-info-6"
+    data-ouia-component-type="PF4/Alert"
+    data-ouia-safe="true"
+  >
+    <div
+      class="pf-c-alert__icon"
+    >
+      <svg
+        aria-hidden="true"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 512 512"
+        width="1em"
+      >
+        <path
+          d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+        />
+      </svg>
+    </div>
+    <h4
+      class="pf-c-alert__title"
+    >
+      <span
+        class="pf-u-screen-reader"
+      >
+        Info alert:
+      </span>
+      Your systems are pre-filtered by the global context selector.
+    </h4>
+    <div
+      class="pf-c-alert__description"
+    >
+      <p>
+        Workloads: SAP. SAP ID (SID): AB1, XY1. Tags: patch: rest=patchman-engine, dev=patchman-engine. insights-client: group=XmygroupX. 
+      </p>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`GlobalFilterAlert react-testing-library should render with SAP with both filters 1`] = `
+<DocumentFragment>
+  <div
+    aria-label="Info Alert"
+    class="pf-c-alert pf-m-inline pf-m-info"
+    data-ouia-component-id="OUIA-Generated-Alert-info-3"
+    data-ouia-component-type="PF4/Alert"
+    data-ouia-safe="true"
+  >
+    <div
+      class="pf-c-alert__icon"
+    >
+      <svg
+        aria-hidden="true"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 512 512"
+        width="1em"
+      >
+        <path
+          d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+        />
+      </svg>
+    </div>
+    <h4
+      class="pf-c-alert__title"
+    >
+      <span
+        class="pf-u-screen-reader"
+      >
+        Info alert:
+      </span>
+      Your systems are pre-filtered by the global context selector.
+    </h4>
+    <div
+      class="pf-c-alert__description"
+    >
+      <p>
+        Workloads: SAP. 
+      </p>
+    </div>
+  </div>
+</DocumentFragment>
 `;

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -83,6 +83,8 @@ export const SystemsTable = ({
                         filter: {
                             system_profile: {
                                 ...workloadsFilter?.SAP?.isSelected && { sap_system: true },
+                                ...workloadsFilter && workloadsFilter['Ansible Automation Platform']?.isSelected
+                                    && { ansible: { controller_version: true }},
                                 ...sidsFilter?.length > 0 && { sap_sids: sidsFilter }
                             }
                         }


### PR DESCRIPTION
To test, see DRFT-995 card on Interact sprint board for a video.

Otherwise
Navigate to Drift -> Comparison
Set SAP or Ansible Automation Platform in global filters
Click 'Add systems or baselines' button

What you'll get is an often incorrect display in the blue alert bar
about which filters are applied. Try selecting one, then the other, then
both, then none and you'll see that the value in the modal are often
incorrect.

This PR properly displays the selected workload filters.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
