### PR TITLE
[DRFT-1042] Add icons for systems

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -317,10 +317,6 @@
 th.sticky-column {
   z-index: 3;
 }
-.sticky-header {
-  top: 0;
-  position: sticky;
-}
 .fact-header {
   vertical-align: bottom;
 }
@@ -428,6 +424,10 @@ th.sticky-column {
 
 .hsp-icon-padding {
   height: 22px;
+}
+
+.system-header-date-margin {
+  margin-right: 5px;
 }
 
 .md-padding-top {

--- a/src/SmartComponents/DriftPage/DriftTable/ComparisonHeader/ComparisonHeader.js
+++ b/src/SmartComponents/DriftPage/DriftTable/ComparisonHeader/ComparisonHeader.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Tooltip } from '@patternfly/react-core';
-import { ClockIcon, TimesIcon, ExclamationTriangleIcon, ServerIcon, BlueprintIcon } from '@patternfly/react-icons';
-import { LongArrowAltUpIcon, LongArrowAltDownIcon, ArrowsAltVIcon } from '@patternfly/react-icons';
 import { Skeleton, SkeletonSize } from '@redhat-cloud-services/frontend-components';
+import { ArrowsAltVIcon, BlueprintIcon, ClockIcon, DisconnectedIcon, ExclamationTriangleIcon,
+    LongArrowAltUpIcon, LongArrowAltDownIcon, ServerIcon, TimesIcon } from '@patternfly/react-icons';
 import moment from 'moment';
 
 import { ASC, DESC } from '../../../../constants';
@@ -52,6 +52,33 @@ class ComparisonHeader extends Component {
         return [ <td key='loading-systems-header'><Skeleton size={ SkeletonSize.md } /></td> ];
     }
 
+    renderInsightsIcons = (item) => {
+        return (
+            <React.Fragment>
+                { item.system_stale
+                    ? <Tooltip
+                        position='top'
+                        content={ <div>Stale system</div> }
+                    >
+                        <ExclamationTriangleIcon />
+                    </Tooltip>
+                    : null
+                }
+                { item.insights_enabled === false || item.insights_installed === false
+                    ? <Tooltip
+                        position='top'
+                        content={ !item.insights_installed
+                            ? <div>Insights not installed</div>
+                            : <div>Insights not enabled</div> }
+                    >
+                        <DisconnectedIcon />
+                    </Tooltip>
+                    : null
+                }
+            </React.Fragment>
+        );
+    }
+
     renderSystemHeaders() {
         const { fetchCompare, masterList, permissions, referenceId, removeSystem, selectedBaselineIds,
             selectedHSPIds, selectHistoricProfiles, systemIds, updateReferenceId } = this.props;
@@ -93,6 +120,7 @@ class ComparisonHeader extends Component {
                 >
                     <div>
                         <a
+                            aria-label='remove-system-icon'
                             onClick={ () => removeSystem(item) }
                             className="remove-system-icon"
                             data-ouia-component-type='PF4/Button'
@@ -121,10 +149,12 @@ class ComparisonHeader extends Component {
                                     <ExclamationTriangleIcon color="#f0ab00"/>
                                 </Tooltip> : ''
                             }
-                            { item.last_updated
-                                ? this.formatDate(item.last_updated)
-                                : this.formatDate(item.updated)
-                            }
+                            <span className='system-header-date-margin'>
+                                { item.last_updated
+                                    ? this.formatDate(item.last_updated)
+                                    : this.formatDate(item.updated)
+                                }
+                            </span>
                             { permissions.hspRead &&
                                 (item.type === 'system' || item.type === 'historical-system-profile')
                                 ? <HistoricalProfilesPopover
@@ -141,6 +171,7 @@ class ComparisonHeader extends Component {
                                 />
                                 : null
                             }
+                            { this.renderInsightsIcons(item) }
                         </div>
                     </div>
                 </th>

--- a/src/SmartComponents/DriftPage/DriftTable/ComparisonHeader/__tests__/ComparisonHeader.fixtures.js
+++ b/src/SmartComponents/DriftPage/DriftTable/ComparisonHeader/__tests__/ComparisonHeader.fixtures.js
@@ -4,7 +4,10 @@ const masterListSystem = [
         display_name: 'systemA',
         id: 'dc47qffd-09rt-2kw7-8b9b-53f4g716fec5',
         type: 'system',
-        updated: '2020-11-02T12:41:59.029271Z'
+        updated: '2020-11-02T12:41:59.029271Z',
+        system_stale: false,
+        insights_installed: true,
+        insights_enabled: true
     }
 ];
 
@@ -19,7 +22,60 @@ const masterListAll = [
         display_name: 'systemA',
         id: 'dc47qffd-09rt-2kw7-8b9b-53f4g716fec5',
         type: 'system',
-        updated: '2020-11-02T12:41:59.029271Z'
+        updated: '2020-11-02T12:41:59.029271Z',
+        system_stale: false,
+        insights_installed: true,
+        insights_enabled: true
+    },
+    {
+        display_name: 'hspA',
+        id: 'e3ed3e34-eaa1-45c4-8633-94fef1f678f1',
+        system_id: 'dc47qffd-09rt-2kw7-8b9b-53f4g716fec5',
+        type: 'historical-system-profile',
+        updated: '2021-05-15T07:24:01+00:00'
+    }
+];
+
+const masterListStaleNotInstalled = [
+    {
+        display_name: 'baselineA',
+        id: '12e4d81b-f1c6-489a-a829-9d96f3a71f53',
+        type: 'baseline',
+        updated: '2021-04-30T23:53:03.235265Z'
+    },
+    {
+        display_name: 'systemA',
+        id: 'dc47qffd-09rt-2kw7-8b9b-53f4g716fec5',
+        type: 'system',
+        updated: '2020-11-02T12:41:59.029271Z',
+        system_stale: true,
+        insights_installed: false,
+        insights_enabled: false
+    },
+    {
+        display_name: 'hspA',
+        id: 'e3ed3e34-eaa1-45c4-8633-94fef1f678f1',
+        system_id: 'dc47qffd-09rt-2kw7-8b9b-53f4g716fec5',
+        type: 'historical-system-profile',
+        updated: '2021-05-15T07:24:01+00:00'
+    }
+];
+
+const masterListNotEnabled = [
+    {
+        display_name: 'baselineA',
+        id: '12e4d81b-f1c6-489a-a829-9d96f3a71f53',
+        type: 'baseline',
+        updated: '2021-04-30T23:53:03.235265Z'
+    },
+    {
+        display_name: 'systemA',
+        id: 'dc47qffd-09rt-2kw7-8b9b-53f4g716fec5',
+        type: 'system',
+        updated: '2020-11-02T12:41:59.029271Z',
+        system_stale: false,
+        insights_installed: true,
+        insights_enabled: false
     },
     {
         display_name: 'hspA',
@@ -32,6 +88,8 @@ const masterListAll = [
 
 export default {
     masterListSystem,
-    masterListAll
+    masterListAll,
+    masterListStaleNotInstalled,
+    masterListNotEnabled
 };
 /*eslint-enable camelcase*/

--- a/src/SmartComponents/DriftPage/DriftTable/ComparisonHeader/__tests__/ComparisonHeader.tests.js
+++ b/src/SmartComponents/DriftPage/DriftTable/ComparisonHeader/__tests__/ComparisonHeader.tests.js
@@ -1,9 +1,202 @@
 import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { shallow } from 'enzyme';
-import toJson from 'enzyme-to-json';
+import { MemoryRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
 
 import ComparisonHeader from '../ComparisonHeader';
 import fixtures from './ComparisonHeader.fixtures';
+
+describe('ComparisonHeader react-testing-library', () => {
+    let props;
+    let mockStore;
+
+    beforeEach(() => {
+        mockStore = configureStore();
+        props = {
+            factSort: '',
+            fetchCompare: jest.fn(),
+            hasHSPReadPermissions: true,
+            masterList: [],
+            permissions: {
+                hspRead: true
+            },
+            referenceId: undefined,
+            isFirstReference: true,
+            removeSystem: jest.fn(),
+            stateSort: '',
+            systemIds: [],
+            toggleFactSort: jest.fn(),
+            toggleStateSort: jest.fn(),
+            updateReferenceId: jest.fn(),
+            setHistory: jest.fn()
+        };
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should render correctly', () => {
+        const { asFragment } = render(
+            <ComparisonHeader { ...props }/>
+        );
+        expect(asFragment()).toMatchSnapshot();
+    });
+
+    it('should render fact sort asc', () => {
+        props.factSort = 'asc';
+        const { asFragment } = render(
+            <ComparisonHeader { ...props }/>
+        );
+        expect(asFragment()).toMatchSnapshot();
+    });
+
+    it('should render fact sort desc', () => {
+        props.factSort = 'desc';
+        const { asFragment } = render(
+            <ComparisonHeader { ...props }/>
+        );
+        expect(asFragment()).toMatchSnapshot();
+    });
+
+    it('should render state sort asc', () => {
+        props.stateSort = 'asc';
+        const { asFragment } = render(
+            <ComparisonHeader { ...props }/>
+        );
+        expect(asFragment()).toMatchSnapshot();
+    });
+
+    it('should render state sort desc', () => {
+        props.stateSort = 'desc';
+        const { asFragment } = render(
+            <ComparisonHeader { ...props }/>
+        );
+        expect(asFragment()).toMatchSnapshot();
+    });
+
+    it('should render fact sort desc on click', () => {
+        props.factSort = 'asc';
+        render(<ComparisonHeader { ...props }/>);
+
+        userEvent.click(screen.getByText('Fact'));
+        expect(props.toggleFactSort).toHaveBeenCalledWith('asc');
+    });
+
+    it('should render fact sort asc on click', () => {
+        props.factSort = 'desc';
+        render(<ComparisonHeader { ...props }/>);
+
+        userEvent.click(screen.getByText('Fact'));
+        expect(props.toggleFactSort).toHaveBeenCalledWith('desc');
+    });
+
+    it('should render state sort none on click', () => {
+        props.stateSort = 'desc';
+        render(<ComparisonHeader { ...props }/>);
+
+        userEvent.click(screen.getByText('State'));
+        expect(props.toggleStateSort).toHaveBeenCalledWith('desc');
+    });
+
+    it('should render state sort asc on click', () => {
+        props.stateSort = '';
+        render(<ComparisonHeader { ...props }/>);
+
+        userEvent.click(screen.getByText('State'));
+        expect(props.toggleStateSort).toHaveBeenCalledWith('');
+    });
+
+    it('should render state sort desc on click', () => {
+        props.stateSort = 'asc';
+        render(<ComparisonHeader { ...props }/>);
+
+        userEvent.click(screen.getByText('State'));
+        expect(props.toggleStateSort).toHaveBeenCalledWith('asc');
+    });
+
+    it.skip('should remove a system', async () => {
+        const store = mockStore(props);
+        props.masterList = fixtures.masterListSystem;
+
+        render(<MemoryRouter keyLength={ 0 }>
+            <Provider store={ store }>
+                <ComparisonHeader { ...props }/>
+            </Provider>
+        </MemoryRouter>);
+
+        await userEvent.click(screen.getByRole('row', {
+            name: /remove-system-icon/i
+        }));
+        expect(store.removeSystem).toHaveBeenCalled();
+    });
+
+    it('should render a system, baseline and hsp', () => {
+        const store = mockStore(props);
+        props.masterList = fixtures.masterListAll;
+
+        const { asFragment } = render(<MemoryRouter keyLength={ 0 }>
+            <Provider store={ store }>
+                <ComparisonHeader { ...props }/>
+            </Provider>
+        </MemoryRouter>);
+
+        expect(asFragment()).toMatchSnapshot();
+    });
+
+    it('should render with system_stale=true and insights_installed=false', () => {
+        const store = mockStore(props);
+        props.masterList = fixtures.masterListStaleNotInstalled;
+        const { asFragment } = render(<MemoryRouter keyLength={ 0 }>
+            <Provider store={ store }>
+                <ComparisonHeader { ...props }/>
+            </Provider>
+        </MemoryRouter>);
+
+        expect(asFragment()).toMatchSnapshot();
+    });
+
+    it('should render with insights_enabled=false', () => {
+        const store = mockStore(props);
+        props.masterList = fixtures.masterListNotEnabled;
+        const { asFragment } = render(<MemoryRouter keyLength={ 0 }>
+            <Provider store={ store }>
+                <ComparisonHeader { ...props }/>
+            </Provider>
+        </MemoryRouter>);
+
+        expect(asFragment()).toMatchSnapshot();
+    });
+
+    it('should call setHistory on toggleFactSort', async () => {
+        props.factSort = 'desc';
+        render(<ComparisonHeader { ...props }/>);
+
+        await userEvent.click(screen.getByText('Fact'));
+        expect(props.setHistory).toHaveBeenCalled();
+    });
+
+    it('should call setHistory on toggleStateSort', async () => {
+        props.stateSort = 'desc';
+        render(<ComparisonHeader { ...props }/>);
+
+        await userEvent.click(screen.getByText('State'));
+        expect(props.setHistory).toHaveBeenCalled();
+    });
+
+    it('should not render HistoricalProfilesPopover with no hspRead permissions', () => {
+        props.masterList = fixtures.masterListAll;
+        props.permissions.hspRead = false;
+        const { asFragment } = render(
+            <ComparisonHeader { ...props }/>
+        );
+
+        expect(asFragment()).toMatchSnapshot();
+    });
+});
 
 describe('ComparisonHeader', () => {
     let props;
@@ -33,95 +226,6 @@ describe('ComparisonHeader', () => {
         jest.clearAllMocks();
     });
 
-    it('should render correctly', () => {
-        const wrapper = shallow(
-            <ComparisonHeader { ...props }/>
-        );
-        expect(toJson(wrapper)).toMatchSnapshot();
-    });
-
-    it('should render fact sort asc', () => {
-        props.factSort = 'asc';
-        const wrapper = shallow(
-            <ComparisonHeader { ...props }/>
-        );
-        expect(toJson(wrapper)).toMatchSnapshot();
-    });
-
-    it('should render fact sort desc', () => {
-        props.factSort = 'desc';
-        const wrapper = shallow(
-            <ComparisonHeader { ...props }/>
-        );
-        expect(toJson(wrapper)).toMatchSnapshot();
-    });
-
-    it('should render state sort asc', () => {
-        props.stateSort = 'asc';
-        const wrapper = shallow(
-            <ComparisonHeader { ...props }/>
-        );
-        expect(toJson(wrapper)).toMatchSnapshot();
-    });
-
-    it('should render state sort desc', () => {
-        props.stateSort = 'desc';
-        const wrapper = shallow(
-            <ComparisonHeader { ...props }/>
-        );
-        expect(toJson(wrapper)).toMatchSnapshot();
-    });
-
-    it('should render fact sort desc on click', () => {
-        props.factSort = 'asc';
-        const wrapper = shallow(
-            <ComparisonHeader { ...props }/>
-        );
-
-        wrapper.find('th').first().simulate('click');
-        expect(props.toggleFactSort).toHaveBeenCalledWith('asc');
-    });
-
-    it('should render fact sort asc on click', () => {
-        props.factSort = 'desc';
-        const wrapper = shallow(
-            <ComparisonHeader { ...props }/>
-        );
-
-        wrapper.find('th').first().simulate('click');
-        expect(props.toggleFactSort).toHaveBeenCalledWith('desc');
-    });
-
-    it('should render state sort none on click', () => {
-        props.stateSort = 'desc';
-        const wrapper = shallow(
-            <ComparisonHeader { ...props }/>
-        );
-
-        wrapper.find('th').at(1).simulate('click');
-        expect(props.toggleStateSort).toHaveBeenCalledWith('desc');
-    });
-
-    it('should render state sort asc on click', () => {
-        props.stateSort = '';
-        const wrapper = shallow(
-            <ComparisonHeader { ...props }/>
-        );
-
-        wrapper.find('th').at(1).simulate('click');
-        expect(props.toggleStateSort).toHaveBeenCalledWith('');
-    });
-
-    it('should render state sort desc on click', () => {
-        props.stateSort = 'asc';
-        const wrapper = shallow(
-            <ComparisonHeader { ...props }/>
-        );
-
-        wrapper.find('th').at(1).simulate('click');
-        expect(props.toggleStateSort).toHaveBeenCalledWith('asc');
-    });
-
     it('should remove a system', () => {
         props.masterList = fixtures.masterListSystem;
 
@@ -131,44 +235,5 @@ describe('ComparisonHeader', () => {
 
         wrapper.find('a').simulate('click');
         expect(props.removeSystem).toHaveBeenCalled();
-    });
-
-    it('should call setHistory on toggleFactSort', async () => {
-        props.factSort = 'desc';
-        const wrapper = shallow(
-            <ComparisonHeader { ...props }/>
-        );
-
-        await wrapper.instance().toggleSort('fact', 'desc');
-        expect(props.setHistory).toHaveBeenCalled();
-    });
-
-    it('should call setHistory on toggleStateSort', async () => {
-        props.stateSort = 'desc';
-        const wrapper = shallow(
-            <ComparisonHeader { ...props }/>
-        );
-
-        await wrapper.instance().toggleSort('state', 'desc');
-        expect(props.setHistory).toHaveBeenCalled();
-    });
-
-    it('should render a system, baseline and hsp', () => {
-        props.masterList = fixtures.masterListAll;
-        const wrapper = shallow(
-            <ComparisonHeader { ...props }/>
-        );
-
-        expect(toJson(wrapper)).toMatchSnapshot();
-    });
-
-    it('should not render HistoricalProfilesPopover with no hspRead permissions', () => {
-        props.masterList = fixtures.masterListAll;
-        props.permissions.hspRead = false;
-        const wrapper = shallow(
-            <ComparisonHeader { ...props }/>
-        );
-
-        expect(toJson(wrapper)).toMatchSnapshot();
     });
 });

--- a/src/SmartComponents/DriftPage/DriftTable/ComparisonHeader/__tests__/__snapshots__/ComparisonHeader.tests.js.snap
+++ b/src/SmartComponents/DriftPage/DriftTable/ComparisonHeader/__tests__/__snapshots__/ComparisonHeader.tests.js.snap
@@ -1,812 +1,1468 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ComparisonHeader should not render HistoricalProfilesPopover with no hspRead permissions 1`] = `
-<Fragment>
-  <tr
-    className="sticky-column-header"
-    data-ouia-component-id="comparison-table-header-row"
-    data-ouia-component-type="PF4/TableRow"
+exports[`ComparisonHeader react-testing-library should not render HistoricalProfilesPopover with no hspRead permissions 1`] = `
+<DocumentFragment>
+  <div
+    class="active-blue"
   >
-    <th
-      className="fact-header sticky-column fixed-column-1 pointer sticky-header"
-      data-ouia-component-id="fact-sort-button"
-      data-ouia-component-type="PF4/Button"
-      id=""
-      key="fact-header"
-      onClick={[Function]}
+    Fact 
+    <svg
+      aria-hidden="true"
+      class="not-active"
+      fill="currentColor"
+      height="1em"
+      role="img"
+      style="vertical-align: -0.125em;"
+      viewBox="0 0 256 512"
+      width="1em"
     >
-      <div
-        className="active-blue"
-      >
-        Fact 
-        <ArrowsAltVIcon
-          className="not-active"
-          color="currentColor"
-          noVerticalAlign={false}
-          size="sm"
-        />
-      </div>
-    </th>
-    <th
-      className="state-header sticky-column fixed-column-2 pointer right-border sticky-header"
-      data-ouia-component-id="state-sort-button"
-      data-ouia-component-type="PF4/Button"
-      id="disabled"
-      key="state-header"
-      onClick={[Function]}
-    >
-      <div>
-        State 
-        <ArrowsAltVIcon
-          className="not-active"
-          color="currentColor"
-          noVerticalAlign={false}
-          size="sm"
-        />
-      </div>
-    </th>
-    <th
-      className="drift-header right-border baseline-header sticky-header"
-      header-id="12e4d81b-f1c6-489a-a829-9d96f3a71f53"
-      key="12e4d81b-f1c6-489a-a829-9d96f3a71f53"
-    >
-      <div>
-        <a
-          className="remove-system-icon"
-          data-ouia-component-id="remove-system-button-12e4d81b-f1c6-489a-a829-9d96f3a71f53"
-          data-ouia-component-type="PF4/Button"
-          onClick={[Function]}
-        >
-          <TimesIcon
-            color="currentColor"
-            noVerticalAlign={false}
-            size="sm"
-          />
-        </a>
-      </div>
-      <div
-        className="comparison-header"
-      >
-        <div>
-          <span
-            className="drift-header-icon"
-          >
-            <Tooltip
-              content={
-                <div>
-                  Baseline
-                </div>
-              }
-              position="top"
-            >
-              <BlueprintIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
-              />
-            </Tooltip>
-          </span>
-          <span
-            className="system-name"
-          >
-            baselineA
-          </span>
-        </div>
-        <div
-          className="system-updated-and-reference"
-        >
-          <ReferenceSelector
-            isReference={false}
-            item={
-              Object {
-                "display_name": "baselineA",
-                "id": "12e4d81b-f1c6-489a-a829-9d96f3a71f53",
-                "type": "baseline",
-                "updated": "2021-04-30T23:53:03.235265Z",
-              }
-            }
-            updateReferenceId={[MockFunction]}
-          />
-          30 Apr 2021, 23:53 UTC
-        </div>
-      </div>
-    </th>
-    <th
-      className="drift-header right-border system-header sticky-header"
-      header-id="dc47qffd-09rt-2kw7-8b9b-53f4g716fec5"
-      key="dc47qffd-09rt-2kw7-8b9b-53f4g716fec5"
-    >
-      <div>
-        <a
-          className="remove-system-icon"
-          data-ouia-component-id="remove-system-button-dc47qffd-09rt-2kw7-8b9b-53f4g716fec5"
-          data-ouia-component-type="PF4/Button"
-          onClick={[Function]}
-        >
-          <TimesIcon
-            color="currentColor"
-            noVerticalAlign={false}
-            size="sm"
-          />
-        </a>
-      </div>
-      <div
-        className="comparison-header"
-      >
-        <div>
-          <span
-            className="drift-header-icon"
-          >
-            <Tooltip
-              content={
-                <div>
-                  System
-                </div>
-              }
-              position="top"
-            >
-              <ServerIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
-              />
-            </Tooltip>
-          </span>
-          <span
-            className="system-name"
-          >
-            systemA
-          </span>
-        </div>
-        <div
-          className="system-updated-and-reference"
-        >
-          <ReferenceSelector
-            isReference={false}
-            item={
-              Object {
-                "display_name": "systemA",
-                "id": "dc47qffd-09rt-2kw7-8b9b-53f4g716fec5",
-                "type": "system",
-                "updated": "2020-11-02T12:41:59.029271Z",
-              }
-            }
-            updateReferenceId={[MockFunction]}
-          />
-          02 Nov 2020, 12:41 UTC
-        </div>
-      </div>
-    </th>
-    <th
-      className="drift-header right-border historical-system-profile-header sticky-header"
-      header-id="e3ed3e34-eaa1-45c4-8633-94fef1f678f1"
-      key="e3ed3e34-eaa1-45c4-8633-94fef1f678f1"
-    >
-      <div>
-        <a
-          className="remove-system-icon"
-          data-ouia-component-id="remove-system-button-e3ed3e34-eaa1-45c4-8633-94fef1f678f1"
-          data-ouia-component-type="PF4/Button"
-          onClick={[Function]}
-        >
-          <TimesIcon
-            color="currentColor"
-            noVerticalAlign={false}
-            size="sm"
-          />
-        </a>
-      </div>
-      <div
-        className="comparison-header"
-      >
-        <div>
-          <span
-            className="drift-header-icon"
-          >
-            <Tooltip
-              content={
-                <div>
-                  Historical system
-                </div>
-              }
-              position="top"
-            >
-              <ClockIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
-              />
-            </Tooltip>
-          </span>
-          <span
-            className="system-name"
-          >
-            hspA
-          </span>
-        </div>
-        <div
-          className="system-updated-and-reference"
-        >
-          <ReferenceSelector
-            isReference={false}
-            item={
-              Object {
-                "display_name": "hspA",
-                "id": "e3ed3e34-eaa1-45c4-8633-94fef1f678f1",
-                "system_id": "dc47qffd-09rt-2kw7-8b9b-53f4g716fec5",
-                "type": "historical-system-profile",
-                "updated": "2021-05-15T07:24:01+00:00",
-              }
-            }
-            updateReferenceId={[MockFunction]}
-          />
-          15 May 2021, 07:24 UTC
-        </div>
-      </div>
-    </th>
-  </tr>
-</Fragment>
-`;
-
-exports[`ComparisonHeader should render a system, baseline and hsp 1`] = `
-<Fragment>
-  <tr
-    className="sticky-column-header"
-    data-ouia-component-id="comparison-table-header-row"
-    data-ouia-component-type="PF4/TableRow"
-  >
-    <th
-      className="fact-header sticky-column fixed-column-1 pointer sticky-header"
-      data-ouia-component-id="fact-sort-button"
-      data-ouia-component-type="PF4/Button"
-      id=""
-      key="fact-header"
-      onClick={[Function]}
-    >
-      <div
-        className="active-blue"
-      >
-        Fact 
-        <ArrowsAltVIcon
-          className="not-active"
-          color="currentColor"
-          noVerticalAlign={false}
-          size="sm"
-        />
-      </div>
-    </th>
-    <th
-      className="state-header sticky-column fixed-column-2 pointer right-border sticky-header"
-      data-ouia-component-id="state-sort-button"
-      data-ouia-component-type="PF4/Button"
-      id="disabled"
-      key="state-header"
-      onClick={[Function]}
-    >
-      <div>
-        State 
-        <ArrowsAltVIcon
-          className="not-active"
-          color="currentColor"
-          noVerticalAlign={false}
-          size="sm"
-        />
-      </div>
-    </th>
-    <th
-      className="drift-header right-border baseline-header sticky-header"
-      header-id="12e4d81b-f1c6-489a-a829-9d96f3a71f53"
-      key="12e4d81b-f1c6-489a-a829-9d96f3a71f53"
-    >
-      <div>
-        <a
-          className="remove-system-icon"
-          data-ouia-component-id="remove-system-button-12e4d81b-f1c6-489a-a829-9d96f3a71f53"
-          data-ouia-component-type="PF4/Button"
-          onClick={[Function]}
-        >
-          <TimesIcon
-            color="currentColor"
-            noVerticalAlign={false}
-            size="sm"
-          />
-        </a>
-      </div>
-      <div
-        className="comparison-header"
-      >
-        <div>
-          <span
-            className="drift-header-icon"
-          >
-            <Tooltip
-              content={
-                <div>
-                  Baseline
-                </div>
-              }
-              position="top"
-            >
-              <BlueprintIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
-              />
-            </Tooltip>
-          </span>
-          <span
-            className="system-name"
-          >
-            baselineA
-          </span>
-        </div>
-        <div
-          className="system-updated-and-reference"
-        >
-          <ReferenceSelector
-            isReference={false}
-            item={
-              Object {
-                "display_name": "baselineA",
-                "id": "12e4d81b-f1c6-489a-a829-9d96f3a71f53",
-                "type": "baseline",
-                "updated": "2021-04-30T23:53:03.235265Z",
-              }
-            }
-            updateReferenceId={[MockFunction]}
-          />
-          30 Apr 2021, 23:53 UTC
-        </div>
-      </div>
-    </th>
-    <th
-      className="drift-header right-border system-header sticky-header"
-      header-id="dc47qffd-09rt-2kw7-8b9b-53f4g716fec5"
-      key="dc47qffd-09rt-2kw7-8b9b-53f4g716fec5"
-    >
-      <div>
-        <a
-          className="remove-system-icon"
-          data-ouia-component-id="remove-system-button-dc47qffd-09rt-2kw7-8b9b-53f4g716fec5"
-          data-ouia-component-type="PF4/Button"
-          onClick={[Function]}
-        >
-          <TimesIcon
-            color="currentColor"
-            noVerticalAlign={false}
-            size="sm"
-          />
-        </a>
-      </div>
-      <div
-        className="comparison-header"
-      >
-        <div>
-          <span
-            className="drift-header-icon"
-          >
-            <Tooltip
-              content={
-                <div>
-                  System
-                </div>
-              }
-              position="top"
-            >
-              <ServerIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
-              />
-            </Tooltip>
-          </span>
-          <span
-            className="system-name"
-          >
-            systemA
-          </span>
-        </div>
-        <div
-          className="system-updated-and-reference"
-        >
-          <ReferenceSelector
-            isReference={false}
-            item={
-              Object {
-                "display_name": "systemA",
-                "id": "dc47qffd-09rt-2kw7-8b9b-53f4g716fec5",
-                "type": "system",
-                "updated": "2020-11-02T12:41:59.029271Z",
-              }
-            }
-            updateReferenceId={[MockFunction]}
-          />
-          02 Nov 2020, 12:41 UTC
-          <withRouter(Connect(HistoricalProfilesPopover))
-            fetchCompare={[MockFunction]}
-            hasCompareButton={true}
-            hasMultiSelect={true}
-            system={
-              Object {
-                "display_name": "systemA",
-                "id": "dc47qffd-09rt-2kw7-8b9b-53f4g716fec5",
-                "type": "system",
-                "updated": "2020-11-02T12:41:59.029271Z",
-              }
-            }
-            systemIds={Array []}
-            systemName="systemA"
-          />
-        </div>
-      </div>
-    </th>
-    <th
-      className="drift-header right-border historical-system-profile-header sticky-header"
-      header-id="e3ed3e34-eaa1-45c4-8633-94fef1f678f1"
-      key="e3ed3e34-eaa1-45c4-8633-94fef1f678f1"
-    >
-      <div>
-        <a
-          className="remove-system-icon"
-          data-ouia-component-id="remove-system-button-e3ed3e34-eaa1-45c4-8633-94fef1f678f1"
-          data-ouia-component-type="PF4/Button"
-          onClick={[Function]}
-        >
-          <TimesIcon
-            color="currentColor"
-            noVerticalAlign={false}
-            size="sm"
-          />
-        </a>
-      </div>
-      <div
-        className="comparison-header"
-      >
-        <div>
-          <span
-            className="drift-header-icon"
-          >
-            <Tooltip
-              content={
-                <div>
-                  Historical system
-                </div>
-              }
-              position="top"
-            >
-              <ClockIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
-              />
-            </Tooltip>
-          </span>
-          <span
-            className="system-name"
-          >
-            hspA
-          </span>
-        </div>
-        <div
-          className="system-updated-and-reference"
-        >
-          <ReferenceSelector
-            isReference={false}
-            item={
-              Object {
-                "display_name": "hspA",
-                "id": "e3ed3e34-eaa1-45c4-8633-94fef1f678f1",
-                "system_id": "dc47qffd-09rt-2kw7-8b9b-53f4g716fec5",
-                "type": "historical-system-profile",
-                "updated": "2021-05-15T07:24:01+00:00",
-              }
-            }
-            updateReferenceId={[MockFunction]}
-          />
-          15 May 2021, 07:24 UTC
-          <withRouter(Connect(HistoricalProfilesPopover))
-            fetchCompare={[MockFunction]}
-            hasCompareButton={true}
-            hasMultiSelect={true}
-            system={
-              Object {
-                "display_name": "hspA",
-                "id": "e3ed3e34-eaa1-45c4-8633-94fef1f678f1",
-                "system_id": "dc47qffd-09rt-2kw7-8b9b-53f4g716fec5",
-                "type": "historical-system-profile",
-                "updated": "2021-05-15T07:24:01+00:00",
-              }
-            }
-            systemIds={Array []}
-            systemName="hspA"
-          />
-        </div>
-      </div>
-    </th>
-  </tr>
-</Fragment>
-`;
-
-exports[`ComparisonHeader should render correctly 1`] = `
-<Fragment>
-  <tr
-    className="sticky-column-header"
-    data-ouia-component-id="comparison-table-header-row"
-    data-ouia-component-type="PF4/TableRow"
-  >
-    <th
-      className="fact-header sticky-column fixed-column-1 pointer sticky-header"
-      data-ouia-component-id="fact-sort-button"
-      data-ouia-component-type="PF4/Button"
-      id=""
-      key="fact-header"
-      onClick={[Function]}
-    >
-      <div
-        className="active-blue"
-      >
-        Fact 
-        <ArrowsAltVIcon
-          className="not-active"
-          color="currentColor"
-          noVerticalAlign={false}
-          size="sm"
-        />
-      </div>
-    </th>
-    <th
-      className="state-header sticky-column fixed-column-2 pointer right-border sticky-header"
-      data-ouia-component-id="state-sort-button"
-      data-ouia-component-type="PF4/Button"
-      id="disabled"
-      key="state-header"
-      onClick={[Function]}
-    >
-      <div>
-        State 
-        <ArrowsAltVIcon
-          className="not-active"
-          color="currentColor"
-          noVerticalAlign={false}
-          size="sm"
-        />
-      </div>
-    </th>
-    <td
-      key="loading-systems-header"
-    >
-      <Skeleton
-        size="md"
+      <path
+        d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
       />
-    </td>
-  </tr>
-</Fragment>
+    </svg>
+  </div>
+  <div>
+    State 
+    <svg
+      aria-hidden="true"
+      class="not-active"
+      fill="currentColor"
+      height="1em"
+      role="img"
+      style="vertical-align: -0.125em;"
+      viewBox="0 0 256 512"
+      width="1em"
+    >
+      <path
+        d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+      />
+    </svg>
+  </div>
+  <div>
+    <a
+      aria-label="remove-system-icon"
+      class="remove-system-icon"
+      data-ouia-component-id="remove-system-button-12e4d81b-f1c6-489a-a829-9d96f3a71f53"
+      data-ouia-component-type="PF4/Button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 352 512"
+        width="1em"
+      >
+        <path
+          d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+        />
+      </svg>
+    </a>
+  </div>
+  <div
+    class="comparison-header"
+  >
+    <div>
+      <span
+        class="drift-header-icon"
+      >
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align: -0.125em;"
+          viewBox="0 0 1024 1024"
+          width="1em"
+        >
+          <path
+            d="M0,767.3 L0,640 L64,640 L64,752.3 C64,760.584271 70.7157288,767.3 79,767.3 L128,768.1 L128,832.1 L64,831.3 C28.6674863,831.266922 0.0330777378,802.632514 0,767.3 Z M64,0 L191.3,0 L191.3,64 L79,64 C70.7157288,64 64,70.7157288 64,79 L64,192 L0,192 L0,64 C0.0330777378,28.6674863 28.6674863,0.0330777378 64,0 Z M0,384 L64,384 L64,256 L0,256 L0,384 Z M0,576 L64,576 L64,448 L0,448 L0,576 Z M832,64.7 L832,128 L768,128 L768,79.7 C768,71.4157288 761.284271,64.7 753,64.7 L640,64.7 L640,0.7 L768,0.7 C803.332514,0.733077738 831.966922,29.3674863 832,64.7 Z M448,64.7 L576,64.7 L576,0.7 L448,0.7 L448,64.7 Z M256,64.7 L384,64.7 L384,0.7 L256,0.7 L256,64.7 Z M960,192 L256,192 C220.667486,192.033078 192.033078,220.667486 192,256 L192,960 C192.033078,995.332514 220.667486,1023.96692 256,1024 L960,1024 C995.332514,1023.96692 1023.96692,995.332514 1024,960 L1024,256 C1023.96692,220.667486 995.332514,192.033078 960,192 Z M960,945 C960,953.284271 953.284271,960 945,960 L271,960 C262.715729,960 256,953.284271 256,945 L256,271 C256,262.715729 262.715729,256 271,256 L945,256 C953.284271,256 960,262.715729 960,271 L960,945 Z"
+          />
+        </svg>
+      </span>
+      <span
+        class="system-name"
+      >
+        baselineA
+      </span>
+    </div>
+    <div
+      class="system-updated-and-reference"
+    >
+      <svg
+        aria-hidden="true"
+        class="reference-selector pointer"
+        data-ouia-component-id="reference-selector-12e4d81b-f1c6-489a-a829-9d96f3a71f53"
+        data-ouia-component-type="PF4/Button"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 576 512"
+        width="1em"
+      >
+        <path
+          d="M528.1 171.5L382 150.2 316.7 17.8c-11.7-23.6-45.6-23.9-57.4 0L194 150.2 47.9 171.5c-26.2 3.8-36.7 36.1-17.7 54.6l105.7 103-25 145.5c-4.5 26.3 23.2 46 46.4 33.7L288 439.6l130.7 68.7c23.2 12.2 50.9-7.4 46.4-33.7l-25-145.5 105.7-103c19-18.5 8.5-50.8-17.7-54.6zM388.6 312.3l23.7 138.4L288 385.4l-124.3 65.3 23.7-138.4-100.6-98 139-20.2 62.2-126 62.2 126 139 20.2-100.6 98z"
+        />
+      </svg>
+      <span
+        class="system-header-date-margin"
+      >
+        30 Apr 2021, 23:53 UTC
+      </span>
+    </div>
+  </div>
+  <div>
+    <a
+      aria-label="remove-system-icon"
+      class="remove-system-icon"
+      data-ouia-component-id="remove-system-button-dc47qffd-09rt-2kw7-8b9b-53f4g716fec5"
+      data-ouia-component-type="PF4/Button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 352 512"
+        width="1em"
+      >
+        <path
+          d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+        />
+      </svg>
+    </a>
+  </div>
+  <div
+    class="comparison-header"
+  >
+    <div>
+      <span
+        class="drift-header-icon"
+      >
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align: -0.125em;"
+          viewBox="0 0 512 512"
+          width="1em"
+        >
+          <path
+            d="M480 160H32c-17.673 0-32-14.327-32-32V64c0-17.673 14.327-32 32-32h448c17.673 0 32 14.327 32 32v64c0 17.673-14.327 32-32 32zm-48-88c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm-64 0c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm112 248H32c-17.673 0-32-14.327-32-32v-64c0-17.673 14.327-32 32-32h448c17.673 0 32 14.327 32 32v64c0 17.673-14.327 32-32 32zm-48-88c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm-64 0c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm112 248H32c-17.673 0-32-14.327-32-32v-64c0-17.673 14.327-32 32-32h448c17.673 0 32 14.327 32 32v64c0 17.673-14.327 32-32 32zm-48-88c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm-64 0c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24z"
+          />
+        </svg>
+      </span>
+      <span
+        class="system-name"
+      >
+        systemA
+      </span>
+    </div>
+    <div
+      class="system-updated-and-reference"
+    >
+      <svg
+        aria-hidden="true"
+        class="reference-selector pointer"
+        data-ouia-component-id="reference-selector-dc47qffd-09rt-2kw7-8b9b-53f4g716fec5"
+        data-ouia-component-type="PF4/Button"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 576 512"
+        width="1em"
+      >
+        <path
+          d="M528.1 171.5L382 150.2 316.7 17.8c-11.7-23.6-45.6-23.9-57.4 0L194 150.2 47.9 171.5c-26.2 3.8-36.7 36.1-17.7 54.6l105.7 103-25 145.5c-4.5 26.3 23.2 46 46.4 33.7L288 439.6l130.7 68.7c23.2 12.2 50.9-7.4 46.4-33.7l-25-145.5 105.7-103c19-18.5 8.5-50.8-17.7-54.6zM388.6 312.3l23.7 138.4L288 385.4l-124.3 65.3 23.7-138.4-100.6-98 139-20.2 62.2-126 62.2 126 139 20.2-100.6 98z"
+        />
+      </svg>
+      <span
+        class="system-header-date-margin"
+      >
+        02 Nov 2020, 12:41 UTC
+      </span>
+    </div>
+  </div>
+  <div>
+    <a
+      aria-label="remove-system-icon"
+      class="remove-system-icon"
+      data-ouia-component-id="remove-system-button-e3ed3e34-eaa1-45c4-8633-94fef1f678f1"
+      data-ouia-component-type="PF4/Button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 352 512"
+        width="1em"
+      >
+        <path
+          d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+        />
+      </svg>
+    </a>
+  </div>
+  <div
+    class="comparison-header"
+  >
+    <div>
+      <span
+        class="drift-header-icon"
+      >
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align: -0.125em;"
+          viewBox="0 0 512 512"
+          width="1em"
+        >
+          <path
+            d="M256,8C119,8,8,119,8,256S119,504,256,504,504,393,504,256,393,8,256,8Zm92.49,313h0l-20,25a16,16,0,0,1-22.49,2.5h0l-67-49.72a40,40,0,0,1-15-31.23V112a16,16,0,0,1,16-16h32a16,16,0,0,1,16,16V256l58,42.5A16,16,0,0,1,348.49,321Z"
+          />
+        </svg>
+      </span>
+      <span
+        class="system-name"
+      >
+        hspA
+      </span>
+    </div>
+    <div
+      class="system-updated-and-reference"
+    >
+      <svg
+        aria-hidden="true"
+        class="reference-selector pointer"
+        data-ouia-component-id="reference-selector-e3ed3e34-eaa1-45c4-8633-94fef1f678f1"
+        data-ouia-component-type="PF4/Button"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 576 512"
+        width="1em"
+      >
+        <path
+          d="M528.1 171.5L382 150.2 316.7 17.8c-11.7-23.6-45.6-23.9-57.4 0L194 150.2 47.9 171.5c-26.2 3.8-36.7 36.1-17.7 54.6l105.7 103-25 145.5c-4.5 26.3 23.2 46 46.4 33.7L288 439.6l130.7 68.7c23.2 12.2 50.9-7.4 46.4-33.7l-25-145.5 105.7-103c19-18.5 8.5-50.8-17.7-54.6zM388.6 312.3l23.7 138.4L288 385.4l-124.3 65.3 23.7-138.4-100.6-98 139-20.2 62.2-126 62.2 126 139 20.2-100.6 98z"
+        />
+      </svg>
+      <span
+        class="system-header-date-margin"
+      >
+        15 May 2021, 07:24 UTC
+      </span>
+    </div>
+  </div>
+</DocumentFragment>
 `;
 
-exports[`ComparisonHeader should render fact sort asc 1`] = `
-<Fragment>
-  <tr
-    className="sticky-column-header"
-    data-ouia-component-id="comparison-table-header-row"
-    data-ouia-component-type="PF4/TableRow"
+exports[`ComparisonHeader react-testing-library should render a system, baseline and hsp 1`] = `
+<DocumentFragment>
+  <div
+    class="active-blue"
   >
-    <th
-      className="fact-header sticky-column fixed-column-1 pointer sticky-header"
-      data-ouia-component-id="fact-sort-button"
-      data-ouia-component-type="PF4/Button"
-      id="asc"
-      key="fact-header"
-      onClick={[Function]}
+    Fact 
+    <svg
+      aria-hidden="true"
+      class="not-active"
+      fill="currentColor"
+      height="1em"
+      role="img"
+      style="vertical-align: -0.125em;"
+      viewBox="0 0 256 512"
+      width="1em"
     >
-      <div
-        className="active-blue"
-      >
-        Fact 
-        <LongArrowAltUpIcon
-          className="active-blue"
-          color="currentColor"
-          noVerticalAlign={false}
-          size="sm"
-        />
-      </div>
-    </th>
-    <th
-      className="state-header sticky-column fixed-column-2 pointer right-border sticky-header"
-      data-ouia-component-id="state-sort-button"
-      data-ouia-component-type="PF4/Button"
-      id="disabled"
-      key="state-header"
-      onClick={[Function]}
-    >
-      <div>
-        State 
-        <ArrowsAltVIcon
-          className="not-active"
-          color="currentColor"
-          noVerticalAlign={false}
-          size="sm"
-        />
-      </div>
-    </th>
-    <td
-      key="loading-systems-header"
-    >
-      <Skeleton
-        size="md"
+      <path
+        d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
       />
-    </td>
-  </tr>
-</Fragment>
+    </svg>
+  </div>
+  <div>
+    State 
+    <svg
+      aria-hidden="true"
+      class="not-active"
+      fill="currentColor"
+      height="1em"
+      role="img"
+      style="vertical-align: -0.125em;"
+      viewBox="0 0 256 512"
+      width="1em"
+    >
+      <path
+        d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+      />
+    </svg>
+  </div>
+  <div>
+    <a
+      aria-label="remove-system-icon"
+      class="remove-system-icon"
+      data-ouia-component-id="remove-system-button-12e4d81b-f1c6-489a-a829-9d96f3a71f53"
+      data-ouia-component-type="PF4/Button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 352 512"
+        width="1em"
+      >
+        <path
+          d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+        />
+      </svg>
+    </a>
+  </div>
+  <div
+    class="comparison-header"
+  >
+    <div>
+      <span
+        class="drift-header-icon"
+      >
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align: -0.125em;"
+          viewBox="0 0 1024 1024"
+          width="1em"
+        >
+          <path
+            d="M0,767.3 L0,640 L64,640 L64,752.3 C64,760.584271 70.7157288,767.3 79,767.3 L128,768.1 L128,832.1 L64,831.3 C28.6674863,831.266922 0.0330777378,802.632514 0,767.3 Z M64,0 L191.3,0 L191.3,64 L79,64 C70.7157288,64 64,70.7157288 64,79 L64,192 L0,192 L0,64 C0.0330777378,28.6674863 28.6674863,0.0330777378 64,0 Z M0,384 L64,384 L64,256 L0,256 L0,384 Z M0,576 L64,576 L64,448 L0,448 L0,576 Z M832,64.7 L832,128 L768,128 L768,79.7 C768,71.4157288 761.284271,64.7 753,64.7 L640,64.7 L640,0.7 L768,0.7 C803.332514,0.733077738 831.966922,29.3674863 832,64.7 Z M448,64.7 L576,64.7 L576,0.7 L448,0.7 L448,64.7 Z M256,64.7 L384,64.7 L384,0.7 L256,0.7 L256,64.7 Z M960,192 L256,192 C220.667486,192.033078 192.033078,220.667486 192,256 L192,960 C192.033078,995.332514 220.667486,1023.96692 256,1024 L960,1024 C995.332514,1023.96692 1023.96692,995.332514 1024,960 L1024,256 C1023.96692,220.667486 995.332514,192.033078 960,192 Z M960,945 C960,953.284271 953.284271,960 945,960 L271,960 C262.715729,960 256,953.284271 256,945 L256,271 C256,262.715729 262.715729,256 271,256 L945,256 C953.284271,256 960,262.715729 960,271 L960,945 Z"
+          />
+        </svg>
+      </span>
+      <span
+        class="system-name"
+      >
+        baselineA
+      </span>
+    </div>
+    <div
+      class="system-updated-and-reference"
+    >
+      <svg
+        aria-hidden="true"
+        class="reference-selector pointer"
+        data-ouia-component-id="reference-selector-12e4d81b-f1c6-489a-a829-9d96f3a71f53"
+        data-ouia-component-type="PF4/Button"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 576 512"
+        width="1em"
+      >
+        <path
+          d="M528.1 171.5L382 150.2 316.7 17.8c-11.7-23.6-45.6-23.9-57.4 0L194 150.2 47.9 171.5c-26.2 3.8-36.7 36.1-17.7 54.6l105.7 103-25 145.5c-4.5 26.3 23.2 46 46.4 33.7L288 439.6l130.7 68.7c23.2 12.2 50.9-7.4 46.4-33.7l-25-145.5 105.7-103c19-18.5 8.5-50.8-17.7-54.6zM388.6 312.3l23.7 138.4L288 385.4l-124.3 65.3 23.7-138.4-100.6-98 139-20.2 62.2-126 62.2 126 139 20.2-100.6 98z"
+        />
+      </svg>
+      <span
+        class="system-header-date-margin"
+      >
+        30 Apr 2021, 23:53 UTC
+      </span>
+    </div>
+  </div>
+  <div>
+    <a
+      aria-label="remove-system-icon"
+      class="remove-system-icon"
+      data-ouia-component-id="remove-system-button-dc47qffd-09rt-2kw7-8b9b-53f4g716fec5"
+      data-ouia-component-type="PF4/Button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 352 512"
+        width="1em"
+      >
+        <path
+          d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+        />
+      </svg>
+    </a>
+  </div>
+  <div
+    class="comparison-header"
+  >
+    <div>
+      <span
+        class="drift-header-icon"
+      >
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align: -0.125em;"
+          viewBox="0 0 512 512"
+          width="1em"
+        >
+          <path
+            d="M480 160H32c-17.673 0-32-14.327-32-32V64c0-17.673 14.327-32 32-32h448c17.673 0 32 14.327 32 32v64c0 17.673-14.327 32-32 32zm-48-88c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm-64 0c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm112 248H32c-17.673 0-32-14.327-32-32v-64c0-17.673 14.327-32 32-32h448c17.673 0 32 14.327 32 32v64c0 17.673-14.327 32-32 32zm-48-88c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm-64 0c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm112 248H32c-17.673 0-32-14.327-32-32v-64c0-17.673 14.327-32 32-32h448c17.673 0 32 14.327 32 32v64c0 17.673-14.327 32-32 32zm-48-88c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm-64 0c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24z"
+          />
+        </svg>
+      </span>
+      <span
+        class="system-name"
+      >
+        systemA
+      </span>
+    </div>
+    <div
+      class="system-updated-and-reference"
+    >
+      <svg
+        aria-hidden="true"
+        class="reference-selector pointer"
+        data-ouia-component-id="reference-selector-dc47qffd-09rt-2kw7-8b9b-53f4g716fec5"
+        data-ouia-component-type="PF4/Button"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 576 512"
+        width="1em"
+      >
+        <path
+          d="M528.1 171.5L382 150.2 316.7 17.8c-11.7-23.6-45.6-23.9-57.4 0L194 150.2 47.9 171.5c-26.2 3.8-36.7 36.1-17.7 54.6l105.7 103-25 145.5c-4.5 26.3 23.2 46 46.4 33.7L288 439.6l130.7 68.7c23.2 12.2 50.9-7.4 46.4-33.7l-25-145.5 105.7-103c19-18.5 8.5-50.8-17.7-54.6zM388.6 312.3l23.7 138.4L288 385.4l-124.3 65.3 23.7-138.4-100.6-98 139-20.2 62.2-126 62.2 126 139 20.2-100.6 98z"
+        />
+      </svg>
+      <span
+        class="system-header-date-margin"
+      >
+        02 Nov 2020, 12:41 UTC
+      </span>
+      <span
+        class="hsp-icon-padding"
+        data-ouia-component-id="hsp-popover-toggle-dc47qffd-09rt-2kw7-8b9b-53f4g716fec5"
+        data-ouia-component-type="PF4/Button"
+      >
+        <svg
+          aria-hidden="true"
+          class="hsp-dropdown-icon"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align: -0.125em;"
+          viewBox="0 0 512 512"
+          width="1em"
+        >
+          <path
+            d="M504 255.531c.253 136.64-111.18 248.372-247.82 248.468-59.015.042-113.223-20.53-155.822-54.911-11.077-8.94-11.905-25.541-1.839-35.607l11.267-11.267c8.609-8.609 22.353-9.551 31.891-1.984C173.062 425.135 212.781 440 256 440c101.705 0 184-82.311 184-184 0-101.705-82.311-184-184-184-48.814 0-93.149 18.969-126.068 49.932l50.754 50.754c10.08 10.08 2.941 27.314-11.313 27.314H24c-8.837 0-16-7.163-16-16V38.627c0-14.254 17.234-21.393 27.314-11.314l49.372 49.372C129.209 34.136 189.552 8 256 8c136.81 0 247.747 110.78 248 247.531zm-180.912 78.784l9.823-12.63c8.138-10.463 6.253-25.542-4.21-33.679L288 256.349V152c0-13.255-10.745-24-24-24h-16c-13.255 0-24 10.745-24 24v135.651l65.409 50.874c10.463 8.137 25.541 6.253 33.679-4.21z"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>
+  <div>
+    <a
+      aria-label="remove-system-icon"
+      class="remove-system-icon"
+      data-ouia-component-id="remove-system-button-e3ed3e34-eaa1-45c4-8633-94fef1f678f1"
+      data-ouia-component-type="PF4/Button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 352 512"
+        width="1em"
+      >
+        <path
+          d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+        />
+      </svg>
+    </a>
+  </div>
+  <div
+    class="comparison-header"
+  >
+    <div>
+      <span
+        class="drift-header-icon"
+      >
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align: -0.125em;"
+          viewBox="0 0 512 512"
+          width="1em"
+        >
+          <path
+            d="M256,8C119,8,8,119,8,256S119,504,256,504,504,393,504,256,393,8,256,8Zm92.49,313h0l-20,25a16,16,0,0,1-22.49,2.5h0l-67-49.72a40,40,0,0,1-15-31.23V112a16,16,0,0,1,16-16h32a16,16,0,0,1,16,16V256l58,42.5A16,16,0,0,1,348.49,321Z"
+          />
+        </svg>
+      </span>
+      <span
+        class="system-name"
+      >
+        hspA
+      </span>
+    </div>
+    <div
+      class="system-updated-and-reference"
+    >
+      <svg
+        aria-hidden="true"
+        class="reference-selector pointer"
+        data-ouia-component-id="reference-selector-e3ed3e34-eaa1-45c4-8633-94fef1f678f1"
+        data-ouia-component-type="PF4/Button"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 576 512"
+        width="1em"
+      >
+        <path
+          d="M528.1 171.5L382 150.2 316.7 17.8c-11.7-23.6-45.6-23.9-57.4 0L194 150.2 47.9 171.5c-26.2 3.8-36.7 36.1-17.7 54.6l105.7 103-25 145.5c-4.5 26.3 23.2 46 46.4 33.7L288 439.6l130.7 68.7c23.2 12.2 50.9-7.4 46.4-33.7l-25-145.5 105.7-103c19-18.5 8.5-50.8-17.7-54.6zM388.6 312.3l23.7 138.4L288 385.4l-124.3 65.3 23.7-138.4-100.6-98 139-20.2 62.2-126 62.2 126 139 20.2-100.6 98z"
+        />
+      </svg>
+      <span
+        class="system-header-date-margin"
+      >
+        15 May 2021, 07:24 UTC
+      </span>
+      <span
+        class="hsp-icon-padding"
+        data-ouia-component-id="hsp-popover-toggle-dc47qffd-09rt-2kw7-8b9b-53f4g716fec5"
+        data-ouia-component-type="PF4/Button"
+      >
+        <svg
+          aria-hidden="true"
+          class="hsp-dropdown-icon"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align: -0.125em;"
+          viewBox="0 0 512 512"
+          width="1em"
+        >
+          <path
+            d="M504 255.531c.253 136.64-111.18 248.372-247.82 248.468-59.015.042-113.223-20.53-155.822-54.911-11.077-8.94-11.905-25.541-1.839-35.607l11.267-11.267c8.609-8.609 22.353-9.551 31.891-1.984C173.062 425.135 212.781 440 256 440c101.705 0 184-82.311 184-184 0-101.705-82.311-184-184-184-48.814 0-93.149 18.969-126.068 49.932l50.754 50.754c10.08 10.08 2.941 27.314-11.313 27.314H24c-8.837 0-16-7.163-16-16V38.627c0-14.254 17.234-21.393 27.314-11.314l49.372 49.372C129.209 34.136 189.552 8 256 8c136.81 0 247.747 110.78 248 247.531zm-180.912 78.784l9.823-12.63c8.138-10.463 6.253-25.542-4.21-33.679L288 256.349V152c0-13.255-10.745-24-24-24h-16c-13.255 0-24 10.745-24 24v135.651l65.409 50.874c10.463 8.137 25.541 6.253 33.679-4.21z"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>
+</DocumentFragment>
 `;
 
-exports[`ComparisonHeader should render fact sort desc 1`] = `
-<Fragment>
-  <tr
-    className="sticky-column-header"
-    data-ouia-component-id="comparison-table-header-row"
-    data-ouia-component-type="PF4/TableRow"
+exports[`ComparisonHeader react-testing-library should render correctly 1`] = `
+<DocumentFragment>
+  <div
+    class="active-blue"
   >
-    <th
-      className="fact-header sticky-column fixed-column-1 pointer sticky-header"
-      data-ouia-component-id="fact-sort-button"
-      data-ouia-component-type="PF4/Button"
-      id="desc"
-      key="fact-header"
-      onClick={[Function]}
+    Fact 
+    <svg
+      aria-hidden="true"
+      class="not-active"
+      fill="currentColor"
+      height="1em"
+      role="img"
+      style="vertical-align: -0.125em;"
+      viewBox="0 0 256 512"
+      width="1em"
     >
-      <div
-        className="active-blue"
-      >
-        Fact 
-        <LongArrowAltDownIcon
-          className="active-blue"
-          color="currentColor"
-          noVerticalAlign={false}
-          size="sm"
-        />
-      </div>
-    </th>
-    <th
-      className="state-header sticky-column fixed-column-2 pointer right-border sticky-header"
-      data-ouia-component-id="state-sort-button"
-      data-ouia-component-type="PF4/Button"
-      id="disabled"
-      key="state-header"
-      onClick={[Function]}
-    >
-      <div>
-        State 
-        <ArrowsAltVIcon
-          className="not-active"
-          color="currentColor"
-          noVerticalAlign={false}
-          size="sm"
-        />
-      </div>
-    </th>
-    <td
-      key="loading-systems-header"
-    >
-      <Skeleton
-        size="md"
+      <path
+        d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
       />
-    </td>
-  </tr>
-</Fragment>
+    </svg>
+  </div>
+  <div>
+    State 
+    <svg
+      aria-hidden="true"
+      class="not-active"
+      fill="currentColor"
+      height="1em"
+      role="img"
+      style="vertical-align: -0.125em;"
+      viewBox="0 0 256 512"
+      width="1em"
+    >
+      <path
+        d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+      />
+    </svg>
+  </div>
+  <div
+    class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__md"
+  >
+    <span
+      class="pf-u-screen-reader"
+    />
+  </div>
+</DocumentFragment>
 `;
 
-exports[`ComparisonHeader should render state sort asc 1`] = `
-<Fragment>
-  <tr
-    className="sticky-column-header"
-    data-ouia-component-id="comparison-table-header-row"
-    data-ouia-component-type="PF4/TableRow"
+exports[`ComparisonHeader react-testing-library should render fact sort asc 1`] = `
+<DocumentFragment>
+  <div
+    class="active-blue"
   >
-    <th
-      className="fact-header sticky-column fixed-column-1 pointer sticky-header"
-      data-ouia-component-id="fact-sort-button"
-      data-ouia-component-type="PF4/Button"
-      id=""
-      key="fact-header"
-      onClick={[Function]}
+    Fact 
+    <svg
+      aria-hidden="true"
+      class="active-blue"
+      fill="currentColor"
+      height="1em"
+      role="img"
+      style="vertical-align: -0.125em;"
+      viewBox="0 0 256 512"
+      width="1em"
     >
-      <div
-        className="active-blue"
-      >
-        Fact 
-        <ArrowsAltVIcon
-          className="not-active"
-          color="currentColor"
-          noVerticalAlign={false}
-          size="sm"
-        />
-      </div>
-    </th>
-    <th
-      className="state-header sticky-column fixed-column-2 pointer right-border sticky-header"
-      data-ouia-component-id="state-sort-button"
-      data-ouia-component-type="PF4/Button"
-      id="asc"
-      key="state-header"
-      onClick={[Function]}
-    >
-      <div
-        className="active-blue"
-      >
-        State 
-        <LongArrowAltUpIcon
-          className="active-blue"
-          color="currentColor"
-          noVerticalAlign={false}
-          size="sm"
-        />
-      </div>
-    </th>
-    <td
-      key="loading-systems-header"
-    >
-      <Skeleton
-        size="md"
+      <path
+        d="M88 166.059V468c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12V166.059h46.059c21.382 0 32.09-25.851 16.971-40.971l-86.059-86.059c-9.373-9.373-24.569-9.373-33.941 0l-86.059 86.059c-15.119 15.119-4.411 40.971 16.971 40.971H88z"
       />
-    </td>
-  </tr>
-</Fragment>
+    </svg>
+  </div>
+  <div>
+    State 
+    <svg
+      aria-hidden="true"
+      class="not-active"
+      fill="currentColor"
+      height="1em"
+      role="img"
+      style="vertical-align: -0.125em;"
+      viewBox="0 0 256 512"
+      width="1em"
+    >
+      <path
+        d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+      />
+    </svg>
+  </div>
+  <div
+    class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__md"
+  >
+    <span
+      class="pf-u-screen-reader"
+    />
+  </div>
+</DocumentFragment>
 `;
 
-exports[`ComparisonHeader should render state sort desc 1`] = `
-<Fragment>
-  <tr
-    className="sticky-column-header"
-    data-ouia-component-id="comparison-table-header-row"
-    data-ouia-component-type="PF4/TableRow"
+exports[`ComparisonHeader react-testing-library should render fact sort desc 1`] = `
+<DocumentFragment>
+  <div
+    class="active-blue"
   >
-    <th
-      className="fact-header sticky-column fixed-column-1 pointer sticky-header"
-      data-ouia-component-id="fact-sort-button"
-      data-ouia-component-type="PF4/Button"
-      id=""
-      key="fact-header"
-      onClick={[Function]}
+    Fact 
+    <svg
+      aria-hidden="true"
+      class="active-blue"
+      fill="currentColor"
+      height="1em"
+      role="img"
+      style="vertical-align: -0.125em;"
+      viewBox="0 0 256 512"
+      width="1em"
     >
-      <div
-        className="active-blue"
-      >
-        Fact 
-        <ArrowsAltVIcon
-          className="not-active"
-          color="currentColor"
-          noVerticalAlign={false}
-          size="sm"
-        />
-      </div>
-    </th>
-    <th
-      className="state-header sticky-column fixed-column-2 pointer right-border sticky-header"
-      data-ouia-component-id="state-sort-button"
-      data-ouia-component-type="PF4/Button"
-      id="desc"
-      key="state-header"
-      onClick={[Function]}
-    >
-      <div
-        className="active-blue"
-      >
-        State 
-        <LongArrowAltDownIcon
-          className="active-blue"
-          color="currentColor"
-          noVerticalAlign={false}
-          size="sm"
-        />
-      </div>
-    </th>
-    <td
-      key="loading-systems-header"
-    >
-      <Skeleton
-        size="md"
+      <path
+        d="M168 345.941V44c0-6.627-5.373-12-12-12h-56c-6.627 0-12 5.373-12 12v301.941H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.569 9.373 33.941 0l86.059-86.059c15.119-15.119 4.411-40.971-16.971-40.971H168z"
       />
-    </td>
-  </tr>
-</Fragment>
+    </svg>
+  </div>
+  <div>
+    State 
+    <svg
+      aria-hidden="true"
+      class="not-active"
+      fill="currentColor"
+      height="1em"
+      role="img"
+      style="vertical-align: -0.125em;"
+      viewBox="0 0 256 512"
+      width="1em"
+    >
+      <path
+        d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+      />
+    </svg>
+  </div>
+  <div
+    class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__md"
+  >
+    <span
+      class="pf-u-screen-reader"
+    />
+  </div>
+</DocumentFragment>
+`;
+
+exports[`ComparisonHeader react-testing-library should render state sort asc 1`] = `
+<DocumentFragment>
+  <div
+    class="active-blue"
+  >
+    Fact 
+    <svg
+      aria-hidden="true"
+      class="not-active"
+      fill="currentColor"
+      height="1em"
+      role="img"
+      style="vertical-align: -0.125em;"
+      viewBox="0 0 256 512"
+      width="1em"
+    >
+      <path
+        d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+      />
+    </svg>
+  </div>
+  <div
+    class="active-blue"
+  >
+    State 
+    <svg
+      aria-hidden="true"
+      class="active-blue"
+      fill="currentColor"
+      height="1em"
+      role="img"
+      style="vertical-align: -0.125em;"
+      viewBox="0 0 256 512"
+      width="1em"
+    >
+      <path
+        d="M88 166.059V468c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12V166.059h46.059c21.382 0 32.09-25.851 16.971-40.971l-86.059-86.059c-9.373-9.373-24.569-9.373-33.941 0l-86.059 86.059c-15.119 15.119-4.411 40.971 16.971 40.971H88z"
+      />
+    </svg>
+  </div>
+  <div
+    class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__md"
+  >
+    <span
+      class="pf-u-screen-reader"
+    />
+  </div>
+</DocumentFragment>
+`;
+
+exports[`ComparisonHeader react-testing-library should render state sort desc 1`] = `
+<DocumentFragment>
+  <div
+    class="active-blue"
+  >
+    Fact 
+    <svg
+      aria-hidden="true"
+      class="not-active"
+      fill="currentColor"
+      height="1em"
+      role="img"
+      style="vertical-align: -0.125em;"
+      viewBox="0 0 256 512"
+      width="1em"
+    >
+      <path
+        d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+      />
+    </svg>
+  </div>
+  <div
+    class="active-blue"
+  >
+    State 
+    <svg
+      aria-hidden="true"
+      class="active-blue"
+      fill="currentColor"
+      height="1em"
+      role="img"
+      style="vertical-align: -0.125em;"
+      viewBox="0 0 256 512"
+      width="1em"
+    >
+      <path
+        d="M168 345.941V44c0-6.627-5.373-12-12-12h-56c-6.627 0-12 5.373-12 12v301.941H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.569 9.373 33.941 0l86.059-86.059c15.119-15.119 4.411-40.971-16.971-40.971H168z"
+      />
+    </svg>
+  </div>
+  <div
+    class="pf-c-skeleton ins-c-skeleton ins-c-skeleton__md"
+  >
+    <span
+      class="pf-u-screen-reader"
+    />
+  </div>
+</DocumentFragment>
+`;
+
+exports[`ComparisonHeader react-testing-library should render with insights_enabled=false 1`] = `
+<DocumentFragment>
+  <div
+    class="active-blue"
+  >
+    Fact 
+    <svg
+      aria-hidden="true"
+      class="not-active"
+      fill="currentColor"
+      height="1em"
+      role="img"
+      style="vertical-align: -0.125em;"
+      viewBox="0 0 256 512"
+      width="1em"
+    >
+      <path
+        d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+      />
+    </svg>
+  </div>
+  <div>
+    State 
+    <svg
+      aria-hidden="true"
+      class="not-active"
+      fill="currentColor"
+      height="1em"
+      role="img"
+      style="vertical-align: -0.125em;"
+      viewBox="0 0 256 512"
+      width="1em"
+    >
+      <path
+        d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+      />
+    </svg>
+  </div>
+  <div>
+    <a
+      aria-label="remove-system-icon"
+      class="remove-system-icon"
+      data-ouia-component-id="remove-system-button-12e4d81b-f1c6-489a-a829-9d96f3a71f53"
+      data-ouia-component-type="PF4/Button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 352 512"
+        width="1em"
+      >
+        <path
+          d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+        />
+      </svg>
+    </a>
+  </div>
+  <div
+    class="comparison-header"
+  >
+    <div>
+      <span
+        class="drift-header-icon"
+      >
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align: -0.125em;"
+          viewBox="0 0 1024 1024"
+          width="1em"
+        >
+          <path
+            d="M0,767.3 L0,640 L64,640 L64,752.3 C64,760.584271 70.7157288,767.3 79,767.3 L128,768.1 L128,832.1 L64,831.3 C28.6674863,831.266922 0.0330777378,802.632514 0,767.3 Z M64,0 L191.3,0 L191.3,64 L79,64 C70.7157288,64 64,70.7157288 64,79 L64,192 L0,192 L0,64 C0.0330777378,28.6674863 28.6674863,0.0330777378 64,0 Z M0,384 L64,384 L64,256 L0,256 L0,384 Z M0,576 L64,576 L64,448 L0,448 L0,576 Z M832,64.7 L832,128 L768,128 L768,79.7 C768,71.4157288 761.284271,64.7 753,64.7 L640,64.7 L640,0.7 L768,0.7 C803.332514,0.733077738 831.966922,29.3674863 832,64.7 Z M448,64.7 L576,64.7 L576,0.7 L448,0.7 L448,64.7 Z M256,64.7 L384,64.7 L384,0.7 L256,0.7 L256,64.7 Z M960,192 L256,192 C220.667486,192.033078 192.033078,220.667486 192,256 L192,960 C192.033078,995.332514 220.667486,1023.96692 256,1024 L960,1024 C995.332514,1023.96692 1023.96692,995.332514 1024,960 L1024,256 C1023.96692,220.667486 995.332514,192.033078 960,192 Z M960,945 C960,953.284271 953.284271,960 945,960 L271,960 C262.715729,960 256,953.284271 256,945 L256,271 C256,262.715729 262.715729,256 271,256 L945,256 C953.284271,256 960,262.715729 960,271 L960,945 Z"
+          />
+        </svg>
+      </span>
+      <span
+        class="system-name"
+      >
+        baselineA
+      </span>
+    </div>
+    <div
+      class="system-updated-and-reference"
+    >
+      <svg
+        aria-hidden="true"
+        class="reference-selector pointer"
+        data-ouia-component-id="reference-selector-12e4d81b-f1c6-489a-a829-9d96f3a71f53"
+        data-ouia-component-type="PF4/Button"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 576 512"
+        width="1em"
+      >
+        <path
+          d="M528.1 171.5L382 150.2 316.7 17.8c-11.7-23.6-45.6-23.9-57.4 0L194 150.2 47.9 171.5c-26.2 3.8-36.7 36.1-17.7 54.6l105.7 103-25 145.5c-4.5 26.3 23.2 46 46.4 33.7L288 439.6l130.7 68.7c23.2 12.2 50.9-7.4 46.4-33.7l-25-145.5 105.7-103c19-18.5 8.5-50.8-17.7-54.6zM388.6 312.3l23.7 138.4L288 385.4l-124.3 65.3 23.7-138.4-100.6-98 139-20.2 62.2-126 62.2 126 139 20.2-100.6 98z"
+        />
+      </svg>
+      <span
+        class="system-header-date-margin"
+      >
+        30 Apr 2021, 23:53 UTC
+      </span>
+    </div>
+  </div>
+  <div>
+    <a
+      aria-label="remove-system-icon"
+      class="remove-system-icon"
+      data-ouia-component-id="remove-system-button-dc47qffd-09rt-2kw7-8b9b-53f4g716fec5"
+      data-ouia-component-type="PF4/Button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 352 512"
+        width="1em"
+      >
+        <path
+          d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+        />
+      </svg>
+    </a>
+  </div>
+  <div
+    class="comparison-header"
+  >
+    <div>
+      <span
+        class="drift-header-icon"
+      >
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align: -0.125em;"
+          viewBox="0 0 512 512"
+          width="1em"
+        >
+          <path
+            d="M480 160H32c-17.673 0-32-14.327-32-32V64c0-17.673 14.327-32 32-32h448c17.673 0 32 14.327 32 32v64c0 17.673-14.327 32-32 32zm-48-88c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm-64 0c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm112 248H32c-17.673 0-32-14.327-32-32v-64c0-17.673 14.327-32 32-32h448c17.673 0 32 14.327 32 32v64c0 17.673-14.327 32-32 32zm-48-88c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm-64 0c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm112 248H32c-17.673 0-32-14.327-32-32v-64c0-17.673 14.327-32 32-32h448c17.673 0 32 14.327 32 32v64c0 17.673-14.327 32-32 32zm-48-88c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm-64 0c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24z"
+          />
+        </svg>
+      </span>
+      <span
+        class="system-name"
+      >
+        systemA
+      </span>
+    </div>
+    <div
+      class="system-updated-and-reference"
+    >
+      <svg
+        aria-hidden="true"
+        class="reference-selector pointer"
+        data-ouia-component-id="reference-selector-dc47qffd-09rt-2kw7-8b9b-53f4g716fec5"
+        data-ouia-component-type="PF4/Button"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 576 512"
+        width="1em"
+      >
+        <path
+          d="M528.1 171.5L382 150.2 316.7 17.8c-11.7-23.6-45.6-23.9-57.4 0L194 150.2 47.9 171.5c-26.2 3.8-36.7 36.1-17.7 54.6l105.7 103-25 145.5c-4.5 26.3 23.2 46 46.4 33.7L288 439.6l130.7 68.7c23.2 12.2 50.9-7.4 46.4-33.7l-25-145.5 105.7-103c19-18.5 8.5-50.8-17.7-54.6zM388.6 312.3l23.7 138.4L288 385.4l-124.3 65.3 23.7-138.4-100.6-98 139-20.2 62.2-126 62.2 126 139 20.2-100.6 98z"
+        />
+      </svg>
+      <span
+        class="system-header-date-margin"
+      >
+        02 Nov 2020, 12:41 UTC
+      </span>
+      <span
+        class="hsp-icon-padding"
+        data-ouia-component-id="hsp-popover-toggle-dc47qffd-09rt-2kw7-8b9b-53f4g716fec5"
+        data-ouia-component-type="PF4/Button"
+      >
+        <svg
+          aria-hidden="true"
+          class="hsp-dropdown-icon"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align: -0.125em;"
+          viewBox="0 0 512 512"
+          width="1em"
+        >
+          <path
+            d="M504 255.531c.253 136.64-111.18 248.372-247.82 248.468-59.015.042-113.223-20.53-155.822-54.911-11.077-8.94-11.905-25.541-1.839-35.607l11.267-11.267c8.609-8.609 22.353-9.551 31.891-1.984C173.062 425.135 212.781 440 256 440c101.705 0 184-82.311 184-184 0-101.705-82.311-184-184-184-48.814 0-93.149 18.969-126.068 49.932l50.754 50.754c10.08 10.08 2.941 27.314-11.313 27.314H24c-8.837 0-16-7.163-16-16V38.627c0-14.254 17.234-21.393 27.314-11.314l49.372 49.372C129.209 34.136 189.552 8 256 8c136.81 0 247.747 110.78 248 247.531zm-180.912 78.784l9.823-12.63c8.138-10.463 6.253-25.542-4.21-33.679L288 256.349V152c0-13.255-10.745-24-24-24h-16c-13.255 0-24 10.745-24 24v135.651l65.409 50.874c10.463 8.137 25.541 6.253 33.679-4.21z"
+          />
+        </svg>
+      </span>
+      <svg
+        aria-hidden="true"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 1024 1024"
+        width="1em"
+      >
+        <path
+          d="M107.625758,511.919812 C107.647579,453.639819 120.473237,396.076275 145.195758,343.299812 L66.0757577,263.919812 C64.9757577,266.019812 63.7857577,268.019812 62.6857577,270.119812 C-38.2858609,455.136708 -13.6478565,683.418046 124.475758,842.629812 C134.640866,854.227038 149.304208,860.890207 164.725758,860.920803 C177.621501,860.999229 190.089847,856.300444 199.725758,847.729812 C222.045758,828.339812 224.235758,794.349812 204.725758,771.959812 C142.116482,699.791587 107.639971,607.46129 107.625758,511.919812 Z M298.965758,512.769812 C298.965758,507.959812 299.165758,503.349812 299.465758,498.849812 L223.695758,422.919812 C195.943021,511.49644 210.859555,607.936744 264.075758,683.989812 C272.417691,695.880397 286.040845,702.947712 300.565758,702.92092 C309.717884,702.984827 318.661486,700.187766 326.145758,694.919812 C346.244069,680.682503 351.030068,652.865563 336.845758,632.729812 C312.094475,597.618928 298.858215,555.687799 298.965758,512.729812 L298.965758,512.769812 Z M903.425758,837.839812 C1064.25516,648.181373 1062.68818,369.557312 899.735758,181.719812 C890.46515,170.983736 877.290268,164.395355 863.139154,163.418898 C848.98804,162.442441 835.033106,167.158807 824.375758,176.519812 C802.005758,195.919812 799.815758,229.919812 819.185758,252.309812 C945.123654,397.620078 948.572544,612.370403 827.365758,761.649812 L754.005758,688.159812 C755.244385,686.815558 756.37773,685.377981 757.395758,683.859812 C792.844775,633.759435 811.790626,573.852791 811.595758,512.479812 C811.595758,450.189812 792.735758,390.599812 756.695758,340.199812 C749.880846,330.567 739.510358,324.044705 727.876268,322.074416 C716.242178,320.104127 704.302408,322.848071 694.695758,329.699812 C674.625758,343.899812 670.135758,371.699812 684.215758,391.799812 C733.317078,460.966176 735.688504,552.965658 690.215758,624.569812 L615.045758,549.479812 C619.447596,537.503845 621.679174,524.839047 621.635758,512.079812 C621.657896,451.518897 572.616613,402.388105 512.055758,402.299812 C499.315423,402.259246 486.670236,404.494336 474.715758,408.899812 L82.6457577,15.6398121 C64.3651324,-2.58558468 34.7711544,-2.54081316 16.5457577,15.7398121 C-1.67963909,34.0204373 -1.63486757,63.6144153 16.6457577,81.8398121 L120.475758,185.919812 L196.535758,261.919812 L333.185758,398.799812 L408.845758,474.589812 L549.005758,614.969812 L941.455758,1008.21981 C959.733621,1026.4673 989.34327,1026.44268 1007.59076,1008.16481 C1025.83825,989.886948 1025.81362,960.2773 1007.53576,942.029812 L903.425758,837.839812 Z"
+        />
+      </svg>
+    </div>
+  </div>
+  <div>
+    <a
+      aria-label="remove-system-icon"
+      class="remove-system-icon"
+      data-ouia-component-id="remove-system-button-e3ed3e34-eaa1-45c4-8633-94fef1f678f1"
+      data-ouia-component-type="PF4/Button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 352 512"
+        width="1em"
+      >
+        <path
+          d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+        />
+      </svg>
+    </a>
+  </div>
+  <div
+    class="comparison-header"
+  >
+    <div>
+      <span
+        class="drift-header-icon"
+      >
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align: -0.125em;"
+          viewBox="0 0 512 512"
+          width="1em"
+        >
+          <path
+            d="M256,8C119,8,8,119,8,256S119,504,256,504,504,393,504,256,393,8,256,8Zm92.49,313h0l-20,25a16,16,0,0,1-22.49,2.5h0l-67-49.72a40,40,0,0,1-15-31.23V112a16,16,0,0,1,16-16h32a16,16,0,0,1,16,16V256l58,42.5A16,16,0,0,1,348.49,321Z"
+          />
+        </svg>
+      </span>
+      <span
+        class="system-name"
+      >
+        hspA
+      </span>
+    </div>
+    <div
+      class="system-updated-and-reference"
+    >
+      <svg
+        aria-hidden="true"
+        class="reference-selector pointer"
+        data-ouia-component-id="reference-selector-e3ed3e34-eaa1-45c4-8633-94fef1f678f1"
+        data-ouia-component-type="PF4/Button"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 576 512"
+        width="1em"
+      >
+        <path
+          d="M528.1 171.5L382 150.2 316.7 17.8c-11.7-23.6-45.6-23.9-57.4 0L194 150.2 47.9 171.5c-26.2 3.8-36.7 36.1-17.7 54.6l105.7 103-25 145.5c-4.5 26.3 23.2 46 46.4 33.7L288 439.6l130.7 68.7c23.2 12.2 50.9-7.4 46.4-33.7l-25-145.5 105.7-103c19-18.5 8.5-50.8-17.7-54.6zM388.6 312.3l23.7 138.4L288 385.4l-124.3 65.3 23.7-138.4-100.6-98 139-20.2 62.2-126 62.2 126 139 20.2-100.6 98z"
+        />
+      </svg>
+      <span
+        class="system-header-date-margin"
+      >
+        15 May 2021, 07:24 UTC
+      </span>
+      <span
+        class="hsp-icon-padding"
+        data-ouia-component-id="hsp-popover-toggle-dc47qffd-09rt-2kw7-8b9b-53f4g716fec5"
+        data-ouia-component-type="PF4/Button"
+      >
+        <svg
+          aria-hidden="true"
+          class="hsp-dropdown-icon"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align: -0.125em;"
+          viewBox="0 0 512 512"
+          width="1em"
+        >
+          <path
+            d="M504 255.531c.253 136.64-111.18 248.372-247.82 248.468-59.015.042-113.223-20.53-155.822-54.911-11.077-8.94-11.905-25.541-1.839-35.607l11.267-11.267c8.609-8.609 22.353-9.551 31.891-1.984C173.062 425.135 212.781 440 256 440c101.705 0 184-82.311 184-184 0-101.705-82.311-184-184-184-48.814 0-93.149 18.969-126.068 49.932l50.754 50.754c10.08 10.08 2.941 27.314-11.313 27.314H24c-8.837 0-16-7.163-16-16V38.627c0-14.254 17.234-21.393 27.314-11.314l49.372 49.372C129.209 34.136 189.552 8 256 8c136.81 0 247.747 110.78 248 247.531zm-180.912 78.784l9.823-12.63c8.138-10.463 6.253-25.542-4.21-33.679L288 256.349V152c0-13.255-10.745-24-24-24h-16c-13.255 0-24 10.745-24 24v135.651l65.409 50.874c10.463 8.137 25.541 6.253 33.679-4.21z"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`ComparisonHeader react-testing-library should render with system_stale=true and insights_installed=false 1`] = `
+<DocumentFragment>
+  <div
+    class="active-blue"
+  >
+    Fact 
+    <svg
+      aria-hidden="true"
+      class="not-active"
+      fill="currentColor"
+      height="1em"
+      role="img"
+      style="vertical-align: -0.125em;"
+      viewBox="0 0 256 512"
+      width="1em"
+    >
+      <path
+        d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+      />
+    </svg>
+  </div>
+  <div>
+    State 
+    <svg
+      aria-hidden="true"
+      class="not-active"
+      fill="currentColor"
+      height="1em"
+      role="img"
+      style="vertical-align: -0.125em;"
+      viewBox="0 0 256 512"
+      width="1em"
+    >
+      <path
+        d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+      />
+    </svg>
+  </div>
+  <div>
+    <a
+      aria-label="remove-system-icon"
+      class="remove-system-icon"
+      data-ouia-component-id="remove-system-button-12e4d81b-f1c6-489a-a829-9d96f3a71f53"
+      data-ouia-component-type="PF4/Button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 352 512"
+        width="1em"
+      >
+        <path
+          d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+        />
+      </svg>
+    </a>
+  </div>
+  <div
+    class="comparison-header"
+  >
+    <div>
+      <span
+        class="drift-header-icon"
+      >
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align: -0.125em;"
+          viewBox="0 0 1024 1024"
+          width="1em"
+        >
+          <path
+            d="M0,767.3 L0,640 L64,640 L64,752.3 C64,760.584271 70.7157288,767.3 79,767.3 L128,768.1 L128,832.1 L64,831.3 C28.6674863,831.266922 0.0330777378,802.632514 0,767.3 Z M64,0 L191.3,0 L191.3,64 L79,64 C70.7157288,64 64,70.7157288 64,79 L64,192 L0,192 L0,64 C0.0330777378,28.6674863 28.6674863,0.0330777378 64,0 Z M0,384 L64,384 L64,256 L0,256 L0,384 Z M0,576 L64,576 L64,448 L0,448 L0,576 Z M832,64.7 L832,128 L768,128 L768,79.7 C768,71.4157288 761.284271,64.7 753,64.7 L640,64.7 L640,0.7 L768,0.7 C803.332514,0.733077738 831.966922,29.3674863 832,64.7 Z M448,64.7 L576,64.7 L576,0.7 L448,0.7 L448,64.7 Z M256,64.7 L384,64.7 L384,0.7 L256,0.7 L256,64.7 Z M960,192 L256,192 C220.667486,192.033078 192.033078,220.667486 192,256 L192,960 C192.033078,995.332514 220.667486,1023.96692 256,1024 L960,1024 C995.332514,1023.96692 1023.96692,995.332514 1024,960 L1024,256 C1023.96692,220.667486 995.332514,192.033078 960,192 Z M960,945 C960,953.284271 953.284271,960 945,960 L271,960 C262.715729,960 256,953.284271 256,945 L256,271 C256,262.715729 262.715729,256 271,256 L945,256 C953.284271,256 960,262.715729 960,271 L960,945 Z"
+          />
+        </svg>
+      </span>
+      <span
+        class="system-name"
+      >
+        baselineA
+      </span>
+    </div>
+    <div
+      class="system-updated-and-reference"
+    >
+      <svg
+        aria-hidden="true"
+        class="reference-selector pointer"
+        data-ouia-component-id="reference-selector-12e4d81b-f1c6-489a-a829-9d96f3a71f53"
+        data-ouia-component-type="PF4/Button"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 576 512"
+        width="1em"
+      >
+        <path
+          d="M528.1 171.5L382 150.2 316.7 17.8c-11.7-23.6-45.6-23.9-57.4 0L194 150.2 47.9 171.5c-26.2 3.8-36.7 36.1-17.7 54.6l105.7 103-25 145.5c-4.5 26.3 23.2 46 46.4 33.7L288 439.6l130.7 68.7c23.2 12.2 50.9-7.4 46.4-33.7l-25-145.5 105.7-103c19-18.5 8.5-50.8-17.7-54.6zM388.6 312.3l23.7 138.4L288 385.4l-124.3 65.3 23.7-138.4-100.6-98 139-20.2 62.2-126 62.2 126 139 20.2-100.6 98z"
+        />
+      </svg>
+      <span
+        class="system-header-date-margin"
+      >
+        30 Apr 2021, 23:53 UTC
+      </span>
+    </div>
+  </div>
+  <div>
+    <a
+      aria-label="remove-system-icon"
+      class="remove-system-icon"
+      data-ouia-component-id="remove-system-button-dc47qffd-09rt-2kw7-8b9b-53f4g716fec5"
+      data-ouia-component-type="PF4/Button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 352 512"
+        width="1em"
+      >
+        <path
+          d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+        />
+      </svg>
+    </a>
+  </div>
+  <div
+    class="comparison-header"
+  >
+    <div>
+      <span
+        class="drift-header-icon"
+      >
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align: -0.125em;"
+          viewBox="0 0 512 512"
+          width="1em"
+        >
+          <path
+            d="M480 160H32c-17.673 0-32-14.327-32-32V64c0-17.673 14.327-32 32-32h448c17.673 0 32 14.327 32 32v64c0 17.673-14.327 32-32 32zm-48-88c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm-64 0c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm112 248H32c-17.673 0-32-14.327-32-32v-64c0-17.673 14.327-32 32-32h448c17.673 0 32 14.327 32 32v64c0 17.673-14.327 32-32 32zm-48-88c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm-64 0c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm112 248H32c-17.673 0-32-14.327-32-32v-64c0-17.673 14.327-32 32-32h448c17.673 0 32 14.327 32 32v64c0 17.673-14.327 32-32 32zm-48-88c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm-64 0c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24z"
+          />
+        </svg>
+      </span>
+      <span
+        class="system-name"
+      >
+        systemA
+      </span>
+    </div>
+    <div
+      class="system-updated-and-reference"
+    >
+      <svg
+        aria-hidden="true"
+        class="reference-selector pointer"
+        data-ouia-component-id="reference-selector-dc47qffd-09rt-2kw7-8b9b-53f4g716fec5"
+        data-ouia-component-type="PF4/Button"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 576 512"
+        width="1em"
+      >
+        <path
+          d="M528.1 171.5L382 150.2 316.7 17.8c-11.7-23.6-45.6-23.9-57.4 0L194 150.2 47.9 171.5c-26.2 3.8-36.7 36.1-17.7 54.6l105.7 103-25 145.5c-4.5 26.3 23.2 46 46.4 33.7L288 439.6l130.7 68.7c23.2 12.2 50.9-7.4 46.4-33.7l-25-145.5 105.7-103c19-18.5 8.5-50.8-17.7-54.6zM388.6 312.3l23.7 138.4L288 385.4l-124.3 65.3 23.7-138.4-100.6-98 139-20.2 62.2-126 62.2 126 139 20.2-100.6 98z"
+        />
+      </svg>
+      <span
+        class="system-header-date-margin"
+      >
+        02 Nov 2020, 12:41 UTC
+      </span>
+      <span
+        class="hsp-icon-padding"
+        data-ouia-component-id="hsp-popover-toggle-dc47qffd-09rt-2kw7-8b9b-53f4g716fec5"
+        data-ouia-component-type="PF4/Button"
+      >
+        <svg
+          aria-hidden="true"
+          class="hsp-dropdown-icon"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align: -0.125em;"
+          viewBox="0 0 512 512"
+          width="1em"
+        >
+          <path
+            d="M504 255.531c.253 136.64-111.18 248.372-247.82 248.468-59.015.042-113.223-20.53-155.822-54.911-11.077-8.94-11.905-25.541-1.839-35.607l11.267-11.267c8.609-8.609 22.353-9.551 31.891-1.984C173.062 425.135 212.781 440 256 440c101.705 0 184-82.311 184-184 0-101.705-82.311-184-184-184-48.814 0-93.149 18.969-126.068 49.932l50.754 50.754c10.08 10.08 2.941 27.314-11.313 27.314H24c-8.837 0-16-7.163-16-16V38.627c0-14.254 17.234-21.393 27.314-11.314l49.372 49.372C129.209 34.136 189.552 8 256 8c136.81 0 247.747 110.78 248 247.531zm-180.912 78.784l9.823-12.63c8.138-10.463 6.253-25.542-4.21-33.679L288 256.349V152c0-13.255-10.745-24-24-24h-16c-13.255 0-24 10.745-24 24v135.651l65.409 50.874c10.463 8.137 25.541 6.253 33.679-4.21z"
+          />
+        </svg>
+      </span>
+      <svg
+        aria-hidden="true"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 576 512"
+        width="1em"
+      >
+        <path
+          d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+        />
+      </svg>
+      <svg
+        aria-hidden="true"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 1024 1024"
+        width="1em"
+      >
+        <path
+          d="M107.625758,511.919812 C107.647579,453.639819 120.473237,396.076275 145.195758,343.299812 L66.0757577,263.919812 C64.9757577,266.019812 63.7857577,268.019812 62.6857577,270.119812 C-38.2858609,455.136708 -13.6478565,683.418046 124.475758,842.629812 C134.640866,854.227038 149.304208,860.890207 164.725758,860.920803 C177.621501,860.999229 190.089847,856.300444 199.725758,847.729812 C222.045758,828.339812 224.235758,794.349812 204.725758,771.959812 C142.116482,699.791587 107.639971,607.46129 107.625758,511.919812 Z M298.965758,512.769812 C298.965758,507.959812 299.165758,503.349812 299.465758,498.849812 L223.695758,422.919812 C195.943021,511.49644 210.859555,607.936744 264.075758,683.989812 C272.417691,695.880397 286.040845,702.947712 300.565758,702.92092 C309.717884,702.984827 318.661486,700.187766 326.145758,694.919812 C346.244069,680.682503 351.030068,652.865563 336.845758,632.729812 C312.094475,597.618928 298.858215,555.687799 298.965758,512.729812 L298.965758,512.769812 Z M903.425758,837.839812 C1064.25516,648.181373 1062.68818,369.557312 899.735758,181.719812 C890.46515,170.983736 877.290268,164.395355 863.139154,163.418898 C848.98804,162.442441 835.033106,167.158807 824.375758,176.519812 C802.005758,195.919812 799.815758,229.919812 819.185758,252.309812 C945.123654,397.620078 948.572544,612.370403 827.365758,761.649812 L754.005758,688.159812 C755.244385,686.815558 756.37773,685.377981 757.395758,683.859812 C792.844775,633.759435 811.790626,573.852791 811.595758,512.479812 C811.595758,450.189812 792.735758,390.599812 756.695758,340.199812 C749.880846,330.567 739.510358,324.044705 727.876268,322.074416 C716.242178,320.104127 704.302408,322.848071 694.695758,329.699812 C674.625758,343.899812 670.135758,371.699812 684.215758,391.799812 C733.317078,460.966176 735.688504,552.965658 690.215758,624.569812 L615.045758,549.479812 C619.447596,537.503845 621.679174,524.839047 621.635758,512.079812 C621.657896,451.518897 572.616613,402.388105 512.055758,402.299812 C499.315423,402.259246 486.670236,404.494336 474.715758,408.899812 L82.6457577,15.6398121 C64.3651324,-2.58558468 34.7711544,-2.54081316 16.5457577,15.7398121 C-1.67963909,34.0204373 -1.63486757,63.6144153 16.6457577,81.8398121 L120.475758,185.919812 L196.535758,261.919812 L333.185758,398.799812 L408.845758,474.589812 L549.005758,614.969812 L941.455758,1008.21981 C959.733621,1026.4673 989.34327,1026.44268 1007.59076,1008.16481 C1025.83825,989.886948 1025.81362,960.2773 1007.53576,942.029812 L903.425758,837.839812 Z"
+        />
+      </svg>
+    </div>
+  </div>
+  <div>
+    <a
+      aria-label="remove-system-icon"
+      class="remove-system-icon"
+      data-ouia-component-id="remove-system-button-e3ed3e34-eaa1-45c4-8633-94fef1f678f1"
+      data-ouia-component-type="PF4/Button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 352 512"
+        width="1em"
+      >
+        <path
+          d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+        />
+      </svg>
+    </a>
+  </div>
+  <div
+    class="comparison-header"
+  >
+    <div>
+      <span
+        class="drift-header-icon"
+      >
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align: -0.125em;"
+          viewBox="0 0 512 512"
+          width="1em"
+        >
+          <path
+            d="M256,8C119,8,8,119,8,256S119,504,256,504,504,393,504,256,393,8,256,8Zm92.49,313h0l-20,25a16,16,0,0,1-22.49,2.5h0l-67-49.72a40,40,0,0,1-15-31.23V112a16,16,0,0,1,16-16h32a16,16,0,0,1,16,16V256l58,42.5A16,16,0,0,1,348.49,321Z"
+          />
+        </svg>
+      </span>
+      <span
+        class="system-name"
+      >
+        hspA
+      </span>
+    </div>
+    <div
+      class="system-updated-and-reference"
+    >
+      <svg
+        aria-hidden="true"
+        class="reference-selector pointer"
+        data-ouia-component-id="reference-selector-e3ed3e34-eaa1-45c4-8633-94fef1f678f1"
+        data-ouia-component-type="PF4/Button"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 576 512"
+        width="1em"
+      >
+        <path
+          d="M528.1 171.5L382 150.2 316.7 17.8c-11.7-23.6-45.6-23.9-57.4 0L194 150.2 47.9 171.5c-26.2 3.8-36.7 36.1-17.7 54.6l105.7 103-25 145.5c-4.5 26.3 23.2 46 46.4 33.7L288 439.6l130.7 68.7c23.2 12.2 50.9-7.4 46.4-33.7l-25-145.5 105.7-103c19-18.5 8.5-50.8-17.7-54.6zM388.6 312.3l23.7 138.4L288 385.4l-124.3 65.3 23.7-138.4-100.6-98 139-20.2 62.2-126 62.2 126 139 20.2-100.6 98z"
+        />
+      </svg>
+      <span
+        class="system-header-date-margin"
+      >
+        15 May 2021, 07:24 UTC
+      </span>
+      <span
+        class="hsp-icon-padding"
+        data-ouia-component-id="hsp-popover-toggle-dc47qffd-09rt-2kw7-8b9b-53f4g716fec5"
+        data-ouia-component-type="PF4/Button"
+      >
+        <svg
+          aria-hidden="true"
+          class="hsp-dropdown-icon"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align: -0.125em;"
+          viewBox="0 0 512 512"
+          width="1em"
+        >
+          <path
+            d="M504 255.531c.253 136.64-111.18 248.372-247.82 248.468-59.015.042-113.223-20.53-155.822-54.911-11.077-8.94-11.905-25.541-1.839-35.607l11.267-11.267c8.609-8.609 22.353-9.551 31.891-1.984C173.062 425.135 212.781 440 256 440c101.705 0 184-82.311 184-184 0-101.705-82.311-184-184-184-48.814 0-93.149 18.969-126.068 49.932l50.754 50.754c10.08 10.08 2.941 27.314-11.313 27.314H24c-8.837 0-16-7.163-16-16V38.627c0-14.254 17.234-21.393 27.314-11.314l49.372 49.372C129.209 34.136 189.552 8 256 8c136.81 0 247.747 110.78 248 247.531zm-180.912 78.784l9.823-12.63c8.138-10.463 6.253-25.542-4.21-33.679L288 256.349V152c0-13.255-10.745-24-24-24h-16c-13.255 0-24 10.745-24 24v135.651l65.409 50.874c10.463 8.137 25.541 6.253 33.679-4.21z"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>
+</DocumentFragment>
 `;

--- a/src/SmartComponents/DriftPage/DriftTable/__tests__/__snapshots__/DriftTable.tests.js.snap
+++ b/src/SmartComponents/DriftPage/DriftTable/__tests__/__snapshots__/DriftTable.tests.js.snap
@@ -10238,6 +10238,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                         >
                           <div>
                             <a
+                              aria-label="remove-system-icon"
                               className="remove-system-icon"
                               data-ouia-component-id="remove-system-button-9bbbefcc-8f23-4d97-07f2-142asdl234e9"
                               data-ouia-component-type="PF4/Button"
@@ -10521,7 +10522,11 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                                   </Popper>
                                 </Tooltip>
                               </ReferenceSelector>
-                              15 Jan 2019, 14:53 UTC
+                              <span
+                                className="system-header-date-margin"
+                              >
+                                15 Jan 2019, 14:53 UTC
+                              </span>
                             </div>
                           </div>
                         </th>
@@ -10532,6 +10537,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                         >
                           <div>
                             <a
+                              aria-label="remove-system-icon"
                               className="remove-system-icon"
                               data-ouia-component-id="remove-system-button-fdmk59dj-fn42-dfjk-alv3-bmn2854mnn29"
                               data-ouia-component-type="PF4/Button"
@@ -10815,7 +10821,11 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                                   </Popper>
                                 </Tooltip>
                               </ReferenceSelector>
-                              15 Jan 2019, 15:25 UTC
+                              <span
+                                className="system-header-date-margin"
+                              >
+                                15 Jan 2019, 15:25 UTC
+                              </span>
                             </div>
                           </div>
                         </th>
@@ -10826,6 +10836,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                         >
                           <div>
                             <a
+                              aria-label="remove-system-icon"
                               className="remove-system-icon"
                               data-ouia-component-id="remove-system-button-9c79efcc-8f9a-47c7-b0f2-142ff52e89e9"
                               data-ouia-component-type="PF4/Button"
@@ -11109,7 +11120,11 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                                   </Popper>
                                 </Tooltip>
                               </ReferenceSelector>
-                              15 Jan 2019, 14:53 UTC
+                              <span
+                                className="system-header-date-margin"
+                              >
+                                15 Jan 2019, 14:53 UTC
+                              </span>
                               <withRouter(Connect(HistoricalProfilesPopover))
                                 fetchCompare={[Function]}
                                 hasCompareButton={true}
@@ -11494,6 +11509,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                         >
                           <div>
                             <a
+                              aria-label="remove-system-icon"
                               className="remove-system-icon"
                               data-ouia-component-id="remove-system-button-9bbbefcc-8f23-4d97-07f2-142asdl234e8"
                               data-ouia-component-type="PF4/Button"
@@ -11778,7 +11794,11 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                                   </Popper>
                                 </Tooltip>
                               </ReferenceSelector>
-                              15 Jan 2019, 14:53 UTC
+                              <span
+                                className="system-header-date-margin"
+                              >
+                                15 Jan 2019, 14:53 UTC
+                              </span>
                               <withRouter(Connect(HistoricalProfilesPopover))
                                 fetchCompare={[Function]}
                                 hasCompareButton={true}
@@ -12166,6 +12186,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                         >
                           <div>
                             <a
+                              aria-label="remove-system-icon"
                               className="remove-system-icon"
                               data-ouia-component-id="remove-system-button-edmk59dj-fn42-dfjk-alv3-bmn2854mnn27"
                               data-ouia-component-type="PF4/Button"
@@ -12450,7 +12471,11 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                                   </Popper>
                                 </Tooltip>
                               </ReferenceSelector>
-                              15 Jan 2019, 15:25 UTC
+                              <span
+                                className="system-header-date-margin"
+                              >
+                                15 Jan 2019, 15:25 UTC
+                              </span>
                               <withRouter(Connect(HistoricalProfilesPopover))
                                 fetchCompare={[Function]}
                                 hasCompareButton={true}
@@ -12838,6 +12863,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                         >
                           <div>
                             <a
+                              aria-label="remove-system-icon"
                               className="remove-system-icon"
                               data-ouia-component-id="remove-system-button-f35b1e1d-d231-43f2-8e4f-8f9cb01e3aa2"
                               data-ouia-component-type="PF4/Button"
@@ -13121,7 +13147,11 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                                   </Popper>
                                 </Tooltip>
                               </ReferenceSelector>
-                              15 Jan 2019, 15:25 UTC
+                              <span
+                                className="system-header-date-margin"
+                              >
+                                15 Jan 2019, 15:25 UTC
+                              </span>
                               <withRouter(Connect(HistoricalProfilesPopover))
                                 fetchCompare={[Function]}
                                 hasCompareButton={true}


### PR DESCRIPTION
New icons are present for systems in comparison. To test:
- Run a comparison with systems that are stale, do not have insights installed and do not have insights enabled. (These may be difficult to find or upload)
- Check the icons in the header row of the comparison table, they should be on the second row of the cells

This is how the icons should appear:
- If a system is stale, it will show the exclamation triangle icon.
- If a system does not have insights installed, then it will also not have insights enabled. This will show an icon and the tooltip will read "Insights not installed".
- If a system has insights installed, but does not have Insights enabled, it will show the same icon as before, but the tooltip will read "Insights not enabled".

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
