### PR TITLE
Correctly deploying to beta env locally

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -7,8 +7,9 @@ const { config: webpackConfig, plugins } = config({
     https: true,
     useProxy: true,
     routesPath: process.env.CONFIG_PATH,
-    appUrl: [ '/insights/drift' ],
-    env: process.env.BETA ? 'stage-beta' : 'stage-stable'
+    appUrl: process.env.BETA ? [ '/beta/insights/drift' ] : [ '/insights/drift' ],
+    env: process.env.BETA ? 'stage-beta' : 'stage-stable',
+    deployment: process.env.BETA ? 'beta/apps' : 'apps'
 });
 
 plugins.push(


### PR DESCRIPTION
Included in [RHIF-27](https://issues.redhat.com/browse/RHIF-27).

Running Drift with `BETA=true` deploys to https://stage.foo.redhat.com:1337/insights/drift not https://stage.foo.redhat.com:1337/beta/insights/drift; this should this be changed to deploy to `/beta`

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
