### PR TITLE
[DRFT-233] Update bulk selectors

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -54,7 +54,7 @@
   top: 0;
   position: sticky;
   background-color: white;
-  z-index: 9999;
+  z-index: 9998;
 }
 
 .comparison-header {
@@ -518,4 +518,10 @@ th.sticky-column {
 
 .state-loading-width {
   width: 100px;
+}
+
+.edit-baseline-toolbar {
+  .pf-c-dropdown__menu {
+    z-index: 9999;
+  }
 }

--- a/src/SmartComponents/AddSystemModal/AddSystemModal.js
+++ b/src/SmartComponents/AddSystemModal/AddSystemModal.js
@@ -165,20 +165,12 @@ export class AddSystemModal extends Component {
         selectActiveTab(tabIndex);
     }
 
-    onBulkSelect = (isSelected) => {
-        const { baselineTableData, handleBaselineSelection, selectBaseline } = this.props;
-        let ids = [];
-        let selectedContent = [];
-
-        baselineTableData.forEach(function(baseline) {
-            ids.push(baseline[0]);
-        });
-
-        selectedContent = baselineTableData.map(function(baseline) {
+    bulkSelectBasket = (baselineTableData, isSelected) => {
+        const { handleBaselineSelection } = this.props;
+        let selectedContent = baselineTableData.map(function(baseline) {
             return this.createContent(baseline[0], 'Baseline', <BlueprintIcon />, baseline[1]);
         }.bind(this));
 
-        selectBaseline(ids, isSelected, 'COMPARISON');
         handleBaselineSelection(selectedContent, isSelected);
     }
 
@@ -317,7 +309,7 @@ export class AddSystemModal extends Component {
                                 tableData={ baselineTableData }
                                 loading={ loading }
                                 columns={ columns }
-                                onBulkSelect={ this.onBulkSelect }
+                                bulkSelectBasket={ this.bulkSelectBasket }
                                 selectedBaselineIds={ selectedBaselineIds }
                                 totalBaselines={ totalBaselines }
                                 permissions={ permissions }
@@ -328,6 +320,7 @@ export class AddSystemModal extends Component {
                                 emptyState={ emptyState }
                                 baselineError={ baselineError }
                                 revertBaselineFetch={ revertBaselineFetch }
+                                selectBaseline={ selectBaseline }
                             />
                         </Tab>
                     </Tabs>
@@ -388,7 +381,7 @@ function mapStateToProps(state) {
         loading: state.baselinesTableState.comparisonTable.loading,
         baselineTableData: state.baselinesTableState.comparisonTable.baselineTableData,
         historicalProfiles: state.compareState.historicalProfiles,
-        totalBaselines: state.baselinesTableState.checkboxTable.totalBaselines,
+        totalBaselines: state.baselinesTableState.comparisonTable.totalBaselines,
         globalFilterState: state.globalFilterState,
         selectedHSPContent: state.addSystemModalState.selectedHSPContent,
         selectedBaselineContent: state.addSystemModalState.selectedBaselineContent,

--- a/src/SmartComponents/AddSystemModal/__tests__/AddSystemModal.tests.js
+++ b/src/SmartComponents/AddSystemModal/__tests__/AddSystemModal.tests.js
@@ -128,25 +128,6 @@ describe('AddSystemModal', () => {
         expect(props.handleBaselineSelection).toHaveBeenCalledWith(modalFixtures.baselineContent2, true);
     });
 
-    it('should handle onBulkSelect', () => {
-        const selectBaseline = jest.fn();
-
-        props.baselineTableData = [
-            [ 'abcd1234', 'baseline1', '1 month ago' ],
-            [ 'efgh5678', 'baseline2', '2 months ago' ]
-        ];
-        const wrapper = shallow(
-            <AddSystemModal
-                { ...props }
-                selectBaseline={ selectBaseline }
-            />
-        );
-
-        wrapper.instance().onBulkSelect(true);
-        expect(selectBaseline).toHaveBeenCalledWith([ 'abcd1234', 'efgh5678' ], true, 'COMPARISON');
-        expect(props.handleBaselineSelection).toHaveBeenCalledWith(modalFixtures.baselineContent2, true);
-    });
-
     it('should confirm modal', () => {
         props.entities.selectedSystemIds = [ 'abcd1234' ];
         props.selectedBaselineIds = [ 'efgh5678' ];

--- a/src/SmartComponents/AddSystemModal/__tests__/__snapshots__/AddSystemModal.tests.js.snap
+++ b/src/SmartComponents/AddSystemModal/__tests__/__snapshots__/AddSystemModal.tests.js.snap
@@ -165,6 +165,7 @@ exports[`AddSystemModal should render correctly 1`] = `
       >
         <Connect(BaselinesTable)
           basketIsVisible={false}
+          bulkSelectBasket={[Function]}
           columns={
             Array [
               Object {
@@ -193,7 +194,6 @@ exports[`AddSystemModal should render correctly 1`] = `
           kebab={false}
           leftAlignToolbar={true}
           loading={false}
-          onBulkSelect={[Function]}
           onSelect={[Function]}
           permissions={
             Object {
@@ -201,6 +201,7 @@ exports[`AddSystemModal should render correctly 1`] = `
               "inventoryRead": true,
             }
           }
+          selectBaseline={[MockFunction]}
           selectedBaselineIds={Array []}
           tableData={Array []}
           tableId="COMPARISON"
@@ -337,7 +338,6 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
             ]
           }
           toggleAddSystemModal={[Function]}
-          totalBaselines={0}
         >
           <Modal
             actions={
@@ -633,7 +633,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                         >
                                           <label
                                             class="pf-c-dropdown__toggle-check"
-                                            for="toggle-checkbox"
+                                            for="baselines-bulk-select-toggle-checkbox"
                                           >
                                             <input
                                               aria-invalid="false"
@@ -641,7 +641,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                               data-ouia-component-id="OUIA-Generated-RHI/BulkSelect-4"
                                               data-ouia-component-type="PF4/DropdownToggleCheckbox"
                                               data-ouia-safe="true"
-                                              id="toggle-checkbox"
+                                              id="baselines-bulk-select-toggle-checkbox"
                                               type="checkbox"
                                             />
                                             
@@ -2370,6 +2370,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                                   Object {
                                                     "checked": false,
                                                     "count": 0,
+                                                    "id": "systems-bulk-select",
                                                     "isDisabled": false,
                                                     "items": Array [
                                                       Object {
@@ -2459,6 +2460,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                                     Object {
                                                       "checked": false,
                                                       "count": 0,
+                                                      "id": "systems-bulk-select",
                                                       "isDisabled": false,
                                                       "items": Array [
                                                         Object {
@@ -2565,6 +2567,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                                               Object {
                                                                 "checked": false,
                                                                 "count": 0,
+                                                                "id": "systems-bulk-select",
                                                                 "isDisabled": false,
                                                                 "items": Array [
                                                                   Object {
@@ -2696,6 +2699,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                                           Object {
                                                             "checked": false,
                                                             "count": 0,
+                                                            "id": "systems-bulk-select",
                                                             "isDisabled": false,
                                                             "items": Array [
                                                               Object {
@@ -2830,6 +2834,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                                                 Object {
                                                                   "checked": false,
                                                                   "count": 0,
+                                                                  "id": "systems-bulk-select",
                                                                   "isDisabled": false,
                                                                   "items": Array [
                                                                     Object {
@@ -2961,6 +2966,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                                             Object {
                                                               "checked": false,
                                                               "count": 0,
+                                                              "id": "systems-bulk-select",
                                                               "isDisabled": false,
                                                               "items": Array [
                                                                 Object {
@@ -3095,6 +3101,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                                               Object {
                                                                 "checked": false,
                                                                 "count": 0,
+                                                                "id": "systems-bulk-select",
                                                                 "isDisabled": false,
                                                                 "items": Array [
                                                                   Object {
@@ -3238,6 +3245,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                                                   Object {
                                                                     "checked": false,
                                                                     "count": 0,
+                                                                    "id": "systems-bulk-select",
                                                                     "isDisabled": false,
                                                                     "items": Array [
                                                                       Object {
@@ -3384,6 +3392,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                       >
                                         <Memo(Connect(BaselinesTable))
                                           basketIsVisible={false}
+                                          bulkSelectBasket={[Function]}
                                           columns={
                                             Array [
                                               Object {
@@ -3412,7 +3421,6 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                           kebab={false}
                                           leftAlignToolbar={true}
                                           loading={false}
-                                          onBulkSelect={[Function]}
                                           onSelect={[Function]}
                                           permissions={
                                             Object {
@@ -3421,10 +3429,10 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                             }
                                           }
                                           revertBaselineFetch={[Function]}
+                                          selectBaseline={[Function]}
                                           selectedBaselineIds={Array []}
                                           tableData={Array []}
                                           tableId="COMPARISON"
-                                          totalBaselines={0}
                                         />
                                       </Tab>
                                     }
@@ -3442,6 +3450,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                         >
                                           <Memo(Connect(BaselinesTable))
                                             basketIsVisible={false}
+                                            bulkSelectBasket={[Function]}
                                             columns={
                                               Array [
                                                 Object {
@@ -3470,7 +3479,6 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                             kebab={false}
                                             leftAlignToolbar={true}
                                             loading={false}
-                                            onBulkSelect={[Function]}
                                             onSelect={[Function]}
                                             permissions={
                                               Object {
@@ -3479,10 +3487,10 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                               }
                                             }
                                             revertBaselineFetch={[Function]}
+                                            selectBaseline={[Function]}
                                             selectedBaselineIds={Array []}
                                             tableData={Array []}
                                             tableId="COMPARISON"
-                                            totalBaselines={0}
                                           />
                                         </Tab>
                                       }
@@ -3501,6 +3509,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                       >
                                         <Connect(BaselinesTable)
                                           basketIsVisible={false}
+                                          bulkSelectBasket={[Function]}
                                           columns={
                                             Array [
                                               Object {
@@ -3529,7 +3538,6 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                           kebab={false}
                                           leftAlignToolbar={true}
                                           loading={false}
-                                          onBulkSelect={[Function]}
                                           onSelect={[Function]}
                                           permissions={
                                             Object {
@@ -3538,13 +3546,14 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                             }
                                           }
                                           revertBaselineFetch={[Function]}
+                                          selectBaseline={[Function]}
                                           selectedBaselineIds={Array []}
                                           tableData={Array []}
                                           tableId="COMPARISON"
-                                          totalBaselines={0}
                                         >
                                           <BaselinesTable
                                             basketIsVisible={false}
+                                            bulkSelectBasket={[Function]}
                                             columns={
                                               Array [
                                                 Object {
@@ -3576,7 +3585,6 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                             kebab={false}
                                             leftAlignToolbar={true}
                                             loading={false}
-                                            onBulkSelect={[Function]}
                                             onSelect={[Function]}
                                             permissions={
                                               Object {
@@ -3585,13 +3593,13 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                               }
                                             }
                                             revertBaselineFetch={[Function]}
+                                            selectBaseline={[Function]}
                                             selectedBaselineIds={Array []}
                                             tableData={Array []}
                                             tableId="COMPARISON"
                                             toggleNotificationFulfilled={[Function]}
                                             toggleNotificationPending={[Function]}
                                             toggleNotificationRejected={[Function]}
-                                            totalBaselines={0}
                                           >
                                             <BaselinesToolbar
                                               exportToCSV={[Function]}
@@ -3615,7 +3623,6 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                               selectedBaselineIds={Array []}
                                               tableData={Array []}
                                               tableId="COMPARISON"
-                                              totalBaselines={0}
                                               updatePagination={[Function]}
                                             >
                                               <Connect(DeleteBaselinesModal)
@@ -3757,21 +3764,22 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                                                   >
                                                                     <BulkSelect
                                                                       checked={false}
-                                                                      count={null}
+                                                                      count={0}
+                                                                      id="baselines-bulk-select"
                                                                       isDisabled={true}
                                                                       items={
                                                                         Array [
                                                                           Object {
-                                                                            "key": "select-all",
+                                                                            "key": "select-page",
                                                                             "onClick": [Function],
-                                                                            "ouiaId": "select-all",
-                                                                            "title": "Select all",
+                                                                            "ouiaId": "baselines-select-page",
+                                                                            "title": "Select page (0)",
                                                                           },
                                                                           Object {
                                                                             "key": "select-none",
                                                                             "onClick": [Function],
-                                                                            "ouiaId": "select-none",
-                                                                            "title": "Select none",
+                                                                            "ouiaId": "baselines-select-none",
+                                                                            "title": "Select none (0)",
                                                                           },
                                                                         ]
                                                                       }
@@ -3784,16 +3792,16 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                                                             <DropdownItem
                                                                               component="button"
                                                                               onClick={[Function]}
-                                                                              ouiaId="OUIA-Generated-RHI/BulkSelect-4-select-all"
+                                                                              ouiaId="OUIA-Generated-RHI/BulkSelect-4-select-page"
                                                                             >
-                                                                              Select all
+                                                                              Select page (0)
                                                                             </DropdownItem>,
                                                                             <DropdownItem
                                                                               component="button"
                                                                               onClick={[Function]}
                                                                               ouiaId="OUIA-Generated-RHI/BulkSelect-4-select-none"
                                                                             >
-                                                                              Select none
+                                                                              Select none (0)
                                                                             </DropdownItem>,
                                                                           ]
                                                                         }
@@ -3812,7 +3820,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                                                                   <DropdownToggleCheckbox
                                                                                     aria-label="Select all"
                                                                                     className=""
-                                                                                    id="toggle-checkbox"
+                                                                                    id="baselines-bulk-select-toggle-checkbox"
                                                                                     isChecked={false}
                                                                                     isDisabled={false}
                                                                                     isValid={true}
@@ -3836,16 +3844,16 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                                                               <DropdownItem
                                                                                 component="button"
                                                                                 onClick={[Function]}
-                                                                                ouiaId="OUIA-Generated-RHI/BulkSelect-4-select-all"
+                                                                                ouiaId="OUIA-Generated-RHI/BulkSelect-4-select-page"
                                                                               >
-                                                                                Select all
+                                                                                Select page (0)
                                                                               </DropdownItem>,
                                                                               <DropdownItem
                                                                                 component="button"
                                                                                 onClick={[Function]}
                                                                                 ouiaId="OUIA-Generated-RHI/BulkSelect-4-select-none"
                                                                               >
-                                                                                Select none
+                                                                                Select none (0)
                                                                               </DropdownItem>,
                                                                             ]
                                                                           }
@@ -3867,7 +3875,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                                                                     <DropdownToggleCheckbox
                                                                                       aria-label="Select all"
                                                                                       className=""
-                                                                                      id="toggle-checkbox"
+                                                                                      id="baselines-bulk-select-toggle-checkbox"
                                                                                       isChecked={false}
                                                                                       isDisabled={false}
                                                                                       isValid={true}
@@ -3913,7 +3921,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                                                                     >
                                                                                       <label
                                                                                         class="pf-c-dropdown__toggle-check"
-                                                                                        for="toggle-checkbox"
+                                                                                        for="baselines-bulk-select-toggle-checkbox"
                                                                                       >
                                                                                         <input
                                                                                           aria-invalid="false"
@@ -3921,7 +3929,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                                                                           data-ouia-component-id="OUIA-Generated-RHI/BulkSelect-4"
                                                                                           data-ouia-component-type="PF4/DropdownToggleCheckbox"
                                                                                           data-ouia-safe="true"
-                                                                                          id="toggle-checkbox"
+                                                                                          id="baselines-bulk-select-toggle-checkbox"
                                                                                           type="checkbox"
                                                                                         />
                                                                                         
@@ -3966,7 +3974,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                                                                     <DropdownToggleCheckbox
                                                                                       aria-label="Select all"
                                                                                       className=""
-                                                                                      id="toggle-checkbox"
+                                                                                      id="baselines-bulk-select-toggle-checkbox"
                                                                                       isChecked={false}
                                                                                       isDisabled={false}
                                                                                       isValid={true}
@@ -3985,7 +3993,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                                                                 <DropdownToggleCheckbox
                                                                                   aria-label="Select all"
                                                                                   className=""
-                                                                                  id="toggle-checkbox"
+                                                                                  id="baselines-bulk-select-toggle-checkbox"
                                                                                   isChecked={false}
                                                                                   isDisabled={false}
                                                                                   isValid={true}
@@ -3994,7 +4002,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                                                                 >
                                                                                   <label
                                                                                     className="pf-c-dropdown__toggle-check"
-                                                                                    htmlFor="toggle-checkbox"
+                                                                                    htmlFor="baselines-bulk-select-toggle-checkbox"
                                                                                   >
                                                                                     <input
                                                                                       aria-invalid={false}
@@ -4004,7 +4012,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                                                                       data-ouia-component-type="PF4/DropdownToggleCheckbox"
                                                                                       data-ouia-safe={true}
                                                                                       disabled={false}
-                                                                                      id="toggle-checkbox"
+                                                                                      id="baselines-bulk-select-toggle-checkbox"
                                                                                       onChange={[Function]}
                                                                                       type="checkbox"
                                                                                     />
@@ -4042,7 +4050,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                                                                         >
                                                                                           <label
                                                                                             class="pf-c-dropdown__toggle-check"
-                                                                                            for="toggle-checkbox"
+                                                                                            for="baselines-bulk-select-toggle-checkbox"
                                                                                           >
                                                                                             <input
                                                                                               aria-invalid="false"
@@ -4050,7 +4058,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                                                                               data-ouia-component-id="OUIA-Generated-RHI/BulkSelect-4"
                                                                                               data-ouia-component-type="PF4/DropdownToggleCheckbox"
                                                                                               data-ouia-safe="true"
-                                                                                              id="toggle-checkbox"
+                                                                                              id="baselines-bulk-select-toggle-checkbox"
                                                                                               type="checkbox"
                                                                                             />
                                                                                             
@@ -8140,7 +8148,6 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
             ]
           }
           toggleAddSystemModal={[Function]}
-          totalBaselines={0}
         >
           <Modal
             actions={
@@ -8436,7 +8443,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                         >
                                           <label
                                             class="pf-c-dropdown__toggle-check"
-                                            for="toggle-checkbox"
+                                            for="baselines-bulk-select-toggle-checkbox"
                                           >
                                             <input
                                               aria-invalid="false"
@@ -8444,7 +8451,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                               data-ouia-component-id="OUIA-Generated-RHI/BulkSelect-1"
                                               data-ouia-component-type="PF4/DropdownToggleCheckbox"
                                               data-ouia-safe="true"
-                                              id="toggle-checkbox"
+                                              id="baselines-bulk-select-toggle-checkbox"
                                               type="checkbox"
                                             />
                                             
@@ -10173,6 +10180,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                                   Object {
                                                     "checked": false,
                                                     "count": 0,
+                                                    "id": "systems-bulk-select",
                                                     "isDisabled": false,
                                                     "items": Array [
                                                       Object {
@@ -10262,6 +10270,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                                     Object {
                                                       "checked": false,
                                                       "count": 0,
+                                                      "id": "systems-bulk-select",
                                                       "isDisabled": false,
                                                       "items": Array [
                                                         Object {
@@ -10368,6 +10377,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                                               Object {
                                                                 "checked": false,
                                                                 "count": 0,
+                                                                "id": "systems-bulk-select",
                                                                 "isDisabled": false,
                                                                 "items": Array [
                                                                   Object {
@@ -10499,6 +10509,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                                           Object {
                                                             "checked": false,
                                                             "count": 0,
+                                                            "id": "systems-bulk-select",
                                                             "isDisabled": false,
                                                             "items": Array [
                                                               Object {
@@ -10633,6 +10644,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                                                 Object {
                                                                   "checked": false,
                                                                   "count": 0,
+                                                                  "id": "systems-bulk-select",
                                                                   "isDisabled": false,
                                                                   "items": Array [
                                                                     Object {
@@ -10764,6 +10776,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                                             Object {
                                                               "checked": false,
                                                               "count": 0,
+                                                              "id": "systems-bulk-select",
                                                               "isDisabled": false,
                                                               "items": Array [
                                                                 Object {
@@ -10898,6 +10911,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                                               Object {
                                                                 "checked": false,
                                                                 "count": 0,
+                                                                "id": "systems-bulk-select",
                                                                 "isDisabled": false,
                                                                 "items": Array [
                                                                   Object {
@@ -11041,6 +11055,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                                                   Object {
                                                                     "checked": false,
                                                                     "count": 0,
+                                                                    "id": "systems-bulk-select",
                                                                     "isDisabled": false,
                                                                     "items": Array [
                                                                       Object {
@@ -11187,6 +11202,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                       >
                                         <Memo(Connect(BaselinesTable))
                                           basketIsVisible={false}
+                                          bulkSelectBasket={[Function]}
                                           columns={
                                             Array [
                                               Object {
@@ -11215,7 +11231,6 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                           kebab={false}
                                           leftAlignToolbar={true}
                                           loading={false}
-                                          onBulkSelect={[Function]}
                                           onSelect={[Function]}
                                           permissions={
                                             Object {
@@ -11224,10 +11239,10 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                             }
                                           }
                                           revertBaselineFetch={[Function]}
+                                          selectBaseline={[Function]}
                                           selectedBaselineIds={Array []}
                                           tableData={Array []}
                                           tableId="COMPARISON"
-                                          totalBaselines={0}
                                         />
                                       </Tab>
                                     }
@@ -11245,6 +11260,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                         >
                                           <Memo(Connect(BaselinesTable))
                                             basketIsVisible={false}
+                                            bulkSelectBasket={[Function]}
                                             columns={
                                               Array [
                                                 Object {
@@ -11273,7 +11289,6 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                             kebab={false}
                                             leftAlignToolbar={true}
                                             loading={false}
-                                            onBulkSelect={[Function]}
                                             onSelect={[Function]}
                                             permissions={
                                               Object {
@@ -11282,10 +11297,10 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                               }
                                             }
                                             revertBaselineFetch={[Function]}
+                                            selectBaseline={[Function]}
                                             selectedBaselineIds={Array []}
                                             tableData={Array []}
                                             tableId="COMPARISON"
-                                            totalBaselines={0}
                                           />
                                         </Tab>
                                       }
@@ -11304,6 +11319,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                       >
                                         <Connect(BaselinesTable)
                                           basketIsVisible={false}
+                                          bulkSelectBasket={[Function]}
                                           columns={
                                             Array [
                                               Object {
@@ -11332,7 +11348,6 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                           kebab={false}
                                           leftAlignToolbar={true}
                                           loading={false}
-                                          onBulkSelect={[Function]}
                                           onSelect={[Function]}
                                           permissions={
                                             Object {
@@ -11341,13 +11356,14 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                             }
                                           }
                                           revertBaselineFetch={[Function]}
+                                          selectBaseline={[Function]}
                                           selectedBaselineIds={Array []}
                                           tableData={Array []}
                                           tableId="COMPARISON"
-                                          totalBaselines={0}
                                         >
                                           <BaselinesTable
                                             basketIsVisible={false}
+                                            bulkSelectBasket={[Function]}
                                             columns={
                                               Array [
                                                 Object {
@@ -11379,7 +11395,6 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                             kebab={false}
                                             leftAlignToolbar={true}
                                             loading={false}
-                                            onBulkSelect={[Function]}
                                             onSelect={[Function]}
                                             permissions={
                                               Object {
@@ -11388,13 +11403,13 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                               }
                                             }
                                             revertBaselineFetch={[Function]}
+                                            selectBaseline={[Function]}
                                             selectedBaselineIds={Array []}
                                             tableData={Array []}
                                             tableId="COMPARISON"
                                             toggleNotificationFulfilled={[Function]}
                                             toggleNotificationPending={[Function]}
                                             toggleNotificationRejected={[Function]}
-                                            totalBaselines={0}
                                           >
                                             <BaselinesToolbar
                                               exportToCSV={[Function]}
@@ -11418,7 +11433,6 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                               selectedBaselineIds={Array []}
                                               tableData={Array []}
                                               tableId="COMPARISON"
-                                              totalBaselines={0}
                                               updatePagination={[Function]}
                                             >
                                               <Connect(DeleteBaselinesModal)
@@ -11560,21 +11574,22 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                                                   >
                                                                     <BulkSelect
                                                                       checked={false}
-                                                                      count={null}
+                                                                      count={0}
+                                                                      id="baselines-bulk-select"
                                                                       isDisabled={true}
                                                                       items={
                                                                         Array [
                                                                           Object {
-                                                                            "key": "select-all",
+                                                                            "key": "select-page",
                                                                             "onClick": [Function],
-                                                                            "ouiaId": "select-all",
-                                                                            "title": "Select all",
+                                                                            "ouiaId": "baselines-select-page",
+                                                                            "title": "Select page (0)",
                                                                           },
                                                                           Object {
                                                                             "key": "select-none",
                                                                             "onClick": [Function],
-                                                                            "ouiaId": "select-none",
-                                                                            "title": "Select none",
+                                                                            "ouiaId": "baselines-select-none",
+                                                                            "title": "Select none (0)",
                                                                           },
                                                                         ]
                                                                       }
@@ -11587,16 +11602,16 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                                                             <DropdownItem
                                                                               component="button"
                                                                               onClick={[Function]}
-                                                                              ouiaId="OUIA-Generated-RHI/BulkSelect-1-select-all"
+                                                                              ouiaId="OUIA-Generated-RHI/BulkSelect-1-select-page"
                                                                             >
-                                                                              Select all
+                                                                              Select page (0)
                                                                             </DropdownItem>,
                                                                             <DropdownItem
                                                                               component="button"
                                                                               onClick={[Function]}
                                                                               ouiaId="OUIA-Generated-RHI/BulkSelect-1-select-none"
                                                                             >
-                                                                              Select none
+                                                                              Select none (0)
                                                                             </DropdownItem>,
                                                                           ]
                                                                         }
@@ -11615,7 +11630,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                                                                   <DropdownToggleCheckbox
                                                                                     aria-label="Select all"
                                                                                     className=""
-                                                                                    id="toggle-checkbox"
+                                                                                    id="baselines-bulk-select-toggle-checkbox"
                                                                                     isChecked={false}
                                                                                     isDisabled={false}
                                                                                     isValid={true}
@@ -11639,16 +11654,16 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                                                               <DropdownItem
                                                                                 component="button"
                                                                                 onClick={[Function]}
-                                                                                ouiaId="OUIA-Generated-RHI/BulkSelect-1-select-all"
+                                                                                ouiaId="OUIA-Generated-RHI/BulkSelect-1-select-page"
                                                                               >
-                                                                                Select all
+                                                                                Select page (0)
                                                                               </DropdownItem>,
                                                                               <DropdownItem
                                                                                 component="button"
                                                                                 onClick={[Function]}
                                                                                 ouiaId="OUIA-Generated-RHI/BulkSelect-1-select-none"
                                                                               >
-                                                                                Select none
+                                                                                Select none (0)
                                                                               </DropdownItem>,
                                                                             ]
                                                                           }
@@ -11670,7 +11685,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                                                                     <DropdownToggleCheckbox
                                                                                       aria-label="Select all"
                                                                                       className=""
-                                                                                      id="toggle-checkbox"
+                                                                                      id="baselines-bulk-select-toggle-checkbox"
                                                                                       isChecked={false}
                                                                                       isDisabled={false}
                                                                                       isValid={true}
@@ -11716,7 +11731,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                                                                     >
                                                                                       <label
                                                                                         class="pf-c-dropdown__toggle-check"
-                                                                                        for="toggle-checkbox"
+                                                                                        for="baselines-bulk-select-toggle-checkbox"
                                                                                       >
                                                                                         <input
                                                                                           aria-invalid="false"
@@ -11724,7 +11739,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                                                                           data-ouia-component-id="OUIA-Generated-RHI/BulkSelect-1"
                                                                                           data-ouia-component-type="PF4/DropdownToggleCheckbox"
                                                                                           data-ouia-safe="true"
-                                                                                          id="toggle-checkbox"
+                                                                                          id="baselines-bulk-select-toggle-checkbox"
                                                                                           type="checkbox"
                                                                                         />
                                                                                         
@@ -11769,7 +11784,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                                                                     <DropdownToggleCheckbox
                                                                                       aria-label="Select all"
                                                                                       className=""
-                                                                                      id="toggle-checkbox"
+                                                                                      id="baselines-bulk-select-toggle-checkbox"
                                                                                       isChecked={false}
                                                                                       isDisabled={false}
                                                                                       isValid={true}
@@ -11788,7 +11803,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                                                                 <DropdownToggleCheckbox
                                                                                   aria-label="Select all"
                                                                                   className=""
-                                                                                  id="toggle-checkbox"
+                                                                                  id="baselines-bulk-select-toggle-checkbox"
                                                                                   isChecked={false}
                                                                                   isDisabled={false}
                                                                                   isValid={true}
@@ -11797,7 +11812,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                                                                 >
                                                                                   <label
                                                                                     className="pf-c-dropdown__toggle-check"
-                                                                                    htmlFor="toggle-checkbox"
+                                                                                    htmlFor="baselines-bulk-select-toggle-checkbox"
                                                                                   >
                                                                                     <input
                                                                                       aria-invalid={false}
@@ -11807,7 +11822,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                                                                       data-ouia-component-type="PF4/DropdownToggleCheckbox"
                                                                                       data-ouia-safe={true}
                                                                                       disabled={false}
-                                                                                      id="toggle-checkbox"
+                                                                                      id="baselines-bulk-select-toggle-checkbox"
                                                                                       onChange={[Function]}
                                                                                       type="checkbox"
                                                                                     />
@@ -11845,7 +11860,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                                                                         >
                                                                                           <label
                                                                                             class="pf-c-dropdown__toggle-check"
-                                                                                            for="toggle-checkbox"
+                                                                                            for="baselines-bulk-select-toggle-checkbox"
                                                                                           >
                                                                                             <input
                                                                                               aria-invalid="false"
@@ -11853,7 +11868,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                                                                               data-ouia-component-id="OUIA-Generated-RHI/BulkSelect-1"
                                                                                               data-ouia-component-type="PF4/DropdownToggleCheckbox"
                                                                                               data-ouia-safe="true"
-                                                                                              id="toggle-checkbox"
+                                                                                              id="baselines-bulk-select-toggle-checkbox"
                                                                                               type="checkbox"
                                                                                             />
                                                                                             
@@ -15943,7 +15958,6 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
             ]
           }
           toggleAddSystemModal={[Function]}
-          totalBaselines={0}
         >
           <Modal
             actions={
@@ -16263,7 +16277,7 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                         >
                                           <label
                                             class="pf-c-dropdown__toggle-check"
-                                            for="toggle-checkbox"
+                                            for="baselines-bulk-select-toggle-checkbox"
                                           >
                                             <input
                                               aria-invalid="false"
@@ -16271,7 +16285,7 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                               data-ouia-component-id="OUIA-Generated-RHI/BulkSelect-2"
                                               data-ouia-component-type="PF4/DropdownToggleCheckbox"
                                               data-ouia-safe="true"
-                                              id="toggle-checkbox"
+                                              id="baselines-bulk-select-toggle-checkbox"
                                               type="checkbox"
                                             />
                                             
@@ -18086,6 +18100,7 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                       >
                                         <Memo(Connect(BaselinesTable))
                                           basketIsVisible={false}
+                                          bulkSelectBasket={[Function]}
                                           columns={
                                             Array [
                                               Object {
@@ -18114,7 +18129,6 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                           kebab={false}
                                           leftAlignToolbar={true}
                                           loading={false}
-                                          onBulkSelect={[Function]}
                                           onSelect={[Function]}
                                           permissions={
                                             Object {
@@ -18123,10 +18137,10 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                             }
                                           }
                                           revertBaselineFetch={[Function]}
+                                          selectBaseline={[Function]}
                                           selectedBaselineIds={Array []}
                                           tableData={Array []}
                                           tableId="COMPARISON"
-                                          totalBaselines={0}
                                         />
                                       </Tab>
                                     }
@@ -18144,6 +18158,7 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                         >
                                           <Memo(Connect(BaselinesTable))
                                             basketIsVisible={false}
+                                            bulkSelectBasket={[Function]}
                                             columns={
                                               Array [
                                                 Object {
@@ -18172,7 +18187,6 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                             kebab={false}
                                             leftAlignToolbar={true}
                                             loading={false}
-                                            onBulkSelect={[Function]}
                                             onSelect={[Function]}
                                             permissions={
                                               Object {
@@ -18181,10 +18195,10 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                               }
                                             }
                                             revertBaselineFetch={[Function]}
+                                            selectBaseline={[Function]}
                                             selectedBaselineIds={Array []}
                                             tableData={Array []}
                                             tableId="COMPARISON"
-                                            totalBaselines={0}
                                           />
                                         </Tab>
                                       }
@@ -18203,6 +18217,7 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                       >
                                         <Connect(BaselinesTable)
                                           basketIsVisible={false}
+                                          bulkSelectBasket={[Function]}
                                           columns={
                                             Array [
                                               Object {
@@ -18231,7 +18246,6 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                           kebab={false}
                                           leftAlignToolbar={true}
                                           loading={false}
-                                          onBulkSelect={[Function]}
                                           onSelect={[Function]}
                                           permissions={
                                             Object {
@@ -18240,13 +18254,14 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                             }
                                           }
                                           revertBaselineFetch={[Function]}
+                                          selectBaseline={[Function]}
                                           selectedBaselineIds={Array []}
                                           tableData={Array []}
                                           tableId="COMPARISON"
-                                          totalBaselines={0}
                                         >
                                           <BaselinesTable
                                             basketIsVisible={false}
+                                            bulkSelectBasket={[Function]}
                                             columns={
                                               Array [
                                                 Object {
@@ -18278,7 +18293,6 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                             kebab={false}
                                             leftAlignToolbar={true}
                                             loading={false}
-                                            onBulkSelect={[Function]}
                                             onSelect={[Function]}
                                             permissions={
                                               Object {
@@ -18287,13 +18301,13 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                               }
                                             }
                                             revertBaselineFetch={[Function]}
+                                            selectBaseline={[Function]}
                                             selectedBaselineIds={Array []}
                                             tableData={Array []}
                                             tableId="COMPARISON"
                                             toggleNotificationFulfilled={[Function]}
                                             toggleNotificationPending={[Function]}
                                             toggleNotificationRejected={[Function]}
-                                            totalBaselines={0}
                                           >
                                             <BaselinesToolbar
                                               exportToCSV={[Function]}
@@ -18317,7 +18331,6 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                               selectedBaselineIds={Array []}
                                               tableData={Array []}
                                               tableId="COMPARISON"
-                                              totalBaselines={0}
                                               updatePagination={[Function]}
                                             >
                                               <Connect(DeleteBaselinesModal)
@@ -18459,21 +18472,22 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                                                   >
                                                                     <BulkSelect
                                                                       checked={false}
-                                                                      count={null}
+                                                                      count={0}
+                                                                      id="baselines-bulk-select"
                                                                       isDisabled={true}
                                                                       items={
                                                                         Array [
                                                                           Object {
-                                                                            "key": "select-all",
+                                                                            "key": "select-page",
                                                                             "onClick": [Function],
-                                                                            "ouiaId": "select-all",
-                                                                            "title": "Select all",
+                                                                            "ouiaId": "baselines-select-page",
+                                                                            "title": "Select page (0)",
                                                                           },
                                                                           Object {
                                                                             "key": "select-none",
                                                                             "onClick": [Function],
-                                                                            "ouiaId": "select-none",
-                                                                            "title": "Select none",
+                                                                            "ouiaId": "baselines-select-none",
+                                                                            "title": "Select none (0)",
                                                                           },
                                                                         ]
                                                                       }
@@ -18486,16 +18500,16 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                                                             <DropdownItem
                                                                               component="button"
                                                                               onClick={[Function]}
-                                                                              ouiaId="OUIA-Generated-RHI/BulkSelect-2-select-all"
+                                                                              ouiaId="OUIA-Generated-RHI/BulkSelect-2-select-page"
                                                                             >
-                                                                              Select all
+                                                                              Select page (0)
                                                                             </DropdownItem>,
                                                                             <DropdownItem
                                                                               component="button"
                                                                               onClick={[Function]}
                                                                               ouiaId="OUIA-Generated-RHI/BulkSelect-2-select-none"
                                                                             >
-                                                                              Select none
+                                                                              Select none (0)
                                                                             </DropdownItem>,
                                                                           ]
                                                                         }
@@ -18514,7 +18528,7 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                                                                   <DropdownToggleCheckbox
                                                                                     aria-label="Select all"
                                                                                     className=""
-                                                                                    id="toggle-checkbox"
+                                                                                    id="baselines-bulk-select-toggle-checkbox"
                                                                                     isChecked={false}
                                                                                     isDisabled={false}
                                                                                     isValid={true}
@@ -18538,16 +18552,16 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                                                               <DropdownItem
                                                                                 component="button"
                                                                                 onClick={[Function]}
-                                                                                ouiaId="OUIA-Generated-RHI/BulkSelect-2-select-all"
+                                                                                ouiaId="OUIA-Generated-RHI/BulkSelect-2-select-page"
                                                                               >
-                                                                                Select all
+                                                                                Select page (0)
                                                                               </DropdownItem>,
                                                                               <DropdownItem
                                                                                 component="button"
                                                                                 onClick={[Function]}
                                                                                 ouiaId="OUIA-Generated-RHI/BulkSelect-2-select-none"
                                                                               >
-                                                                                Select none
+                                                                                Select none (0)
                                                                               </DropdownItem>,
                                                                             ]
                                                                           }
@@ -18569,7 +18583,7 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                                                                     <DropdownToggleCheckbox
                                                                                       aria-label="Select all"
                                                                                       className=""
-                                                                                      id="toggle-checkbox"
+                                                                                      id="baselines-bulk-select-toggle-checkbox"
                                                                                       isChecked={false}
                                                                                       isDisabled={false}
                                                                                       isValid={true}
@@ -18615,7 +18629,7 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                                                                     >
                                                                                       <label
                                                                                         class="pf-c-dropdown__toggle-check"
-                                                                                        for="toggle-checkbox"
+                                                                                        for="baselines-bulk-select-toggle-checkbox"
                                                                                       >
                                                                                         <input
                                                                                           aria-invalid="false"
@@ -18623,7 +18637,7 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                                                                           data-ouia-component-id="OUIA-Generated-RHI/BulkSelect-2"
                                                                                           data-ouia-component-type="PF4/DropdownToggleCheckbox"
                                                                                           data-ouia-safe="true"
-                                                                                          id="toggle-checkbox"
+                                                                                          id="baselines-bulk-select-toggle-checkbox"
                                                                                           type="checkbox"
                                                                                         />
                                                                                         
@@ -18668,7 +18682,7 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                                                                     <DropdownToggleCheckbox
                                                                                       aria-label="Select all"
                                                                                       className=""
-                                                                                      id="toggle-checkbox"
+                                                                                      id="baselines-bulk-select-toggle-checkbox"
                                                                                       isChecked={false}
                                                                                       isDisabled={false}
                                                                                       isValid={true}
@@ -18687,7 +18701,7 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                                                                 <DropdownToggleCheckbox
                                                                                   aria-label="Select all"
                                                                                   className=""
-                                                                                  id="toggle-checkbox"
+                                                                                  id="baselines-bulk-select-toggle-checkbox"
                                                                                   isChecked={false}
                                                                                   isDisabled={false}
                                                                                   isValid={true}
@@ -18696,7 +18710,7 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                                                                 >
                                                                                   <label
                                                                                     className="pf-c-dropdown__toggle-check"
-                                                                                    htmlFor="toggle-checkbox"
+                                                                                    htmlFor="baselines-bulk-select-toggle-checkbox"
                                                                                   >
                                                                                     <input
                                                                                       aria-invalid={false}
@@ -18706,7 +18720,7 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                                                                       data-ouia-component-type="PF4/DropdownToggleCheckbox"
                                                                                       data-ouia-safe={true}
                                                                                       disabled={false}
-                                                                                      id="toggle-checkbox"
+                                                                                      id="baselines-bulk-select-toggle-checkbox"
                                                                                       onChange={[Function]}
                                                                                       type="checkbox"
                                                                                     />
@@ -18744,7 +18758,7 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                                                                         >
                                                                                           <label
                                                                                             class="pf-c-dropdown__toggle-check"
-                                                                                            for="toggle-checkbox"
+                                                                                            for="baselines-bulk-select-toggle-checkbox"
                                                                                           >
                                                                                             <input
                                                                                               aria-invalid="false"
@@ -18752,7 +18766,7 @@ exports[`ConnectedAddSystemModal should render disabled with no inventory permis
                                                                                               data-ouia-component-id="OUIA-Generated-RHI/BulkSelect-2"
                                                                                               data-ouia-component-type="PF4/DropdownToggleCheckbox"
                                                                                               data-ouia-safe="true"
-                                                                                              id="toggle-checkbox"
+                                                                                              id="baselines-bulk-select-toggle-checkbox"
                                                                                               type="checkbox"
                                                                                             />
                                                                                             

--- a/src/SmartComponents/BaselinesPage/BaselinesPage.js
+++ b/src/SmartComponents/BaselinesPage/BaselinesPage.js
@@ -27,10 +27,6 @@ export class BaselinesPage extends Component {
                 { title: 'Associated systems', transforms: [ cellWidth(20) ]},
                 { title: '', transforms: [ cellWidth(5) ]}
             ],
-            errorMessage: [ 'The list of baselines cannot be displayed at this time. Please retry and if',
-                'the problem persists contact your system administrator.',
-                ''
-            ],
             error: {}
         };
     }
@@ -73,26 +69,14 @@ export class BaselinesPage extends Component {
         selectBaseline(ids, isSelected, 'CHECKBOX');
     }
 
-    onBulkSelect = (isSelected) => {
-        const { baselineTableData, selectBaseline } = this.props;
-        let ids = [];
-
-        baselineTableData.forEach(function(baseline) {
-            ids.push(baseline[0]);
-        });
-
-        selectBaseline(ids, isSelected, 'CHECKBOX');
-    }
-
     renderTable(permissions) {
-        const { baselineTableData, clearEditBaselineData, emptyState, loading, notificationsSwitchError, selectedBaselineIds,
-            totalBaselines, revertBaselineFetch, baselineError } = this.props;
+        const { baselineError, baselineTableData, clearEditBaselineData, emptyState, loading, notificationsSwitchError, revertBaselineFetch,
+            selectBaseline, selectedBaselineIds, totalBaselines } = this.props;
         const { columns, error } = this.state;
 
         clearEditBaselineData();
 
         return (
-
             <div>
                 <BaselinesTable
                     tableId='CHECKBOX'
@@ -105,7 +89,7 @@ export class BaselinesPage extends Component {
                     createButton={ true }
                     exportButton={ true }
                     onClick={ this.fetchBaseline }
-                    onBulkSelect={ this.onBulkSelect }
+                    selectBaseline={ selectBaseline }
                     selectedBaselineIds={ selectedBaselineIds }
                     totalBaselines={ totalBaselines }
                     permissions={ permissions }

--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaselineToolbar/EditBaselineToolbar.js
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaselineToolbar/EditBaselineToolbar.js
@@ -18,7 +18,7 @@ export class EditBaselineToolbar extends Component {
                     key: 'select-all',
                     onClick: () => this.props.onBulkSelect(true)
                 }, {
-                    title: 'Select none',
+                    title: 'Select none (0)',
                     key: 'select-none',
                     onClick: () => this.props.onBulkSelect(false)
                 }
@@ -45,6 +45,20 @@ export class EditBaselineToolbar extends Component {
         };
     }
 
+    componentDidUpdate(prevProps) {
+        const { totalFacts } = this.props;
+
+        if (totalFacts !== prevProps.totalFacts) {
+            this.setState(prevState => ({
+                bulkSelectItems: prevState.bulkSelectItems.map(
+                    obj => (
+                        obj.key === 'select-all' ? Object.assign(obj, { title: `Select all (${totalFacts})` }) : obj
+                    )
+                )
+            }));
+        }
+    }
+
     onToggle = () => {
         const { dropdownOpen } = this.state;
 
@@ -58,7 +72,7 @@ export class EditBaselineToolbar extends Component {
         const { bulkSelectItems, dropdownItems, dropdownOpen } = this.state;
 
         return (
-            <Toolbar className='drift-toolbar'>
+            <Toolbar className='edit-baseline-toolbar'>
                 <ToolbarContent>
                     <ToolbarItem>
                         <BulkSelect

--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaselineToolbar/__tests__/__snapshots__/EditBaselineToolbar.tests.js.snap
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaselineToolbar/__tests__/__snapshots__/EditBaselineToolbar.tests.js.snap
@@ -61,13 +61,13 @@ exports[`ConnectedEditBaselineToolbar should render correctly 1`] = `
         totalFacts={2}
       >
         <Toolbar
-          className="drift-toolbar"
+          className="edit-baseline-toolbar"
         >
           <GenerateId
             prefix="pf-random-id-"
           >
             <div
-              className="pf-c-toolbar drift-toolbar"
+              className="pf-c-toolbar edit-baseline-toolbar"
               data-ouia-component-id="OUIA-Generated-Toolbar-1"
               data-ouia-component-type="PF4/Toolbar"
               data-ouia-safe={true}
@@ -101,7 +101,7 @@ exports[`ConnectedEditBaselineToolbar should render correctly 1`] = `
                               Object {
                                 "key": "select-none",
                                 "onClick": [Function],
-                                "title": "Select none",
+                                "title": "Select none (0)",
                               },
                             ]
                           }
@@ -124,7 +124,7 @@ exports[`ConnectedEditBaselineToolbar should render correctly 1`] = `
                                   onClick={[Function]}
                                   ouiaId="edit-baseline-bulk-selector-dropdown-select-none"
                                 >
-                                  Select none
+                                  Select none (0)
                                 </DropdownItem>,
                               ]
                             }
@@ -176,7 +176,7 @@ exports[`ConnectedEditBaselineToolbar should render correctly 1`] = `
                                     onClick={[Function]}
                                     ouiaId="edit-baseline-bulk-selector-dropdown-select-none"
                                   >
-                                    Select none
+                                    Select none (0)
                                   </DropdownItem>,
                                 ]
                               }
@@ -1206,7 +1206,7 @@ exports[`ConnectedEditBaselineToolbar should render correctly 1`] = `
 
 exports[`EditBaselineToolbar should render correctly 1`] = `
 <Toolbar
-  className="drift-toolbar"
+  className="edit-baseline-toolbar"
 >
   <ToolbarContent
     isExpanded={false}
@@ -1227,7 +1227,7 @@ exports[`EditBaselineToolbar should render correctly 1`] = `
             Object {
               "key": "select-none",
               "onClick": [Function],
-              "title": "Select none",
+              "title": "Select none (0)",
             },
           ]
         }

--- a/src/SmartComponents/BaselinesPage/__tests__/BaselinesPage.tests.js
+++ b/src/SmartComponents/BaselinesPage/__tests__/BaselinesPage.tests.js
@@ -100,44 +100,6 @@ describe('BaselinesPage', () => {
         wrapper.find(BaselinesPage).dive().instance().onSelect(_, true, -1);
         expect(selectBaseline).toHaveBeenCalledWith([ '1234', '5678' ], true, 'CHECKBOX');
     });
-
-    it('should call onBulkSelect with isSelected true', () => {
-        props.baselineTableData = [
-            [ '1234', 'baseline 1', '1 month ago' ],
-            [ '5678', 'baseline 2', '2 months ago' ]
-        ];
-        const selectBaseline = jest.fn();
-        const wrapper = shallow(
-            <PermissionContext.Provider value={ value }>
-                <BaselinesPage
-                    { ...props }
-                    selectBaseline={ selectBaseline }
-                />
-            </PermissionContext.Provider>
-        );
-
-        wrapper.find(BaselinesPage).dive().instance().onBulkSelect(true);
-        expect(selectBaseline).toHaveBeenCalledWith([ '1234', '5678' ], true, 'CHECKBOX');
-    });
-
-    it('should call onBulkSelect with isSelected false', () => {
-        props.baselineTableData = [
-            [ '1234', 'baseline 1', '1 month ago' ],
-            [ '5678', 'baseline 2', '2 months ago' ]
-        ];
-        const selectBaseline = jest.fn();
-        const wrapper = shallow(
-            <PermissionContext.Provider value={ value }>
-                <BaselinesPage
-                    { ...props }
-                    selectBaseline={ selectBaseline }
-                />
-            </PermissionContext.Provider>
-        );
-
-        wrapper.find(BaselinesPage).dive().instance().onBulkSelect(false);
-        expect(selectBaseline).toHaveBeenCalledWith([ '1234', '5678' ], false, 'CHECKBOX');
-    });
 });
 
 describe('ConnectedBaselinesPage', () => {

--- a/src/SmartComponents/BaselinesPage/__tests__/__snapshots__/BaselinesPage.tests.js.snap
+++ b/src/SmartComponents/BaselinesPage/__tests__/__snapshots__/BaselinesPage.tests.js.snap
@@ -450,7 +450,6 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                       kebab={true}
                       loading={false}
                       notificationsSwitchError={Object {}}
-                      onBulkSelect={[Function]}
                       onClick={[Function]}
                       onSelect={[Function]}
                       permissions={
@@ -461,6 +460,7 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                         }
                       }
                       revertBaselineFetch={[Function]}
+                      selectBaseline={[Function]}
                       selectedBaselineIds={Array []}
                       tableData={Array []}
                       tableId="CHECKBOX"
@@ -509,7 +509,6 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                         kebab={true}
                         loading={false}
                         notificationsSwitchError={Object {}}
-                        onBulkSelect={[Function]}
                         onClick={[Function]}
                         onSelect={[Function]}
                         permissions={
@@ -520,6 +519,7 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                           }
                         }
                         revertBaselineFetch={[Function]}
+                        selectBaseline={[Function]}
                         selectedBaselineIds={Array []}
                         tableData={Array []}
                         tableId="CHECKBOX"
@@ -688,21 +688,22 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                                               >
                                                 <BulkSelect
                                                   checked={false}
-                                                  count={null}
+                                                  count={0}
+                                                  id="baselines-bulk-select"
                                                   isDisabled={true}
                                                   items={
                                                     Array [
                                                       Object {
-                                                        "key": "select-all",
+                                                        "key": "select-page",
                                                         "onClick": [Function],
-                                                        "ouiaId": "select-all",
-                                                        "title": "Select all",
+                                                        "ouiaId": "baselines-select-page",
+                                                        "title": "Select page (0)",
                                                       },
                                                       Object {
                                                         "key": "select-none",
                                                         "onClick": [Function],
-                                                        "ouiaId": "select-none",
-                                                        "title": "Select none",
+                                                        "ouiaId": "baselines-select-none",
+                                                        "title": "Select none (0)",
                                                       },
                                                     ]
                                                   }
@@ -715,16 +716,16 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                                                         <DropdownItem
                                                           component="button"
                                                           onClick={[Function]}
-                                                          ouiaId="OUIA-Generated-RHI/BulkSelect-1-select-all"
+                                                          ouiaId="OUIA-Generated-RHI/BulkSelect-1-select-page"
                                                         >
-                                                          Select all
+                                                          Select page (0)
                                                         </DropdownItem>,
                                                         <DropdownItem
                                                           component="button"
                                                           onClick={[Function]}
                                                           ouiaId="OUIA-Generated-RHI/BulkSelect-1-select-none"
                                                         >
-                                                          Select none
+                                                          Select none (0)
                                                         </DropdownItem>,
                                                       ]
                                                     }
@@ -743,7 +744,7 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                                                               <DropdownToggleCheckbox
                                                                 aria-label="Select all"
                                                                 className=""
-                                                                id="toggle-checkbox"
+                                                                id="baselines-bulk-select-toggle-checkbox"
                                                                 isChecked={false}
                                                                 isDisabled={false}
                                                                 isValid={true}
@@ -767,16 +768,16 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                                                           <DropdownItem
                                                             component="button"
                                                             onClick={[Function]}
-                                                            ouiaId="OUIA-Generated-RHI/BulkSelect-1-select-all"
+                                                            ouiaId="OUIA-Generated-RHI/BulkSelect-1-select-page"
                                                           >
-                                                            Select all
+                                                            Select page (0)
                                                           </DropdownItem>,
                                                           <DropdownItem
                                                             component="button"
                                                             onClick={[Function]}
                                                             ouiaId="OUIA-Generated-RHI/BulkSelect-1-select-none"
                                                           >
-                                                            Select none
+                                                            Select none (0)
                                                           </DropdownItem>,
                                                         ]
                                                       }
@@ -798,7 +799,7 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                                                                 <DropdownToggleCheckbox
                                                                   aria-label="Select all"
                                                                   className=""
-                                                                  id="toggle-checkbox"
+                                                                  id="baselines-bulk-select-toggle-checkbox"
                                                                   isChecked={false}
                                                                   isDisabled={false}
                                                                   isValid={true}
@@ -844,7 +845,7 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                                                                 >
                                                                   <label
                                                                     class="pf-c-dropdown__toggle-check"
-                                                                    for="toggle-checkbox"
+                                                                    for="baselines-bulk-select-toggle-checkbox"
                                                                   >
                                                                     <input
                                                                       aria-invalid="false"
@@ -852,7 +853,7 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                                                                       data-ouia-component-id="OUIA-Generated-RHI/BulkSelect-1"
                                                                       data-ouia-component-type="PF4/DropdownToggleCheckbox"
                                                                       data-ouia-safe="true"
-                                                                      id="toggle-checkbox"
+                                                                      id="baselines-bulk-select-toggle-checkbox"
                                                                       type="checkbox"
                                                                     />
                                                                     
@@ -897,7 +898,7 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                                                                 <DropdownToggleCheckbox
                                                                   aria-label="Select all"
                                                                   className=""
-                                                                  id="toggle-checkbox"
+                                                                  id="baselines-bulk-select-toggle-checkbox"
                                                                   isChecked={false}
                                                                   isDisabled={false}
                                                                   isValid={true}
@@ -916,7 +917,7 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                                                             <DropdownToggleCheckbox
                                                               aria-label="Select all"
                                                               className=""
-                                                              id="toggle-checkbox"
+                                                              id="baselines-bulk-select-toggle-checkbox"
                                                               isChecked={false}
                                                               isDisabled={false}
                                                               isValid={true}
@@ -925,7 +926,7 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                                                             >
                                                               <label
                                                                 className="pf-c-dropdown__toggle-check"
-                                                                htmlFor="toggle-checkbox"
+                                                                htmlFor="baselines-bulk-select-toggle-checkbox"
                                                               >
                                                                 <input
                                                                   aria-invalid={false}
@@ -935,7 +936,7 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                                                                   data-ouia-component-type="PF4/DropdownToggleCheckbox"
                                                                   data-ouia-safe={true}
                                                                   disabled={false}
-                                                                  id="toggle-checkbox"
+                                                                  id="baselines-bulk-select-toggle-checkbox"
                                                                   onChange={[Function]}
                                                                   type="checkbox"
                                                                 />
@@ -973,7 +974,7 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                                                                     >
                                                                       <label
                                                                         class="pf-c-dropdown__toggle-check"
-                                                                        for="toggle-checkbox"
+                                                                        for="baselines-bulk-select-toggle-checkbox"
                                                                       >
                                                                         <input
                                                                           aria-invalid="false"
@@ -981,7 +982,7 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                                                                           data-ouia-component-id="OUIA-Generated-RHI/BulkSelect-1"
                                                                           data-ouia-component-type="PF4/DropdownToggleCheckbox"
                                                                           data-ouia-safe="true"
-                                                                          id="toggle-checkbox"
+                                                                          id="baselines-bulk-select-toggle-checkbox"
                                                                           type="checkbox"
                                                                         />
                                                                         
@@ -6365,7 +6366,6 @@ exports[`ConnectedBaselinesPage should render empty state 1`] = `
                       kebab={true}
                       loading={false}
                       notificationsSwitchError={Object {}}
-                      onBulkSelect={[Function]}
                       onClick={[Function]}
                       onSelect={[Function]}
                       permissions={
@@ -6376,6 +6376,7 @@ exports[`ConnectedBaselinesPage should render empty state 1`] = `
                         }
                       }
                       revertBaselineFetch={[Function]}
+                      selectBaseline={[Function]}
                       selectedBaselineIds={Array []}
                       tableData={Array []}
                       tableId="CHECKBOX"
@@ -6424,7 +6425,6 @@ exports[`ConnectedBaselinesPage should render empty state 1`] = `
                         kebab={true}
                         loading={false}
                         notificationsSwitchError={Object {}}
-                        onBulkSelect={[Function]}
                         onClick={[Function]}
                         onSelect={[Function]}
                         permissions={
@@ -6435,6 +6435,7 @@ exports[`ConnectedBaselinesPage should render empty state 1`] = `
                           }
                         }
                         revertBaselineFetch={[Function]}
+                        selectBaseline={[Function]}
                         selectedBaselineIds={Array []}
                         tableData={Array []}
                         tableId="CHECKBOX"

--- a/src/SmartComponents/BaselinesTable/BaselinesToolbar/BaselinesToolbar.js
+++ b/src/SmartComponents/BaselinesTable/BaselinesToolbar/BaselinesToolbar.js
@@ -11,6 +11,7 @@ import ActionKebab from '../../DriftPage/ActionKebab/ActionKebab';
 import DeleteBaselinesModal from '../../BaselinesPage/DeleteBaselinesModal/DeleteBaselinesModal';
 import helpers from '../../helpers';
 import { TablePagination } from '../../Pagination/Pagination';
+import { bulkSelectItems } from '../../../constants';
 
 export class BaselinesToolbar extends Component {
     constructor(props) {
@@ -18,19 +19,6 @@ export class BaselinesToolbar extends Component {
         this.state = {
             nameSearch: '',
             modalOpened: false,
-            bulkSelectItems: [
-                {
-                    title: 'Select all',
-                    key: 'select-all',
-                    ouiaId: 'select-all',
-                    onClick: () => this.props.onBulkSelect(true)
-                }, {
-                    title: 'Select none',
-                    key: 'select-none',
-                    ouiaId: 'select-none',
-                    onClick: () => this.props.onBulkSelect(false)
-                }
-            ],
             dropdownOpen: false,
             dropdownItems: [
                 <DropdownItem
@@ -116,8 +104,7 @@ export class BaselinesToolbar extends Component {
     render() {
         const { createButton, exportButton, fetchWithParams, hasMultiSelect, kebab, leftAlignToolbar, loading, onBulkSelect,
             tableData, tableId, page, permissions, perPage, selectedBaselineIds, totalBaselines, updatePagination } = this.props;
-        const { bulkSelectItems, dropdownItems, dropdownOpen, modalOpened, nameSearch } = this.state;
-        let selected = tableData.filter(baseline => baseline.selected === true).length;
+        const { dropdownItems, dropdownOpen, modalOpened, nameSearch } = this.state;
 
         return (
             <React.Fragment>
@@ -136,10 +123,11 @@ export class BaselinesToolbar extends Component {
                             ? <ToolbarGroup variant='filter-group'>
                                 <ToolbarItem>
                                     <BulkSelect
-                                        count={ selected > 0 ? selected : null }
-                                        items={ bulkSelectItems }
-                                        checked={ helpers.findCheckedValue(tableData.length, selected) }
-                                        onSelect={ () => onBulkSelect(!selected > 0) }
+                                        id='baselines-bulk-select'
+                                        count={ selectedBaselineIds.length }
+                                        items={ bulkSelectItems(onBulkSelect, tableData.length) }
+                                        checked={ helpers.findCheckedValue(totalBaselines, selectedBaselineIds.length) }
+                                        onSelect={ () => onBulkSelect('page') }
                                         isDisabled={ tableData.length === 0
                                             || (!permissions.baselinesWrite && kebab)
                                             || (!permissions.baselinesRead && !createButton) }

--- a/src/SmartComponents/BaselinesTable/BaselinesToolbar/__test__/BaselinesToolbar.test.js
+++ b/src/SmartComponents/BaselinesTable/BaselinesToolbar/__test__/BaselinesToolbar.test.js
@@ -26,6 +26,8 @@ describe('jest-tests', () => {
                     baselinesWrite: true,
                     baselinesRead: true
                 },
+                selectedBaselineIds: [],
+                totalBaselines: 2,
                 onSearch: jest.fn()
             };
         });
@@ -133,7 +135,8 @@ describe('jest-tests', () => {
                     baselinesWrite: true,
                     baselinesRead: true
                 },
-                selectedBaselineIds: []
+                selectedBaselineIds: [],
+                totalBaselines: 2
             };
         });
 
@@ -166,7 +169,7 @@ describe('jest-tests', () => {
 
             wrapper.find('.pf-c-dropdown__toggle-button').simulate('click');
             wrapper.find('.pf-c-dropdown__menu-item').at(0).simulate('click');
-            expect(onBulkSelect).toHaveBeenCalledWith(true);
+            expect(onBulkSelect).toHaveBeenCalledWith('page');
         });
 
         it('should call onBulkSelect with false', () => {
@@ -185,7 +188,7 @@ describe('jest-tests', () => {
 
             wrapper.find('.pf-c-dropdown__toggle-button').simulate('click');
             wrapper.find('.pf-c-dropdown__menu-item').at(1).simulate('click');
-            expect(onBulkSelect).toHaveBeenCalledWith(false);
+            expect(onBulkSelect).toHaveBeenCalledWith('none');
         });
 
         it('should set checked false in BulkSelect', () => {
@@ -205,6 +208,7 @@ describe('jest-tests', () => {
 
         it('should set checked null in BulkSelect', () => {
             props.tableData[1].selected = true;
+            props.selectedBaselineIds = [ 'abcd' ];
 
             const store = mockStore(initialState);
             const wrapper = mount(
@@ -224,6 +228,7 @@ describe('jest-tests', () => {
             props.tableData.forEach(function(baseline) {
                 baseline.selected = true;
             });
+            props.selectedBaselineIds = [ 'abcd', '1234' ];
 
             const store = mockStore(initialState);
             const wrapper = mount(

--- a/src/SmartComponents/BaselinesTable/BaselinesToolbar/__test__/__snapshots__/BaselinesToolbar.test.js.snap
+++ b/src/SmartComponents/BaselinesTable/BaselinesToolbar/__test__/__snapshots__/BaselinesToolbar.test.js.snap
@@ -4,6 +4,7 @@ exports[`jest-tests BaselinesToolbar should render correctly 1`] = `
 <Fragment>
   <Connect(DeleteBaselinesModal)
     modalOpened={false}
+    selectedBaselineIds={Array []}
     tableId="CHECKBOX"
     toggleModal={[Function]}
   />
@@ -21,21 +22,22 @@ exports[`jest-tests BaselinesToolbar should render correctly 1`] = `
         <ToolbarItem>
           <BulkSelect
             checked={false}
-            count={null}
+            count={0}
+            id="baselines-bulk-select"
             isDisabled={false}
             items={
               Array [
                 Object {
-                  "key": "select-all",
+                  "key": "select-page",
                   "onClick": [Function],
-                  "ouiaId": "select-all",
-                  "title": "Select all",
+                  "ouiaId": "baselines-select-page",
+                  "title": "Select page (2)",
                 },
                 Object {
                   "key": "select-none",
                   "onClick": [Function],
-                  "ouiaId": "select-none",
-                  "title": "Select none",
+                  "ouiaId": "baselines-select-none",
+                  "title": "Select none (0)",
                 },
               ]
             }
@@ -131,6 +133,7 @@ exports[`jest-tests BaselinesToolbar should render correctly 1`] = `
         <TablePagination
           isCompact={true}
           tableId="CHECKBOX"
+          total={2}
         />
       </ToolbarItem>
     </ToolbarContent>
@@ -217,6 +220,7 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
           ]
         }
         tableId="CHECKBOX"
+        totalBaselines={2}
       >
         <Connect(DeleteBaselinesModal)
           modalOpened={false}
@@ -351,21 +355,22 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
                             >
                               <BulkSelect
                                 checked={false}
-                                count={null}
+                                count={0}
+                                id="baselines-bulk-select"
                                 isDisabled={false}
                                 items={
                                   Array [
                                     Object {
-                                      "key": "select-all",
+                                      "key": "select-page",
                                       "onClick": [Function],
-                                      "ouiaId": "select-all",
-                                      "title": "Select all",
+                                      "ouiaId": "baselines-select-page",
+                                      "title": "Select page (2)",
                                     },
                                     Object {
                                       "key": "select-none",
                                       "onClick": [Function],
-                                      "ouiaId": "select-none",
-                                      "title": "Select none",
+                                      "ouiaId": "baselines-select-none",
+                                      "title": "Select none (0)",
                                     },
                                   ]
                                 }
@@ -378,16 +383,16 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
                                       <DropdownItem
                                         component="button"
                                         onClick={[Function]}
-                                        ouiaId="OUIA-Generated-RHI/BulkSelect-1-select-all"
+                                        ouiaId="OUIA-Generated-RHI/BulkSelect-1-select-page"
                                       >
-                                        Select all
+                                        Select page (2)
                                       </DropdownItem>,
                                       <DropdownItem
                                         component="button"
                                         onClick={[Function]}
                                         ouiaId="OUIA-Generated-RHI/BulkSelect-1-select-none"
                                       >
-                                        Select none
+                                        Select none (0)
                                       </DropdownItem>,
                                     ]
                                   }
@@ -406,7 +411,7 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
                                             <DropdownToggleCheckbox
                                               aria-label="Select all"
                                               className=""
-                                              id="toggle-checkbox"
+                                              id="baselines-bulk-select-toggle-checkbox"
                                               isChecked={false}
                                               isDisabled={false}
                                               isValid={true}
@@ -430,16 +435,16 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
                                         <DropdownItem
                                           component="button"
                                           onClick={[Function]}
-                                          ouiaId="OUIA-Generated-RHI/BulkSelect-1-select-all"
+                                          ouiaId="OUIA-Generated-RHI/BulkSelect-1-select-page"
                                         >
-                                          Select all
+                                          Select page (2)
                                         </DropdownItem>,
                                         <DropdownItem
                                           component="button"
                                           onClick={[Function]}
                                           ouiaId="OUIA-Generated-RHI/BulkSelect-1-select-none"
                                         >
-                                          Select none
+                                          Select none (0)
                                         </DropdownItem>,
                                       ]
                                     }
@@ -461,7 +466,7 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
                                               <DropdownToggleCheckbox
                                                 aria-label="Select all"
                                                 className=""
-                                                id="toggle-checkbox"
+                                                id="baselines-bulk-select-toggle-checkbox"
                                                 isChecked={false}
                                                 isDisabled={false}
                                                 isValid={true}
@@ -507,7 +512,7 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
                                               >
                                                 <label
                                                   class="pf-c-dropdown__toggle-check"
-                                                  for="toggle-checkbox"
+                                                  for="baselines-bulk-select-toggle-checkbox"
                                                 >
                                                   <input
                                                     aria-invalid="false"
@@ -515,7 +520,7 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
                                                     data-ouia-component-id="OUIA-Generated-RHI/BulkSelect-1"
                                                     data-ouia-component-type="PF4/DropdownToggleCheckbox"
                                                     data-ouia-safe="true"
-                                                    id="toggle-checkbox"
+                                                    id="baselines-bulk-select-toggle-checkbox"
                                                     type="checkbox"
                                                   />
                                                   
@@ -559,7 +564,7 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
                                               <DropdownToggleCheckbox
                                                 aria-label="Select all"
                                                 className=""
-                                                id="toggle-checkbox"
+                                                id="baselines-bulk-select-toggle-checkbox"
                                                 isChecked={false}
                                                 isDisabled={false}
                                                 isValid={true}
@@ -578,7 +583,7 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
                                           <DropdownToggleCheckbox
                                             aria-label="Select all"
                                             className=""
-                                            id="toggle-checkbox"
+                                            id="baselines-bulk-select-toggle-checkbox"
                                             isChecked={false}
                                             isDisabled={false}
                                             isValid={true}
@@ -587,7 +592,7 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
                                           >
                                             <label
                                               className="pf-c-dropdown__toggle-check"
-                                              htmlFor="toggle-checkbox"
+                                              htmlFor="baselines-bulk-select-toggle-checkbox"
                                             >
                                               <input
                                                 aria-invalid={false}
@@ -597,7 +602,7 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
                                                 data-ouia-component-type="PF4/DropdownToggleCheckbox"
                                                 data-ouia-safe={true}
                                                 disabled={false}
-                                                id="toggle-checkbox"
+                                                id="baselines-bulk-select-toggle-checkbox"
                                                 onChange={[Function]}
                                                 type="checkbox"
                                               />
@@ -635,7 +640,7 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
                                                   >
                                                     <label
                                                       class="pf-c-dropdown__toggle-check"
-                                                      for="toggle-checkbox"
+                                                      for="baselines-bulk-select-toggle-checkbox"
                                                     >
                                                       <input
                                                         aria-invalid="false"
@@ -643,7 +648,7 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
                                                         data-ouia-component-id="OUIA-Generated-RHI/BulkSelect-1"
                                                         data-ouia-component-type="PF4/DropdownToggleCheckbox"
                                                         data-ouia-safe="true"
-                                                        id="toggle-checkbox"
+                                                        id="baselines-bulk-select-toggle-checkbox"
                                                         type="checkbox"
                                                       />
                                                       
@@ -1605,6 +1610,7 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
                         <TablePagination
                           isCompact={true}
                           tableId="CHECKBOX"
+                          total={2}
                         >
                           <Pagination
                             className=""
@@ -1613,7 +1619,7 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
                             isCompact={true}
                             isDisabled={false}
                             isSticky={false}
-                            itemCount={0}
+                            itemCount={2}
                             itemsEnd={null}
                             itemsStart={null}
                             offset={0}
@@ -1678,22 +1684,22 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
                                 className="pf-c-pagination__total-items"
                               >
                                 <ToggleTemplate
-                                  firstIndex={0}
-                                  itemCount={0}
+                                  firstIndex={-9}
+                                  itemCount={2}
                                   itemsTitle=""
-                                  lastIndex={0}
+                                  lastIndex={2}
                                   ofWord="of"
                                 >
                                   <b>
-                                    0
+                                    -9
                                      - 
-                                    0
+                                    2
                                   </b>
                                    
                                   of
                                    
                                   <b>
-                                    0
+                                    2
                                   </b>
                                    
                                 </ToggleTemplate>
@@ -1702,17 +1708,17 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
                                 className=""
                                 defaultToFullPage={false}
                                 dropDirection="down"
-                                firstIndex={0}
+                                firstIndex={-9}
                                 isDisabled={false}
-                                itemCount={0}
+                                itemCount={2}
                                 itemsPerPageTitle="Items per page"
                                 itemsTitle=""
-                                lastIndex={0}
-                                lastPage={0}
+                                lastIndex={2}
+                                lastPage={1}
                                 ofWord="of"
                                 onPerPageSelect={[Function]}
                                 optionsToggle="Items per page"
-                                page={0}
+                                page={1}
                                 perPage={10}
                                 perPageOptions={
                                   Array [
@@ -1800,13 +1806,13 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
                                   position="left"
                                   toggle={
                                     <OptionsToggle
-                                      firstIndex={0}
+                                      firstIndex={-9}
                                       isDisabled={false}
                                       isOpen={false}
-                                      itemCount={0}
+                                      itemCount={2}
                                       itemsPerPageTitle="Items per page"
                                       itemsTitle=""
-                                      lastIndex={0}
+                                      lastIndex={2}
                                       ofWord="of"
                                       onToggle={[Function]}
                                       optionsToggle="Items per page"
@@ -1824,18 +1830,18 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
                                   >
                                     <OptionsToggle
                                       aria-haspopup={true}
-                                      firstIndex={0}
+                                      firstIndex={-9}
                                       getMenuRef={[Function]}
                                       id="pf-dropdown-toggle-id-3"
                                       isDisabled={false}
                                       isOpen={false}
                                       isPlain={true}
                                       isText={false}
-                                      itemCount={0}
+                                      itemCount={2}
                                       itemsPerPageTitle="Items per page"
                                       itemsTitle=""
                                       key=".0"
-                                      lastIndex={0}
+                                      lastIndex={2}
                                       ofWord="of"
                                       onEnter={[Function]}
                                       onToggle={[Function]}
@@ -1854,15 +1860,15 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
                                                 class="pf-c-options-menu__toggle-text"
                                               >
                                                 <b>
-                                                  0
+                                                  -9
                                                    - 
-                                                  0
+                                                  2
                                                 </b>
                                                  
                                                 of
                                                  
                                                 <b>
-                                                  0
+                                                  2
                                                 </b>
                                                  
                                                 
@@ -1910,22 +1916,22 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
                                           className="pf-c-options-menu__toggle-text"
                                         >
                                           <ToggleTemplate
-                                            firstIndex={0}
-                                            itemCount={0}
+                                            firstIndex={-9}
+                                            itemCount={2}
                                             itemsTitle=""
-                                            lastIndex={0}
+                                            lastIndex={2}
                                             ofWord="of"
                                           >
                                             <b>
-                                              0
+                                              -9
                                                - 
-                                              0
+                                              2
                                             </b>
                                              
                                             of
                                              
                                             <b>
-                                              0
+                                              2
                                             </b>
                                              
                                           </ToggleTemplate>
@@ -1934,7 +1940,7 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
                                           aria-label="Items per page"
                                           className="pf-c-options-menu__toggle-button"
                                           id="pagination-options-menu-toggle-0"
-                                          isDisabled={0}
+                                          isDisabled={false}
                                           isOpen={false}
                                           onEnter={[Function]}
                                           onToggle={[Function]}
@@ -1952,15 +1958,15 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
                                                     class="pf-c-options-menu__toggle-text"
                                                   >
                                                     <b>
-                                                      0
+                                                      -9
                                                        - 
-                                                      0
+                                                      2
                                                     </b>
                                                      
                                                     of
                                                      
                                                     <b>
-                                                      0
+                                                      2
                                                     </b>
                                                      
                                                     
@@ -2008,7 +2014,7 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
                                             getMenuRef={null}
                                             id="pagination-options-menu-toggle-0"
                                             isActive={false}
-                                            isDisabled={0}
+                                            isDisabled={false}
                                             isOpen={false}
                                             isPlain={false}
                                             isPrimary={false}
@@ -2030,15 +2036,15 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
                                                       class="pf-c-options-menu__toggle-text"
                                                     >
                                                       <b>
-                                                        0
+                                                        -9
                                                          - 
-                                                        0
+                                                        2
                                                       </b>
                                                        
                                                       of
                                                        
                                                       <b>
-                                                        0
+                                                        2
                                                       </b>
                                                        
                                                       
@@ -2084,7 +2090,7 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
                                               data-ouia-component-id="OUIA-Generated-DropdownToggle-1"
                                               data-ouia-component-type="PF4/DropdownToggle"
                                               data-ouia-safe={true}
-                                              disabled={0}
+                                              disabled={false}
                                               id="pagination-options-menu-toggle-0"
                                               onClick={[Function]}
                                               onKeyDown={[Function]}
@@ -2132,8 +2138,8 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
                                 firstPage={1}
                                 isCompact={true}
                                 isDisabled={false}
-                                itemCount={0}
-                                lastPage={0}
+                                itemCount={2}
+                                lastPage={1}
                                 ofWord="of"
                                 onFirstClick={[Function]}
                                 onLastClick={[Function]}
@@ -2141,7 +2147,7 @@ exports[`jest-tests ConnectedBaselinesToolbar should render correctly 1`] = `
                                 onPageInput={[Function]}
                                 onPreviousClick={[Function]}
                                 onSetPage={[Function]}
-                                page={0}
+                                page={1}
                                 pagesTitle=""
                                 pagesTitlePlural=""
                                 paginationTitle="Pagination"

--- a/src/SmartComponents/BaselinesTable/__tests__/__snapshots__/BaselinesTable.tests.js.snap
+++ b/src/SmartComponents/BaselinesTable/__tests__/__snapshots__/BaselinesTable.tests.js.snap
@@ -50,6 +50,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
     >
       <Connect(BaselinesTable)
         basketIsVisible={false}
+        bulkSelectItems={[MockFunction]}
         columns={
           Array [
             Object {
@@ -74,7 +75,6 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
         }
         createButton={true}
         exportButton={true}
-        fetchBaselines={[MockFunction]}
         hasMultiSelect={true}
         kebab={true}
         loading={false}
@@ -84,6 +84,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
             "baselinesWrite": true,
           }
         }
+        selectBaseline={[MockFunction]}
         selectedBaselineIds={
           Array [
             "1234",
@@ -108,9 +109,11 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
           ]
         }
         tableId="CHECKBOX"
+        totalBaselines={2}
       >
         <BaselinesTable
           basketIsVisible={false}
+          bulkSelectItems={[MockFunction]}
           columns={
             Array [
               Object {
@@ -147,6 +150,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
               "baselinesWrite": true,
             }
           }
+          selectBaseline={[MockFunction]}
           selectedBaselineIds={
             Array [
               "1234",
@@ -174,6 +178,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
           toggleNotificationFulfilled={[Function]}
           toggleNotificationPending={[Function]}
           toggleNotificationRejected={[Function]}
+          totalBaselines={2}
         >
           <BaselinesToolbar
             createButton={true}
@@ -185,6 +190,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
             isDeleteDisabled={false}
             kebab={true}
             loading={false}
+            onBulkSelect={[Function]}
             onSearch={[Function]}
             page={1}
             perPage={20}
@@ -218,6 +224,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
               ]
             }
             tableId="CHECKBOX"
+            totalBaselines={2}
             updatePagination={[Function]}
           >
             <Connect(DeleteBaselinesModal)
@@ -364,20 +371,21 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                   <BulkSelect
                                     checked={null}
                                     count={1}
+                                    id="baselines-bulk-select"
                                     isDisabled={false}
                                     items={
                                       Array [
                                         Object {
-                                          "key": "select-all",
+                                          "key": "select-page",
                                           "onClick": [Function],
-                                          "ouiaId": "select-all",
-                                          "title": "Select all",
+                                          "ouiaId": "baselines-select-page",
+                                          "title": "Select page (2)",
                                         },
                                         Object {
                                           "key": "select-none",
                                           "onClick": [Function],
-                                          "ouiaId": "select-none",
-                                          "title": "Select none",
+                                          "ouiaId": "baselines-select-none",
+                                          "title": "Select none (0)",
                                         },
                                       ]
                                     }
@@ -397,16 +405,16 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                           <DropdownItem
                                             component="button"
                                             onClick={[Function]}
-                                            ouiaId="OUIA-Generated-RHI/BulkSelect-6-select-all"
+                                            ouiaId="OUIA-Generated-RHI/BulkSelect-6-select-page"
                                           >
-                                            Select all
+                                            Select page (2)
                                           </DropdownItem>,
                                           <DropdownItem
                                             component="button"
                                             onClick={[Function]}
                                             ouiaId="OUIA-Generated-RHI/BulkSelect-6-select-none"
                                           >
-                                            Select none
+                                            Select none (0)
                                           </DropdownItem>,
                                         ]
                                       }
@@ -425,7 +433,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                                 <DropdownToggleCheckbox
                                                   aria-label="Select all"
                                                   className=""
-                                                  id="toggle-checkbox"
+                                                  id="baselines-bulk-select-toggle-checkbox"
                                                   isChecked={null}
                                                   isDisabled={false}
                                                   isValid={true}
@@ -456,16 +464,16 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                             <DropdownItem
                                               component="button"
                                               onClick={[Function]}
-                                              ouiaId="OUIA-Generated-RHI/BulkSelect-6-select-all"
+                                              ouiaId="OUIA-Generated-RHI/BulkSelect-6-select-page"
                                             >
-                                              Select all
+                                              Select page (2)
                                             </DropdownItem>,
                                             <DropdownItem
                                               component="button"
                                               onClick={[Function]}
                                               ouiaId="OUIA-Generated-RHI/BulkSelect-6-select-none"
                                             >
-                                              Select none
+                                              Select none (0)
                                             </DropdownItem>,
                                           ]
                                         }
@@ -487,7 +495,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                                   <DropdownToggleCheckbox
                                                     aria-label="Select all"
                                                     className=""
-                                                    id="toggle-checkbox"
+                                                    id="baselines-bulk-select-toggle-checkbox"
                                                     isChecked={null}
                                                     isDisabled={false}
                                                     isValid={true}
@@ -533,7 +541,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                                   >
                                                     <label
                                                       class="pf-c-dropdown__toggle-check"
-                                                      for="toggle-checkbox"
+                                                      for="baselines-bulk-select-toggle-checkbox"
                                                     >
                                                       <input
                                                         aria-invalid="false"
@@ -541,13 +549,13 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                                         data-ouia-component-id="OUIA-Generated-RHI/BulkSelect-6"
                                                         data-ouia-component-type="PF4/DropdownToggleCheckbox"
                                                         data-ouia-safe="true"
-                                                        id="toggle-checkbox"
+                                                        id="baselines-bulk-select-toggle-checkbox"
                                                         type="checkbox"
                                                       />
                                                       <span
                                                         aria-hidden="true"
                                                         class="pf-c-dropdown__toggle-text"
-                                                        id="toggle-checkbox-text"
+                                                        id="baselines-bulk-select-toggle-checkbox-text"
                                                       >
                                                         1 selected
                                                       </span>
@@ -591,7 +599,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                                   <DropdownToggleCheckbox
                                                     aria-label="Select all"
                                                     className=""
-                                                    id="toggle-checkbox"
+                                                    id="baselines-bulk-select-toggle-checkbox"
                                                     isChecked={null}
                                                     isDisabled={false}
                                                     isValid={true}
@@ -610,7 +618,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                               <DropdownToggleCheckbox
                                                 aria-label="Select all"
                                                 className=""
-                                                id="toggle-checkbox"
+                                                id="baselines-bulk-select-toggle-checkbox"
                                                 isChecked={null}
                                                 isDisabled={false}
                                                 isValid={true}
@@ -619,7 +627,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                               >
                                                 <label
                                                   className="pf-c-dropdown__toggle-check"
-                                                  htmlFor="toggle-checkbox"
+                                                  htmlFor="baselines-bulk-select-toggle-checkbox"
                                                 >
                                                   <input
                                                     aria-invalid={false}
@@ -629,14 +637,14 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                                     data-ouia-component-type="PF4/DropdownToggleCheckbox"
                                                     data-ouia-safe={true}
                                                     disabled={false}
-                                                    id="toggle-checkbox"
+                                                    id="baselines-bulk-select-toggle-checkbox"
                                                     onChange={[Function]}
                                                     type="checkbox"
                                                   />
                                                   <span
                                                     aria-hidden="true"
                                                     className="pf-c-dropdown__toggle-text"
-                                                    id="toggle-checkbox-text"
+                                                    id="baselines-bulk-select-toggle-checkbox-text"
                                                   >
                                                     1 selected
                                                   </span>
@@ -674,7 +682,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                                       >
                                                         <label
                                                           class="pf-c-dropdown__toggle-check"
-                                                          for="toggle-checkbox"
+                                                          for="baselines-bulk-select-toggle-checkbox"
                                                         >
                                                           <input
                                                             aria-invalid="false"
@@ -682,13 +690,13 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                                             data-ouia-component-id="OUIA-Generated-RHI/BulkSelect-6"
                                                             data-ouia-component-type="PF4/DropdownToggleCheckbox"
                                                             data-ouia-safe="true"
-                                                            id="toggle-checkbox"
+                                                            id="baselines-bulk-select-toggle-checkbox"
                                                             type="checkbox"
                                                           />
                                                           <span
                                                             aria-hidden="true"
                                                             class="pf-c-dropdown__toggle-text"
-                                                            id="toggle-checkbox-text"
+                                                            id="baselines-bulk-select-toggle-checkbox-text"
                                                           >
                                                             1 selected
                                                           </span>
@@ -1660,6 +1668,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                               page={1}
                               perPage={20}
                               tableId="CHECKBOX"
+                              total={2}
                               updatePagination={[Function]}
                             >
                               <Pagination
@@ -1669,7 +1678,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                 isCompact={true}
                                 isDisabled={false}
                                 isSticky={false}
-                                itemCount={0}
+                                itemCount={2}
                                 itemsEnd={null}
                                 itemsStart={null}
                                 offset={0}
@@ -1734,22 +1743,22 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                     className="pf-c-pagination__total-items"
                                   >
                                     <ToggleTemplate
-                                      firstIndex={0}
-                                      itemCount={0}
+                                      firstIndex={1}
+                                      itemCount={2}
                                       itemsTitle=""
-                                      lastIndex={0}
+                                      lastIndex={2}
                                       ofWord="of"
                                     >
                                       <b>
-                                        0
+                                        1
                                          - 
-                                        0
+                                        2
                                       </b>
                                        
                                       of
                                        
                                       <b>
-                                        0
+                                        2
                                       </b>
                                        
                                     </ToggleTemplate>
@@ -1758,17 +1767,17 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                     className=""
                                     defaultToFullPage={false}
                                     dropDirection="down"
-                                    firstIndex={0}
+                                    firstIndex={1}
                                     isDisabled={false}
-                                    itemCount={0}
+                                    itemCount={2}
                                     itemsPerPageTitle="Items per page"
                                     itemsTitle=""
-                                    lastIndex={0}
-                                    lastPage={0}
+                                    lastIndex={2}
+                                    lastPage={1}
                                     ofWord="of"
                                     onPerPageSelect={[Function]}
                                     optionsToggle="Items per page"
-                                    page={0}
+                                    page={1}
                                     perPage={20}
                                     perPageOptions={
                                       Array [
@@ -1856,13 +1865,13 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                       position="left"
                                       toggle={
                                         <OptionsToggle
-                                          firstIndex={0}
+                                          firstIndex={1}
                                           isDisabled={false}
                                           isOpen={false}
-                                          itemCount={0}
+                                          itemCount={2}
                                           itemsPerPageTitle="Items per page"
                                           itemsTitle=""
-                                          lastIndex={0}
+                                          lastIndex={2}
                                           ofWord="of"
                                           onToggle={[Function]}
                                           optionsToggle="Items per page"
@@ -1880,18 +1889,18 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                       >
                                         <OptionsToggle
                                           aria-haspopup={true}
-                                          firstIndex={0}
+                                          firstIndex={1}
                                           getMenuRef={[Function]}
                                           id="pf-dropdown-toggle-id-36"
                                           isDisabled={false}
                                           isOpen={false}
                                           isPlain={true}
                                           isText={false}
-                                          itemCount={0}
+                                          itemCount={2}
                                           itemsPerPageTitle="Items per page"
                                           itemsTitle=""
                                           key=".0"
-                                          lastIndex={0}
+                                          lastIndex={2}
                                           ofWord="of"
                                           onEnter={[Function]}
                                           onToggle={[Function]}
@@ -1910,15 +1919,15 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                                     class="pf-c-options-menu__toggle-text"
                                                   >
                                                     <b>
-                                                      0
+                                                      1
                                                        - 
-                                                      0
+                                                      2
                                                     </b>
                                                      
                                                     of
                                                      
                                                     <b>
-                                                      0
+                                                      2
                                                     </b>
                                                      
                                                     
@@ -1966,22 +1975,22 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                               className="pf-c-options-menu__toggle-text"
                                             >
                                               <ToggleTemplate
-                                                firstIndex={0}
-                                                itemCount={0}
+                                                firstIndex={1}
+                                                itemCount={2}
                                                 itemsTitle=""
-                                                lastIndex={0}
+                                                lastIndex={2}
                                                 ofWord="of"
                                               >
                                                 <b>
-                                                  0
+                                                  1
                                                    - 
-                                                  0
+                                                  2
                                                 </b>
                                                  
                                                 of
                                                  
                                                 <b>
-                                                  0
+                                                  2
                                                 </b>
                                                  
                                               </ToggleTemplate>
@@ -1990,7 +1999,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                               aria-label="Items per page"
                                               className="pf-c-options-menu__toggle-button"
                                               id="pagination-options-menu-toggle-12"
-                                              isDisabled={0}
+                                              isDisabled={false}
                                               isOpen={false}
                                               onEnter={[Function]}
                                               onToggle={[Function]}
@@ -2008,15 +2017,15 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                                         class="pf-c-options-menu__toggle-text"
                                                       >
                                                         <b>
-                                                          0
+                                                          1
                                                            - 
-                                                          0
+                                                          2
                                                         </b>
                                                          
                                                         of
                                                          
                                                         <b>
-                                                          0
+                                                          2
                                                         </b>
                                                          
                                                         
@@ -2064,7 +2073,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                                 getMenuRef={null}
                                                 id="pagination-options-menu-toggle-12"
                                                 isActive={false}
-                                                isDisabled={0}
+                                                isDisabled={false}
                                                 isOpen={false}
                                                 isPlain={false}
                                                 isPrimary={false}
@@ -2086,15 +2095,15 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                                           class="pf-c-options-menu__toggle-text"
                                                         >
                                                           <b>
-                                                            0
+                                                            1
                                                              - 
-                                                            0
+                                                            2
                                                           </b>
                                                            
                                                           of
                                                            
                                                           <b>
-                                                            0
+                                                            2
                                                           </b>
                                                            
                                                           
@@ -2140,7 +2149,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                                   data-ouia-component-id="OUIA-Generated-DropdownToggle-13"
                                                   data-ouia-component-type="PF4/DropdownToggle"
                                                   data-ouia-safe={true}
-                                                  disabled={0}
+                                                  disabled={false}
                                                   id="pagination-options-menu-toggle-12"
                                                   onClick={[Function]}
                                                   onKeyDown={[Function]}
@@ -2188,8 +2197,8 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                     firstPage={1}
                                     isCompact={true}
                                     isDisabled={false}
-                                    itemCount={0}
-                                    lastPage={0}
+                                    itemCount={2}
+                                    lastPage={1}
                                     ofWord="of"
                                     onFirstClick={[Function]}
                                     onLastClick={[Function]}
@@ -2197,7 +2206,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                     onPageInput={[Function]}
                                     onPreviousClick={[Function]}
                                     onSetPage={[Function]}
-                                    page={0}
+                                    page={1}
                                     pagesTitle=""
                                     pagesTitlePlural=""
                                     paginationTitle="Pagination"
@@ -7434,6 +7443,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                             page={1}
                             perPage={20}
                             tableId="CHECKBOX"
+                            total={2}
                             updatePagination={[Function]}
                           >
                             <Pagination
@@ -7443,7 +7453,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                               isCompact={false}
                               isDisabled={false}
                               isSticky={false}
-                              itemCount={0}
+                              itemCount={2}
                               itemsEnd={null}
                               itemsStart={null}
                               offset={0}
@@ -7508,22 +7518,22 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                   className="pf-c-pagination__total-items"
                                 >
                                   <ToggleTemplate
-                                    firstIndex={0}
-                                    itemCount={0}
+                                    firstIndex={1}
+                                    itemCount={2}
                                     itemsTitle=""
-                                    lastIndex={0}
+                                    lastIndex={2}
                                     ofWord="of"
                                   >
                                     <b>
-                                      0
+                                      1
                                        - 
-                                      0
+                                      2
                                     </b>
                                      
                                     of
                                      
                                     <b>
-                                      0
+                                      2
                                     </b>
                                      
                                   </ToggleTemplate>
@@ -7532,17 +7542,17 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                   className=""
                                   defaultToFullPage={false}
                                   dropDirection="down"
-                                  firstIndex={0}
+                                  firstIndex={1}
                                   isDisabled={false}
-                                  itemCount={0}
+                                  itemCount={2}
                                   itemsPerPageTitle="Items per page"
                                   itemsTitle=""
-                                  lastIndex={0}
-                                  lastPage={0}
+                                  lastIndex={2}
+                                  lastPage={1}
                                   ofWord="of"
                                   onPerPageSelect={[Function]}
                                   optionsToggle="Items per page"
-                                  page={0}
+                                  page={1}
                                   perPage={20}
                                   perPageOptions={
                                     Array [
@@ -7630,13 +7640,13 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                     position="left"
                                     toggle={
                                       <OptionsToggle
-                                        firstIndex={0}
+                                        firstIndex={1}
                                         isDisabled={false}
                                         isOpen={false}
-                                        itemCount={0}
+                                        itemCount={2}
                                         itemsPerPageTitle="Items per page"
                                         itemsTitle=""
-                                        lastIndex={0}
+                                        lastIndex={2}
                                         ofWord="of"
                                         onToggle={[Function]}
                                         optionsToggle="Items per page"
@@ -7654,18 +7664,18 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                     >
                                       <OptionsToggle
                                         aria-haspopup={true}
-                                        firstIndex={0}
+                                        firstIndex={1}
                                         getMenuRef={[Function]}
                                         id="pf-dropdown-toggle-id-39"
                                         isDisabled={false}
                                         isOpen={false}
                                         isPlain={true}
                                         isText={false}
-                                        itemCount={0}
+                                        itemCount={2}
                                         itemsPerPageTitle="Items per page"
                                         itemsTitle=""
                                         key=".0"
-                                        lastIndex={0}
+                                        lastIndex={2}
                                         ofWord="of"
                                         onEnter={[Function]}
                                         onToggle={[Function]}
@@ -7684,15 +7694,15 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                                   class="pf-c-options-menu__toggle-text"
                                                 >
                                                   <b>
-                                                    0
+                                                    1
                                                      - 
-                                                    0
+                                                    2
                                                   </b>
                                                    
                                                   of
                                                    
                                                   <b>
-                                                    0
+                                                    2
                                                   </b>
                                                    
                                                   
@@ -7740,22 +7750,22 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                             className="pf-c-options-menu__toggle-text"
                                           >
                                             <ToggleTemplate
-                                              firstIndex={0}
-                                              itemCount={0}
+                                              firstIndex={1}
+                                              itemCount={2}
                                               itemsTitle=""
-                                              lastIndex={0}
+                                              lastIndex={2}
                                               ofWord="of"
                                             >
                                               <b>
-                                                0
+                                                1
                                                  - 
-                                                0
+                                                2
                                               </b>
                                                
                                               of
                                                
                                               <b>
-                                                0
+                                                2
                                               </b>
                                                
                                             </ToggleTemplate>
@@ -7764,7 +7774,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                             aria-label="Items per page"
                                             className="pf-c-options-menu__toggle-button"
                                             id="pagination-options-menu-toggle-13"
-                                            isDisabled={0}
+                                            isDisabled={false}
                                             isOpen={false}
                                             onEnter={[Function]}
                                             onToggle={[Function]}
@@ -7782,15 +7792,15 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                                       class="pf-c-options-menu__toggle-text"
                                                     >
                                                       <b>
-                                                        0
+                                                        1
                                                          - 
-                                                        0
+                                                        2
                                                       </b>
                                                        
                                                       of
                                                        
                                                       <b>
-                                                        0
+                                                        2
                                                       </b>
                                                        
                                                       
@@ -7838,7 +7848,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                               getMenuRef={null}
                                               id="pagination-options-menu-toggle-13"
                                               isActive={false}
-                                              isDisabled={0}
+                                              isDisabled={false}
                                               isOpen={false}
                                               isPlain={false}
                                               isPrimary={false}
@@ -7860,15 +7870,15 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                                         class="pf-c-options-menu__toggle-text"
                                                       >
                                                         <b>
-                                                          0
+                                                          1
                                                            - 
-                                                          0
+                                                          2
                                                         </b>
                                                          
                                                         of
                                                          
                                                         <b>
-                                                          0
+                                                          2
                                                         </b>
                                                          
                                                         
@@ -7914,7 +7924,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                                 data-ouia-component-id="OUIA-Generated-DropdownToggle-14"
                                                 data-ouia-component-type="PF4/DropdownToggle"
                                                 data-ouia-safe={true}
-                                                disabled={0}
+                                                disabled={false}
                                                 id="pagination-options-menu-toggle-13"
                                                 onClick={[Function]}
                                                 onKeyDown={[Function]}
@@ -7962,8 +7972,8 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                   firstPage={1}
                                   isCompact={false}
                                   isDisabled={false}
-                                  itemCount={0}
-                                  lastPage={0}
+                                  itemCount={2}
+                                  lastPage={1}
                                   ofWord="of"
                                   onFirstClick={[Function]}
                                   onLastClick={[Function]}
@@ -7971,7 +7981,7 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                   onPageInput={[Function]}
                                   onPreviousClick={[Function]}
                                   onSetPage={[Function]}
-                                  page={0}
+                                  page={1}
                                   pagesTitle=""
                                   pagesTitlePlural=""
                                   paginationTitle="Pagination"
@@ -8112,19 +8122,19 @@ exports[`ConnectedBaselinesTable should render baseline selected 1`] = `
                                         aria-label="Current page"
                                         className="pf-c-form-control"
                                         disabled={true}
-                                        max={0}
+                                        max={1}
                                         min={1}
                                         onChange={[Function]}
                                         onKeyDown={[Function]}
                                         type="number"
-                                        value={0}
+                                        value={1}
                                       />
                                       <span
                                         aria-hidden="true"
                                       >
                                         of
                                          
-                                        0
+                                        1
                                       </span>
                                     </div>
                                     <div
@@ -8355,6 +8365,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
     >
       <Connect(BaselinesTable)
         basketIsVisible={true}
+        bulkSelectItems={[MockFunction]}
         columns={
           Array [
             Object {
@@ -8379,7 +8390,6 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
         }
         createButton={true}
         exportButton={true}
-        fetchBaselines={[MockFunction]}
         hasMultiSelect={true}
         kebab={true}
         loading={false}
@@ -8389,6 +8399,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
             "baselinesWrite": true,
           }
         }
+        selectBaseline={[MockFunction]}
         selectedBaselineIds={Array []}
         tableData={
           Array [
@@ -8409,9 +8420,11 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
           ]
         }
         tableId="CHECKBOX"
+        totalBaselines={2}
       >
         <BaselinesTable
           basketIsVisible={true}
+          bulkSelectItems={[MockFunction]}
           columns={
             Array [
               Object {
@@ -8448,6 +8461,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
               "baselinesWrite": true,
             }
           }
+          selectBaseline={[MockFunction]}
           selectedBaselineIds={Array []}
           tableData={
             Array [
@@ -8471,6 +8485,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
           toggleNotificationFulfilled={[Function]}
           toggleNotificationPending={[Function]}
           toggleNotificationRejected={[Function]}
+          totalBaselines={2}
         >
           <BaselinesToolbar
             createButton={true}
@@ -8482,6 +8497,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
             isDeleteDisabled={true}
             kebab={true}
             loading={false}
+            onBulkSelect={[Function]}
             onSearch={[Function]}
             page={1}
             perPage={20}
@@ -8511,6 +8527,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
               ]
             }
             tableId="CHECKBOX"
+            totalBaselines={2}
             updatePagination={[Function]}
           >
             <Connect(DeleteBaselinesModal)
@@ -8647,22 +8664,23 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                   className="pf-c-toolbar__item"
                                 >
                                   <BulkSelect
-                                    checked={null}
-                                    count={1}
+                                    checked={false}
+                                    count={0}
+                                    id="baselines-bulk-select"
                                     isDisabled={false}
                                     items={
                                       Array [
                                         Object {
-                                          "key": "select-all",
+                                          "key": "select-page",
                                           "onClick": [Function],
-                                          "ouiaId": "select-all",
-                                          "title": "Select all",
+                                          "ouiaId": "baselines-select-page",
+                                          "title": "Select page (2)",
                                         },
                                         Object {
                                           "key": "select-none",
                                           "onClick": [Function],
-                                          "ouiaId": "select-none",
-                                          "title": "Select none",
+                                          "ouiaId": "baselines-select-none",
+                                          "title": "Select none (0)",
                                         },
                                       ]
                                     }
@@ -8673,25 +8691,18 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                       dropdownItems={
                                         Array [
                                           <DropdownItem
-                                            className="ins-c-bulk-select__selected"
-                                            isDisabled={true}
-                                          >
-                                            1
-                                             Selected
-                                          </DropdownItem>,
-                                          <DropdownItem
                                             component="button"
                                             onClick={[Function]}
-                                            ouiaId="OUIA-Generated-RHI/BulkSelect-7-select-all"
+                                            ouiaId="OUIA-Generated-RHI/BulkSelect-7-select-page"
                                           >
-                                            Select all
+                                            Select page (2)
                                           </DropdownItem>,
                                           <DropdownItem
                                             component="button"
                                             onClick={[Function]}
                                             ouiaId="OUIA-Generated-RHI/BulkSelect-7-select-none"
                                           >
-                                            Select none
+                                            Select none (0)
                                           </DropdownItem>,
                                         ]
                                       }
@@ -8710,14 +8721,14 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                                 <DropdownToggleCheckbox
                                                   aria-label="Select all"
                                                   className=""
-                                                  id="toggle-checkbox"
-                                                  isChecked={null}
+                                                  id="baselines-bulk-select-toggle-checkbox"
+                                                  isChecked={false}
                                                   isDisabled={false}
                                                   isValid={true}
                                                   onChange={[Function]}
                                                   ouiaId="OUIA-Generated-RHI/BulkSelect-7"
                                                 >
-                                                  1 selected
+                                                  
                                                 </DropdownToggleCheckbox>
                                               </React.Fragment>,
                                             ]
@@ -8732,25 +8743,18 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                         dropdownItems={
                                           Array [
                                             <DropdownItem
-                                              className="ins-c-bulk-select__selected"
-                                              isDisabled={true}
-                                            >
-                                              1
-                                               Selected
-                                            </DropdownItem>,
-                                            <DropdownItem
                                               component="button"
                                               onClick={[Function]}
-                                              ouiaId="OUIA-Generated-RHI/BulkSelect-7-select-all"
+                                              ouiaId="OUIA-Generated-RHI/BulkSelect-7-select-page"
                                             >
-                                              Select all
+                                              Select page (2)
                                             </DropdownItem>,
                                             <DropdownItem
                                               component="button"
                                               onClick={[Function]}
                                               ouiaId="OUIA-Generated-RHI/BulkSelect-7-select-none"
                                             >
-                                              Select none
+                                              Select none (0)
                                             </DropdownItem>,
                                           ]
                                         }
@@ -8772,14 +8776,14 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                                   <DropdownToggleCheckbox
                                                     aria-label="Select all"
                                                     className=""
-                                                    id="toggle-checkbox"
-                                                    isChecked={null}
+                                                    id="baselines-bulk-select-toggle-checkbox"
+                                                    isChecked={false}
                                                     isDisabled={false}
                                                     isValid={true}
                                                     onChange={[Function]}
                                                     ouiaId="OUIA-Generated-RHI/BulkSelect-7"
                                                   >
-                                                    1 selected
+                                                    
                                                   </DropdownToggleCheckbox>
                                                 </React.Fragment>,
                                               ]
@@ -8818,7 +8822,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                                   >
                                                     <label
                                                       class="pf-c-dropdown__toggle-check"
-                                                      for="toggle-checkbox"
+                                                      for="baselines-bulk-select-toggle-checkbox"
                                                     >
                                                       <input
                                                         aria-invalid="false"
@@ -8826,16 +8830,10 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                                         data-ouia-component-id="OUIA-Generated-RHI/BulkSelect-7"
                                                         data-ouia-component-type="PF4/DropdownToggleCheckbox"
                                                         data-ouia-safe="true"
-                                                        id="toggle-checkbox"
+                                                        id="baselines-bulk-select-toggle-checkbox"
                                                         type="checkbox"
                                                       />
-                                                      <span
-                                                        aria-hidden="true"
-                                                        class="pf-c-dropdown__toggle-text"
-                                                        id="toggle-checkbox-text"
-                                                      >
-                                                        1 selected
-                                                      </span>
+                                                      
                                                     </label>
                                                     <button
                                                       aria-expanded="false"
@@ -8876,14 +8874,14 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                                   <DropdownToggleCheckbox
                                                     aria-label="Select all"
                                                     className=""
-                                                    id="toggle-checkbox"
-                                                    isChecked={null}
+                                                    id="baselines-bulk-select-toggle-checkbox"
+                                                    isChecked={false}
                                                     isDisabled={false}
                                                     isValid={true}
                                                     onChange={[Function]}
                                                     ouiaId="OUIA-Generated-RHI/BulkSelect-7"
                                                   >
-                                                    1 selected
+                                                    
                                                   </DropdownToggleCheckbox>
                                                 </React.Fragment>,
                                               ]
@@ -8895,8 +8893,8 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                               <DropdownToggleCheckbox
                                                 aria-label="Select all"
                                                 className=""
-                                                id="toggle-checkbox"
-                                                isChecked={null}
+                                                id="baselines-bulk-select-toggle-checkbox"
+                                                isChecked={false}
                                                 isDisabled={false}
                                                 isValid={true}
                                                 onChange={[Function]}
@@ -8904,7 +8902,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                               >
                                                 <label
                                                   className="pf-c-dropdown__toggle-check"
-                                                  htmlFor="toggle-checkbox"
+                                                  htmlFor="baselines-bulk-select-toggle-checkbox"
                                                 >
                                                   <input
                                                     aria-invalid={false}
@@ -8914,17 +8912,10 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                                     data-ouia-component-type="PF4/DropdownToggleCheckbox"
                                                     data-ouia-safe={true}
                                                     disabled={false}
-                                                    id="toggle-checkbox"
+                                                    id="baselines-bulk-select-toggle-checkbox"
                                                     onChange={[Function]}
                                                     type="checkbox"
                                                   />
-                                                  <span
-                                                    aria-hidden="true"
-                                                    className="pf-c-dropdown__toggle-text"
-                                                    id="toggle-checkbox-text"
-                                                  >
-                                                    1 selected
-                                                  </span>
                                                 </label>
                                               </DropdownToggleCheckbox>
                                               <Toggle
@@ -8959,7 +8950,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                                       >
                                                         <label
                                                           class="pf-c-dropdown__toggle-check"
-                                                          for="toggle-checkbox"
+                                                          for="baselines-bulk-select-toggle-checkbox"
                                                         >
                                                           <input
                                                             aria-invalid="false"
@@ -8967,16 +8958,10 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                                             data-ouia-component-id="OUIA-Generated-RHI/BulkSelect-7"
                                                             data-ouia-component-type="PF4/DropdownToggleCheckbox"
                                                             data-ouia-safe="true"
-                                                            id="toggle-checkbox"
+                                                            id="baselines-bulk-select-toggle-checkbox"
                                                             type="checkbox"
                                                           />
-                                                          <span
-                                                            aria-hidden="true"
-                                                            class="pf-c-dropdown__toggle-text"
-                                                            id="toggle-checkbox-text"
-                                                          >
-                                                            1 selected
-                                                          </span>
+                                                          
                                                         </label>
                                                         <button
                                                           aria-expanded="false"
@@ -9945,6 +9930,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                               page={1}
                               perPage={20}
                               tableId="CHECKBOX"
+                              total={2}
                               updatePagination={[Function]}
                             >
                               <Pagination
@@ -9954,7 +9940,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                 isCompact={true}
                                 isDisabled={false}
                                 isSticky={false}
-                                itemCount={0}
+                                itemCount={2}
                                 itemsEnd={null}
                                 itemsStart={null}
                                 offset={0}
@@ -10019,22 +10005,22 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                     className="pf-c-pagination__total-items"
                                   >
                                     <ToggleTemplate
-                                      firstIndex={0}
-                                      itemCount={0}
+                                      firstIndex={1}
+                                      itemCount={2}
                                       itemsTitle=""
-                                      lastIndex={0}
+                                      lastIndex={2}
                                       ofWord="of"
                                     >
                                       <b>
-                                        0
+                                        1
                                          - 
-                                        0
+                                        2
                                       </b>
                                        
                                       of
                                        
                                       <b>
-                                        0
+                                        2
                                       </b>
                                        
                                     </ToggleTemplate>
@@ -10043,17 +10029,17 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                     className=""
                                     defaultToFullPage={false}
                                     dropDirection="down"
-                                    firstIndex={0}
+                                    firstIndex={1}
                                     isDisabled={false}
-                                    itemCount={0}
+                                    itemCount={2}
                                     itemsPerPageTitle="Items per page"
                                     itemsTitle=""
-                                    lastIndex={0}
-                                    lastPage={0}
+                                    lastIndex={2}
+                                    lastPage={1}
                                     ofWord="of"
                                     onPerPageSelect={[Function]}
                                     optionsToggle="Items per page"
-                                    page={0}
+                                    page={1}
                                     perPage={20}
                                     perPageOptions={
                                       Array [
@@ -10141,13 +10127,13 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                       position="left"
                                       toggle={
                                         <OptionsToggle
-                                          firstIndex={0}
+                                          firstIndex={1}
                                           isDisabled={false}
                                           isOpen={false}
-                                          itemCount={0}
+                                          itemCount={2}
                                           itemsPerPageTitle="Items per page"
                                           itemsTitle=""
-                                          lastIndex={0}
+                                          lastIndex={2}
                                           ofWord="of"
                                           onToggle={[Function]}
                                           optionsToggle="Items per page"
@@ -10165,18 +10151,18 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                       >
                                         <OptionsToggle
                                           aria-haspopup={true}
-                                          firstIndex={0}
+                                          firstIndex={1}
                                           getMenuRef={[Function]}
                                           id="pf-dropdown-toggle-id-43"
                                           isDisabled={false}
                                           isOpen={false}
                                           isPlain={true}
                                           isText={false}
-                                          itemCount={0}
+                                          itemCount={2}
                                           itemsPerPageTitle="Items per page"
                                           itemsTitle=""
                                           key=".0"
-                                          lastIndex={0}
+                                          lastIndex={2}
                                           ofWord="of"
                                           onEnter={[Function]}
                                           onToggle={[Function]}
@@ -10195,15 +10181,15 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                                     class="pf-c-options-menu__toggle-text"
                                                   >
                                                     <b>
-                                                      0
+                                                      1
                                                        - 
-                                                      0
+                                                      2
                                                     </b>
                                                      
                                                     of
                                                      
                                                     <b>
-                                                      0
+                                                      2
                                                     </b>
                                                      
                                                     
@@ -10251,22 +10237,22 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                               className="pf-c-options-menu__toggle-text"
                                             >
                                               <ToggleTemplate
-                                                firstIndex={0}
-                                                itemCount={0}
+                                                firstIndex={1}
+                                                itemCount={2}
                                                 itemsTitle=""
-                                                lastIndex={0}
+                                                lastIndex={2}
                                                 ofWord="of"
                                               >
                                                 <b>
-                                                  0
+                                                  1
                                                    - 
-                                                  0
+                                                  2
                                                 </b>
                                                  
                                                 of
                                                  
                                                 <b>
-                                                  0
+                                                  2
                                                 </b>
                                                  
                                               </ToggleTemplate>
@@ -10275,7 +10261,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                               aria-label="Items per page"
                                               className="pf-c-options-menu__toggle-button"
                                               id="pagination-options-menu-toggle-14"
-                                              isDisabled={0}
+                                              isDisabled={false}
                                               isOpen={false}
                                               onEnter={[Function]}
                                               onToggle={[Function]}
@@ -10293,15 +10279,15 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                                         class="pf-c-options-menu__toggle-text"
                                                       >
                                                         <b>
-                                                          0
+                                                          1
                                                            - 
-                                                          0
+                                                          2
                                                         </b>
                                                          
                                                         of
                                                          
                                                         <b>
-                                                          0
+                                                          2
                                                         </b>
                                                          
                                                         
@@ -10349,7 +10335,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                                 getMenuRef={null}
                                                 id="pagination-options-menu-toggle-14"
                                                 isActive={false}
-                                                isDisabled={0}
+                                                isDisabled={false}
                                                 isOpen={false}
                                                 isPlain={false}
                                                 isPrimary={false}
@@ -10371,15 +10357,15 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                                           class="pf-c-options-menu__toggle-text"
                                                         >
                                                           <b>
-                                                            0
+                                                            1
                                                              - 
-                                                            0
+                                                            2
                                                           </b>
                                                            
                                                           of
                                                            
                                                           <b>
-                                                            0
+                                                            2
                                                           </b>
                                                            
                                                           
@@ -10425,7 +10411,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                                   data-ouia-component-id="OUIA-Generated-DropdownToggle-15"
                                                   data-ouia-component-type="PF4/DropdownToggle"
                                                   data-ouia-safe={true}
-                                                  disabled={0}
+                                                  disabled={false}
                                                   id="pagination-options-menu-toggle-14"
                                                   onClick={[Function]}
                                                   onKeyDown={[Function]}
@@ -10473,8 +10459,8 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                     firstPage={1}
                                     isCompact={true}
                                     isDisabled={false}
-                                    itemCount={0}
-                                    lastPage={0}
+                                    itemCount={2}
+                                    lastPage={1}
                                     ofWord="of"
                                     onFirstClick={[Function]}
                                     onLastClick={[Function]}
@@ -10482,7 +10468,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                     onPageInput={[Function]}
                                     onPreviousClick={[Function]}
                                     onSetPage={[Function]}
-                                    page={0}
+                                    page={1}
                                     pagesTitle=""
                                     pagesTitlePlural=""
                                     paginationTitle="Pagination"
@@ -15575,6 +15561,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                             page={1}
                             perPage={20}
                             tableId="CHECKBOX"
+                            total={2}
                             updatePagination={[Function]}
                           >
                             <Pagination
@@ -15584,7 +15571,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                               isCompact={false}
                               isDisabled={false}
                               isSticky={false}
-                              itemCount={0}
+                              itemCount={2}
                               itemsEnd={null}
                               itemsStart={null}
                               offset={0}
@@ -15649,22 +15636,22 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                   className="pf-c-pagination__total-items"
                                 >
                                   <ToggleTemplate
-                                    firstIndex={0}
-                                    itemCount={0}
+                                    firstIndex={1}
+                                    itemCount={2}
                                     itemsTitle=""
-                                    lastIndex={0}
+                                    lastIndex={2}
                                     ofWord="of"
                                   >
                                     <b>
-                                      0
+                                      1
                                        - 
-                                      0
+                                      2
                                     </b>
                                      
                                     of
                                      
                                     <b>
-                                      0
+                                      2
                                     </b>
                                      
                                   </ToggleTemplate>
@@ -15673,17 +15660,17 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                   className=""
                                   defaultToFullPage={false}
                                   dropDirection="down"
-                                  firstIndex={0}
+                                  firstIndex={1}
                                   isDisabled={false}
-                                  itemCount={0}
+                                  itemCount={2}
                                   itemsPerPageTitle="Items per page"
                                   itemsTitle=""
-                                  lastIndex={0}
-                                  lastPage={0}
+                                  lastIndex={2}
+                                  lastPage={1}
                                   ofWord="of"
                                   onPerPageSelect={[Function]}
                                   optionsToggle="Items per page"
-                                  page={0}
+                                  page={1}
                                   perPage={20}
                                   perPageOptions={
                                     Array [
@@ -15771,13 +15758,13 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                     position="left"
                                     toggle={
                                       <OptionsToggle
-                                        firstIndex={0}
+                                        firstIndex={1}
                                         isDisabled={false}
                                         isOpen={false}
-                                        itemCount={0}
+                                        itemCount={2}
                                         itemsPerPageTitle="Items per page"
                                         itemsTitle=""
-                                        lastIndex={0}
+                                        lastIndex={2}
                                         ofWord="of"
                                         onToggle={[Function]}
                                         optionsToggle="Items per page"
@@ -15795,18 +15782,18 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                     >
                                       <OptionsToggle
                                         aria-haspopup={true}
-                                        firstIndex={0}
+                                        firstIndex={1}
                                         getMenuRef={[Function]}
                                         id="pf-dropdown-toggle-id-46"
                                         isDisabled={false}
                                         isOpen={false}
                                         isPlain={true}
                                         isText={false}
-                                        itemCount={0}
+                                        itemCount={2}
                                         itemsPerPageTitle="Items per page"
                                         itemsTitle=""
                                         key=".0"
-                                        lastIndex={0}
+                                        lastIndex={2}
                                         ofWord="of"
                                         onEnter={[Function]}
                                         onToggle={[Function]}
@@ -15825,15 +15812,15 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                                   class="pf-c-options-menu__toggle-text"
                                                 >
                                                   <b>
-                                                    0
+                                                    1
                                                      - 
-                                                    0
+                                                    2
                                                   </b>
                                                    
                                                   of
                                                    
                                                   <b>
-                                                    0
+                                                    2
                                                   </b>
                                                    
                                                   
@@ -15881,22 +15868,22 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                             className="pf-c-options-menu__toggle-text"
                                           >
                                             <ToggleTemplate
-                                              firstIndex={0}
-                                              itemCount={0}
+                                              firstIndex={1}
+                                              itemCount={2}
                                               itemsTitle=""
-                                              lastIndex={0}
+                                              lastIndex={2}
                                               ofWord="of"
                                             >
                                               <b>
-                                                0
+                                                1
                                                  - 
-                                                0
+                                                2
                                               </b>
                                                
                                               of
                                                
                                               <b>
-                                                0
+                                                2
                                               </b>
                                                
                                             </ToggleTemplate>
@@ -15905,7 +15892,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                             aria-label="Items per page"
                                             className="pf-c-options-menu__toggle-button"
                                             id="pagination-options-menu-toggle-15"
-                                            isDisabled={0}
+                                            isDisabled={false}
                                             isOpen={false}
                                             onEnter={[Function]}
                                             onToggle={[Function]}
@@ -15923,15 +15910,15 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                                       class="pf-c-options-menu__toggle-text"
                                                     >
                                                       <b>
-                                                        0
+                                                        1
                                                          - 
-                                                        0
+                                                        2
                                                       </b>
                                                        
                                                       of
                                                        
                                                       <b>
-                                                        0
+                                                        2
                                                       </b>
                                                        
                                                       
@@ -15979,7 +15966,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                               getMenuRef={null}
                                               id="pagination-options-menu-toggle-15"
                                               isActive={false}
-                                              isDisabled={0}
+                                              isDisabled={false}
                                               isOpen={false}
                                               isPlain={false}
                                               isPrimary={false}
@@ -16001,15 +15988,15 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                                         class="pf-c-options-menu__toggle-text"
                                                       >
                                                         <b>
-                                                          0
+                                                          1
                                                            - 
-                                                          0
+                                                          2
                                                         </b>
                                                          
                                                         of
                                                          
                                                         <b>
-                                                          0
+                                                          2
                                                         </b>
                                                          
                                                         
@@ -16055,7 +16042,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                                 data-ouia-component-id="OUIA-Generated-DropdownToggle-16"
                                                 data-ouia-component-type="PF4/DropdownToggle"
                                                 data-ouia-safe={true}
-                                                disabled={0}
+                                                disabled={false}
                                                 id="pagination-options-menu-toggle-15"
                                                 onClick={[Function]}
                                                 onKeyDown={[Function]}
@@ -16103,8 +16090,8 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                   firstPage={1}
                                   isCompact={false}
                                   isDisabled={false}
-                                  itemCount={0}
-                                  lastPage={0}
+                                  itemCount={2}
+                                  lastPage={1}
                                   ofWord="of"
                                   onFirstClick={[Function]}
                                   onLastClick={[Function]}
@@ -16112,7 +16099,7 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                   onPageInput={[Function]}
                                   onPreviousClick={[Function]}
                                   onSetPage={[Function]}
-                                  page={0}
+                                  page={1}
                                   pagesTitle=""
                                   pagesTitlePlural=""
                                   paginationTitle="Pagination"
@@ -16253,19 +16240,19 @@ exports[`ConnectedBaselinesTable should render disabled when selected basket is 
                                         aria-label="Current page"
                                         className="pf-c-form-control"
                                         disabled={true}
-                                        max={0}
+                                        max={1}
                                         min={1}
                                         onChange={[Function]}
                                         onKeyDown={[Function]}
                                         type="number"
-                                        value={0}
+                                        value={1}
                                       />
                                       <span
                                         aria-hidden="true"
                                       >
                                         of
                                          
-                                        0
+                                        1
                                       </span>
                                     </div>
                                     <div
@@ -16496,6 +16483,7 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
     >
       <Connect(BaselinesTable)
         basketIsVisible={false}
+        bulkSelectItems={[MockFunction]}
         columns={
           Array [
             Object {
@@ -16520,7 +16508,6 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
         }
         createButton={true}
         exportButton={true}
-        fetchBaselines={[MockFunction]}
         hasMultiSelect={true}
         kebab={true}
         loading={true}
@@ -16530,6 +16517,7 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
             "baselinesWrite": true,
           }
         }
+        selectBaseline={[MockFunction]}
         selectedBaselineIds={Array []}
         tableData={
           Array [
@@ -16550,9 +16538,11 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
           ]
         }
         tableId="CHECKBOX"
+        totalBaselines={2}
       >
         <BaselinesTable
           basketIsVisible={false}
+          bulkSelectItems={[MockFunction]}
           columns={
             Array [
               Object {
@@ -16589,6 +16579,7 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
               "baselinesWrite": true,
             }
           }
+          selectBaseline={[MockFunction]}
           selectedBaselineIds={Array []}
           tableData={
             Array [
@@ -16612,6 +16603,7 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
           toggleNotificationFulfilled={[Function]}
           toggleNotificationPending={[Function]}
           toggleNotificationRejected={[Function]}
+          totalBaselines={2}
         >
           <BaselinesToolbar
             createButton={true}
@@ -16623,6 +16615,7 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
             isDeleteDisabled={true}
             kebab={true}
             loading={true}
+            onBulkSelect={[Function]}
             onSearch={[Function]}
             page={1}
             perPage={20}
@@ -16652,6 +16645,7 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
               ]
             }
             tableId="CHECKBOX"
+            totalBaselines={2}
             updatePagination={[Function]}
           >
             <Connect(DeleteBaselinesModal)
@@ -16789,21 +16783,22 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                 >
                                   <BulkSelect
                                     checked={false}
-                                    count={null}
+                                    count={0}
+                                    id="baselines-bulk-select"
                                     isDisabled={false}
                                     items={
                                       Array [
                                         Object {
-                                          "key": "select-all",
+                                          "key": "select-page",
                                           "onClick": [Function],
-                                          "ouiaId": "select-all",
-                                          "title": "Select all",
+                                          "ouiaId": "baselines-select-page",
+                                          "title": "Select page (2)",
                                         },
                                         Object {
                                           "key": "select-none",
                                           "onClick": [Function],
-                                          "ouiaId": "select-none",
-                                          "title": "Select none",
+                                          "ouiaId": "baselines-select-none",
+                                          "title": "Select none (0)",
                                         },
                                       ]
                                     }
@@ -16816,16 +16811,16 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                           <DropdownItem
                                             component="button"
                                             onClick={[Function]}
-                                            ouiaId="OUIA-Generated-RHI/BulkSelect-5-select-all"
+                                            ouiaId="OUIA-Generated-RHI/BulkSelect-5-select-page"
                                           >
-                                            Select all
+                                            Select page (2)
                                           </DropdownItem>,
                                           <DropdownItem
                                             component="button"
                                             onClick={[Function]}
                                             ouiaId="OUIA-Generated-RHI/BulkSelect-5-select-none"
                                           >
-                                            Select none
+                                            Select none (0)
                                           </DropdownItem>,
                                         ]
                                       }
@@ -16844,7 +16839,7 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                                 <DropdownToggleCheckbox
                                                   aria-label="Select all"
                                                   className=""
-                                                  id="toggle-checkbox"
+                                                  id="baselines-bulk-select-toggle-checkbox"
                                                   isChecked={false}
                                                   isDisabled={false}
                                                   isValid={true}
@@ -16868,16 +16863,16 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                             <DropdownItem
                                               component="button"
                                               onClick={[Function]}
-                                              ouiaId="OUIA-Generated-RHI/BulkSelect-5-select-all"
+                                              ouiaId="OUIA-Generated-RHI/BulkSelect-5-select-page"
                                             >
-                                              Select all
+                                              Select page (2)
                                             </DropdownItem>,
                                             <DropdownItem
                                               component="button"
                                               onClick={[Function]}
                                               ouiaId="OUIA-Generated-RHI/BulkSelect-5-select-none"
                                             >
-                                              Select none
+                                              Select none (0)
                                             </DropdownItem>,
                                           ]
                                         }
@@ -16899,7 +16894,7 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                                   <DropdownToggleCheckbox
                                                     aria-label="Select all"
                                                     className=""
-                                                    id="toggle-checkbox"
+                                                    id="baselines-bulk-select-toggle-checkbox"
                                                     isChecked={false}
                                                     isDisabled={false}
                                                     isValid={true}
@@ -16945,7 +16940,7 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                                   >
                                                     <label
                                                       class="pf-c-dropdown__toggle-check"
-                                                      for="toggle-checkbox"
+                                                      for="baselines-bulk-select-toggle-checkbox"
                                                     >
                                                       <input
                                                         aria-invalid="false"
@@ -16953,7 +16948,7 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                                         data-ouia-component-id="OUIA-Generated-RHI/BulkSelect-5"
                                                         data-ouia-component-type="PF4/DropdownToggleCheckbox"
                                                         data-ouia-safe="true"
-                                                        id="toggle-checkbox"
+                                                        id="baselines-bulk-select-toggle-checkbox"
                                                         type="checkbox"
                                                       />
                                                       
@@ -16997,7 +16992,7 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                                   <DropdownToggleCheckbox
                                                     aria-label="Select all"
                                                     className=""
-                                                    id="toggle-checkbox"
+                                                    id="baselines-bulk-select-toggle-checkbox"
                                                     isChecked={false}
                                                     isDisabled={false}
                                                     isValid={true}
@@ -17016,7 +17011,7 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                               <DropdownToggleCheckbox
                                                 aria-label="Select all"
                                                 className=""
-                                                id="toggle-checkbox"
+                                                id="baselines-bulk-select-toggle-checkbox"
                                                 isChecked={false}
                                                 isDisabled={false}
                                                 isValid={true}
@@ -17025,7 +17020,7 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                               >
                                                 <label
                                                   className="pf-c-dropdown__toggle-check"
-                                                  htmlFor="toggle-checkbox"
+                                                  htmlFor="baselines-bulk-select-toggle-checkbox"
                                                 >
                                                   <input
                                                     aria-invalid={false}
@@ -17035,7 +17030,7 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                                     data-ouia-component-type="PF4/DropdownToggleCheckbox"
                                                     data-ouia-safe={true}
                                                     disabled={false}
-                                                    id="toggle-checkbox"
+                                                    id="baselines-bulk-select-toggle-checkbox"
                                                     onChange={[Function]}
                                                     type="checkbox"
                                                   />
@@ -17073,7 +17068,7 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                                       >
                                                         <label
                                                           class="pf-c-dropdown__toggle-check"
-                                                          for="toggle-checkbox"
+                                                          for="baselines-bulk-select-toggle-checkbox"
                                                         >
                                                           <input
                                                             aria-invalid="false"
@@ -17081,7 +17076,7 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                                             data-ouia-component-id="OUIA-Generated-RHI/BulkSelect-5"
                                                             data-ouia-component-type="PF4/DropdownToggleCheckbox"
                                                             data-ouia-safe="true"
-                                                            id="toggle-checkbox"
+                                                            id="baselines-bulk-select-toggle-checkbox"
                                                             type="checkbox"
                                                           />
                                                           
@@ -18054,6 +18049,7 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                               page={1}
                               perPage={20}
                               tableId="CHECKBOX"
+                              total={2}
                               updatePagination={[Function]}
                             >
                               <Pagination
@@ -18063,7 +18059,7 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                 isCompact={true}
                                 isDisabled={false}
                                 isSticky={false}
-                                itemCount={0}
+                                itemCount={2}
                                 itemsEnd={null}
                                 itemsStart={null}
                                 offset={0}
@@ -18128,22 +18124,22 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                     className="pf-c-pagination__total-items"
                                   >
                                     <ToggleTemplate
-                                      firstIndex={0}
-                                      itemCount={0}
+                                      firstIndex={1}
+                                      itemCount={2}
                                       itemsTitle=""
-                                      lastIndex={0}
+                                      lastIndex={2}
                                       ofWord="of"
                                     >
                                       <b>
-                                        0
+                                        1
                                          - 
-                                        0
+                                        2
                                       </b>
                                        
                                       of
                                        
                                       <b>
-                                        0
+                                        2
                                       </b>
                                        
                                     </ToggleTemplate>
@@ -18152,17 +18148,17 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                     className=""
                                     defaultToFullPage={false}
                                     dropDirection="down"
-                                    firstIndex={0}
+                                    firstIndex={1}
                                     isDisabled={false}
-                                    itemCount={0}
+                                    itemCount={2}
                                     itemsPerPageTitle="Items per page"
                                     itemsTitle=""
-                                    lastIndex={0}
-                                    lastPage={0}
+                                    lastIndex={2}
+                                    lastPage={1}
                                     ofWord="of"
                                     onPerPageSelect={[Function]}
                                     optionsToggle="Items per page"
-                                    page={0}
+                                    page={1}
                                     perPage={20}
                                     perPageOptions={
                                       Array [
@@ -18250,13 +18246,13 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                       position="left"
                                       toggle={
                                         <OptionsToggle
-                                          firstIndex={0}
+                                          firstIndex={1}
                                           isDisabled={false}
                                           isOpen={false}
-                                          itemCount={0}
+                                          itemCount={2}
                                           itemsPerPageTitle="Items per page"
                                           itemsTitle=""
-                                          lastIndex={0}
+                                          lastIndex={2}
                                           ofWord="of"
                                           onToggle={[Function]}
                                           optionsToggle="Items per page"
@@ -18274,18 +18270,18 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                       >
                                         <OptionsToggle
                                           aria-haspopup={true}
-                                          firstIndex={0}
+                                          firstIndex={1}
                                           getMenuRef={[Function]}
                                           id="pf-dropdown-toggle-id-27"
                                           isDisabled={false}
                                           isOpen={false}
                                           isPlain={true}
                                           isText={false}
-                                          itemCount={0}
+                                          itemCount={2}
                                           itemsPerPageTitle="Items per page"
                                           itemsTitle=""
                                           key=".0"
-                                          lastIndex={0}
+                                          lastIndex={2}
                                           ofWord="of"
                                           onEnter={[Function]}
                                           onToggle={[Function]}
@@ -18304,15 +18300,15 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                                     class="pf-c-options-menu__toggle-text"
                                                   >
                                                     <b>
-                                                      0
+                                                      1
                                                        - 
-                                                      0
+                                                      2
                                                     </b>
                                                      
                                                     of
                                                      
                                                     <b>
-                                                      0
+                                                      2
                                                     </b>
                                                      
                                                     
@@ -18360,22 +18356,22 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                               className="pf-c-options-menu__toggle-text"
                                             >
                                               <ToggleTemplate
-                                                firstIndex={0}
-                                                itemCount={0}
+                                                firstIndex={1}
+                                                itemCount={2}
                                                 itemsTitle=""
-                                                lastIndex={0}
+                                                lastIndex={2}
                                                 ofWord="of"
                                               >
                                                 <b>
-                                                  0
+                                                  1
                                                    - 
-                                                  0
+                                                  2
                                                 </b>
                                                  
                                                 of
                                                  
                                                 <b>
-                                                  0
+                                                  2
                                                 </b>
                                                  
                                               </ToggleTemplate>
@@ -18384,7 +18380,7 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                               aria-label="Items per page"
                                               className="pf-c-options-menu__toggle-button"
                                               id="pagination-options-menu-toggle-8"
-                                              isDisabled={0}
+                                              isDisabled={false}
                                               isOpen={false}
                                               onEnter={[Function]}
                                               onToggle={[Function]}
@@ -18402,15 +18398,15 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                                         class="pf-c-options-menu__toggle-text"
                                                       >
                                                         <b>
-                                                          0
+                                                          1
                                                            - 
-                                                          0
+                                                          2
                                                         </b>
                                                          
                                                         of
                                                          
                                                         <b>
-                                                          0
+                                                          2
                                                         </b>
                                                          
                                                         
@@ -18458,7 +18454,7 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                                 getMenuRef={null}
                                                 id="pagination-options-menu-toggle-8"
                                                 isActive={false}
-                                                isDisabled={0}
+                                                isDisabled={false}
                                                 isOpen={false}
                                                 isPlain={false}
                                                 isPrimary={false}
@@ -18480,15 +18476,15 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                                           class="pf-c-options-menu__toggle-text"
                                                         >
                                                           <b>
-                                                            0
+                                                            1
                                                              - 
-                                                            0
+                                                            2
                                                           </b>
                                                            
                                                           of
                                                            
                                                           <b>
-                                                            0
+                                                            2
                                                           </b>
                                                            
                                                           
@@ -18534,7 +18530,7 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                                   data-ouia-component-id="OUIA-Generated-DropdownToggle-9"
                                                   data-ouia-component-type="PF4/DropdownToggle"
                                                   data-ouia-safe={true}
-                                                  disabled={0}
+                                                  disabled={false}
                                                   id="pagination-options-menu-toggle-8"
                                                   onClick={[Function]}
                                                   onKeyDown={[Function]}
@@ -18582,8 +18578,8 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                     firstPage={1}
                                     isCompact={true}
                                     isDisabled={false}
-                                    itemCount={0}
-                                    lastPage={0}
+                                    itemCount={2}
+                                    lastPage={1}
                                     ofWord="of"
                                     onFirstClick={[Function]}
                                     onLastClick={[Function]}
@@ -18591,7 +18587,7 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                     onPageInput={[Function]}
                                     onPreviousClick={[Function]}
                                     onSetPage={[Function]}
-                                    page={0}
+                                    page={1}
                                     pagesTitle=""
                                     pagesTitlePlural=""
                                     paginationTitle="Pagination"
@@ -29848,6 +29844,7 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                             page={1}
                             perPage={20}
                             tableId="CHECKBOX"
+                            total={2}
                             updatePagination={[Function]}
                           >
                             <Pagination
@@ -29857,7 +29854,7 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                               isCompact={false}
                               isDisabled={false}
                               isSticky={false}
-                              itemCount={0}
+                              itemCount={2}
                               itemsEnd={null}
                               itemsStart={null}
                               offset={0}
@@ -29922,22 +29919,22 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                   className="pf-c-pagination__total-items"
                                 >
                                   <ToggleTemplate
-                                    firstIndex={0}
-                                    itemCount={0}
+                                    firstIndex={1}
+                                    itemCount={2}
                                     itemsTitle=""
-                                    lastIndex={0}
+                                    lastIndex={2}
                                     ofWord="of"
                                   >
                                     <b>
-                                      0
+                                      1
                                        - 
-                                      0
+                                      2
                                     </b>
                                      
                                     of
                                      
                                     <b>
-                                      0
+                                      2
                                     </b>
                                      
                                   </ToggleTemplate>
@@ -29946,17 +29943,17 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                   className=""
                                   defaultToFullPage={false}
                                   dropDirection="down"
-                                  firstIndex={0}
+                                  firstIndex={1}
                                   isDisabled={false}
-                                  itemCount={0}
+                                  itemCount={2}
                                   itemsPerPageTitle="Items per page"
                                   itemsTitle=""
-                                  lastIndex={0}
-                                  lastPage={0}
+                                  lastIndex={2}
+                                  lastPage={1}
                                   ofWord="of"
                                   onPerPageSelect={[Function]}
                                   optionsToggle="Items per page"
-                                  page={0}
+                                  page={1}
                                   perPage={20}
                                   perPageOptions={
                                     Array [
@@ -30044,13 +30041,13 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                     position="left"
                                     toggle={
                                       <OptionsToggle
-                                        firstIndex={0}
+                                        firstIndex={1}
                                         isDisabled={false}
                                         isOpen={false}
-                                        itemCount={0}
+                                        itemCount={2}
                                         itemsPerPageTitle="Items per page"
                                         itemsTitle=""
-                                        lastIndex={0}
+                                        lastIndex={2}
                                         ofWord="of"
                                         onToggle={[Function]}
                                         optionsToggle="Items per page"
@@ -30068,18 +30065,18 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                     >
                                       <OptionsToggle
                                         aria-haspopup={true}
-                                        firstIndex={0}
+                                        firstIndex={1}
                                         getMenuRef={[Function]}
                                         id="pf-dropdown-toggle-id-28"
                                         isDisabled={false}
                                         isOpen={false}
                                         isPlain={true}
                                         isText={false}
-                                        itemCount={0}
+                                        itemCount={2}
                                         itemsPerPageTitle="Items per page"
                                         itemsTitle=""
                                         key=".0"
-                                        lastIndex={0}
+                                        lastIndex={2}
                                         ofWord="of"
                                         onEnter={[Function]}
                                         onToggle={[Function]}
@@ -30098,15 +30095,15 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                                   class="pf-c-options-menu__toggle-text"
                                                 >
                                                   <b>
-                                                    0
+                                                    1
                                                      - 
-                                                    0
+                                                    2
                                                   </b>
                                                    
                                                   of
                                                    
                                                   <b>
-                                                    0
+                                                    2
                                                   </b>
                                                    
                                                   
@@ -30154,22 +30151,22 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                             className="pf-c-options-menu__toggle-text"
                                           >
                                             <ToggleTemplate
-                                              firstIndex={0}
-                                              itemCount={0}
+                                              firstIndex={1}
+                                              itemCount={2}
                                               itemsTitle=""
-                                              lastIndex={0}
+                                              lastIndex={2}
                                               ofWord="of"
                                             >
                                               <b>
-                                                0
+                                                1
                                                  - 
-                                                0
+                                                2
                                               </b>
                                                
                                               of
                                                
                                               <b>
-                                                0
+                                                2
                                               </b>
                                                
                                             </ToggleTemplate>
@@ -30178,7 +30175,7 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                             aria-label="Items per page"
                                             className="pf-c-options-menu__toggle-button"
                                             id="pagination-options-menu-toggle-9"
-                                            isDisabled={0}
+                                            isDisabled={false}
                                             isOpen={false}
                                             onEnter={[Function]}
                                             onToggle={[Function]}
@@ -30196,15 +30193,15 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                                       class="pf-c-options-menu__toggle-text"
                                                     >
                                                       <b>
-                                                        0
+                                                        1
                                                          - 
-                                                        0
+                                                        2
                                                       </b>
                                                        
                                                       of
                                                        
                                                       <b>
-                                                        0
+                                                        2
                                                       </b>
                                                        
                                                       
@@ -30252,7 +30249,7 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                               getMenuRef={null}
                                               id="pagination-options-menu-toggle-9"
                                               isActive={false}
-                                              isDisabled={0}
+                                              isDisabled={false}
                                               isOpen={false}
                                               isPlain={false}
                                               isPrimary={false}
@@ -30274,15 +30271,15 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                                         class="pf-c-options-menu__toggle-text"
                                                       >
                                                         <b>
-                                                          0
+                                                          1
                                                            - 
-                                                          0
+                                                          2
                                                         </b>
                                                          
                                                         of
                                                          
                                                         <b>
-                                                          0
+                                                          2
                                                         </b>
                                                          
                                                         
@@ -30328,7 +30325,7 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                                 data-ouia-component-id="OUIA-Generated-DropdownToggle-10"
                                                 data-ouia-component-type="PF4/DropdownToggle"
                                                 data-ouia-safe={true}
-                                                disabled={0}
+                                                disabled={false}
                                                 id="pagination-options-menu-toggle-9"
                                                 onClick={[Function]}
                                                 onKeyDown={[Function]}
@@ -30376,8 +30373,8 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                   firstPage={1}
                                   isCompact={false}
                                   isDisabled={false}
-                                  itemCount={0}
-                                  lastPage={0}
+                                  itemCount={2}
+                                  lastPage={1}
                                   ofWord="of"
                                   onFirstClick={[Function]}
                                   onLastClick={[Function]}
@@ -30385,7 +30382,7 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                   onPageInput={[Function]}
                                   onPreviousClick={[Function]}
                                   onSetPage={[Function]}
-                                  page={0}
+                                  page={1}
                                   pagesTitle=""
                                   pagesTitlePlural=""
                                   paginationTitle="Pagination"
@@ -30526,19 +30523,19 @@ exports[`ConnectedBaselinesTable should render loading rows for multi-select 1`]
                                         aria-label="Current page"
                                         className="pf-c-form-control"
                                         disabled={true}
-                                        max={0}
+                                        max={1}
                                         min={1}
                                         onChange={[Function]}
                                         onKeyDown={[Function]}
                                         type="number"
-                                        value={0}
+                                        value={1}
                                       />
                                       <span
                                         aria-hidden="true"
                                       >
                                         of
                                          
-                                        0
+                                        1
                                       </span>
                                     </div>
                                     <div
@@ -30769,6 +30766,7 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
     >
       <Connect(BaselinesTable)
         basketIsVisible={false}
+        bulkSelectItems={[MockFunction]}
         columns={
           Array [
             Object {
@@ -30793,7 +30791,6 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
         }
         createButton={true}
         exportButton={true}
-        fetchBaselines={[MockFunction]}
         hasMultiSelect={false}
         kebab={true}
         loading={true}
@@ -30803,6 +30800,7 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
             "baselinesWrite": true,
           }
         }
+        selectBaseline={[MockFunction]}
         selectedBaselineIds={Array []}
         tableData={
           Array [
@@ -30823,9 +30821,11 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
           ]
         }
         tableId="CHECKBOX"
+        totalBaselines={2}
       >
         <BaselinesTable
           basketIsVisible={false}
+          bulkSelectItems={[MockFunction]}
           columns={
             Array [
               Object {
@@ -30862,6 +30862,7 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
               "baselinesWrite": true,
             }
           }
+          selectBaseline={[MockFunction]}
           selectedBaselineIds={Array []}
           tableData={
             Array [
@@ -30885,6 +30886,7 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
           toggleNotificationFulfilled={[Function]}
           toggleNotificationPending={[Function]}
           toggleNotificationRejected={[Function]}
+          totalBaselines={2}
         >
           <BaselinesToolbar
             createButton={true}
@@ -30896,6 +30898,7 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
             isDeleteDisabled={true}
             kebab={true}
             loading={true}
+            onBulkSelect={[Function]}
             onSearch={[Function]}
             page={1}
             perPage={20}
@@ -30925,6 +30928,7 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
               ]
             }
             tableId="CHECKBOX"
+            totalBaselines={2}
             updatePagination={[Function]}
           >
             <Connect(DeleteBaselinesModal)
@@ -31924,6 +31928,7 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
                               page={1}
                               perPage={20}
                               tableId="CHECKBOX"
+                              total={2}
                               updatePagination={[Function]}
                             >
                               <Pagination
@@ -31933,7 +31938,7 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
                                 isCompact={true}
                                 isDisabled={false}
                                 isSticky={false}
-                                itemCount={0}
+                                itemCount={2}
                                 itemsEnd={null}
                                 itemsStart={null}
                                 offset={0}
@@ -31998,22 +32003,22 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
                                     className="pf-c-pagination__total-items"
                                   >
                                     <ToggleTemplate
-                                      firstIndex={0}
-                                      itemCount={0}
+                                      firstIndex={1}
+                                      itemCount={2}
                                       itemsTitle=""
-                                      lastIndex={0}
+                                      lastIndex={2}
                                       ofWord="of"
                                     >
                                       <b>
-                                        0
+                                        1
                                          - 
-                                        0
+                                        2
                                       </b>
                                        
                                       of
                                        
                                       <b>
-                                        0
+                                        2
                                       </b>
                                        
                                     </ToggleTemplate>
@@ -32022,17 +32027,17 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
                                     className=""
                                     defaultToFullPage={false}
                                     dropDirection="down"
-                                    firstIndex={0}
+                                    firstIndex={1}
                                     isDisabled={false}
-                                    itemCount={0}
+                                    itemCount={2}
                                     itemsPerPageTitle="Items per page"
                                     itemsTitle=""
-                                    lastIndex={0}
-                                    lastPage={0}
+                                    lastIndex={2}
+                                    lastPage={1}
                                     ofWord="of"
                                     onPerPageSelect={[Function]}
                                     optionsToggle="Items per page"
-                                    page={0}
+                                    page={1}
                                     perPage={20}
                                     perPageOptions={
                                       Array [
@@ -32120,13 +32125,13 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
                                       position="left"
                                       toggle={
                                         <OptionsToggle
-                                          firstIndex={0}
+                                          firstIndex={1}
                                           isDisabled={false}
                                           isOpen={false}
-                                          itemCount={0}
+                                          itemCount={2}
                                           itemsPerPageTitle="Items per page"
                                           itemsTitle=""
-                                          lastIndex={0}
+                                          lastIndex={2}
                                           ofWord="of"
                                           onToggle={[Function]}
                                           optionsToggle="Items per page"
@@ -32144,18 +32149,18 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
                                       >
                                         <OptionsToggle
                                           aria-haspopup={true}
-                                          firstIndex={0}
+                                          firstIndex={1}
                                           getMenuRef={[Function]}
                                           id="pf-dropdown-toggle-id-31"
                                           isDisabled={false}
                                           isOpen={false}
                                           isPlain={true}
                                           isText={false}
-                                          itemCount={0}
+                                          itemCount={2}
                                           itemsPerPageTitle="Items per page"
                                           itemsTitle=""
                                           key=".0"
-                                          lastIndex={0}
+                                          lastIndex={2}
                                           ofWord="of"
                                           onEnter={[Function]}
                                           onToggle={[Function]}
@@ -32174,15 +32179,15 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
                                                     class="pf-c-options-menu__toggle-text"
                                                   >
                                                     <b>
-                                                      0
+                                                      1
                                                        - 
-                                                      0
+                                                      2
                                                     </b>
                                                      
                                                     of
                                                      
                                                     <b>
-                                                      0
+                                                      2
                                                     </b>
                                                      
                                                     
@@ -32230,22 +32235,22 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
                                               className="pf-c-options-menu__toggle-text"
                                             >
                                               <ToggleTemplate
-                                                firstIndex={0}
-                                                itemCount={0}
+                                                firstIndex={1}
+                                                itemCount={2}
                                                 itemsTitle=""
-                                                lastIndex={0}
+                                                lastIndex={2}
                                                 ofWord="of"
                                               >
                                                 <b>
-                                                  0
+                                                  1
                                                    - 
-                                                  0
+                                                  2
                                                 </b>
                                                  
                                                 of
                                                  
                                                 <b>
-                                                  0
+                                                  2
                                                 </b>
                                                  
                                               </ToggleTemplate>
@@ -32254,7 +32259,7 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
                                               aria-label="Items per page"
                                               className="pf-c-options-menu__toggle-button"
                                               id="pagination-options-menu-toggle-10"
-                                              isDisabled={0}
+                                              isDisabled={false}
                                               isOpen={false}
                                               onEnter={[Function]}
                                               onToggle={[Function]}
@@ -32272,15 +32277,15 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
                                                         class="pf-c-options-menu__toggle-text"
                                                       >
                                                         <b>
-                                                          0
+                                                          1
                                                            - 
-                                                          0
+                                                          2
                                                         </b>
                                                          
                                                         of
                                                          
                                                         <b>
-                                                          0
+                                                          2
                                                         </b>
                                                          
                                                         
@@ -32328,7 +32333,7 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
                                                 getMenuRef={null}
                                                 id="pagination-options-menu-toggle-10"
                                                 isActive={false}
-                                                isDisabled={0}
+                                                isDisabled={false}
                                                 isOpen={false}
                                                 isPlain={false}
                                                 isPrimary={false}
@@ -32350,15 +32355,15 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
                                                           class="pf-c-options-menu__toggle-text"
                                                         >
                                                           <b>
-                                                            0
+                                                            1
                                                              - 
-                                                            0
+                                                            2
                                                           </b>
                                                            
                                                           of
                                                            
                                                           <b>
-                                                            0
+                                                            2
                                                           </b>
                                                            
                                                           
@@ -32404,7 +32409,7 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
                                                   data-ouia-component-id="OUIA-Generated-DropdownToggle-11"
                                                   data-ouia-component-type="PF4/DropdownToggle"
                                                   data-ouia-safe={true}
-                                                  disabled={0}
+                                                  disabled={false}
                                                   id="pagination-options-menu-toggle-10"
                                                   onClick={[Function]}
                                                   onKeyDown={[Function]}
@@ -32452,8 +32457,8 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
                                     firstPage={1}
                                     isCompact={true}
                                     isDisabled={false}
-                                    itemCount={0}
-                                    lastPage={0}
+                                    itemCount={2}
+                                    lastPage={1}
                                     ofWord="of"
                                     onFirstClick={[Function]}
                                     onLastClick={[Function]}
@@ -32461,7 +32466,7 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
                                     onPageInput={[Function]}
                                     onPreviousClick={[Function]}
                                     onSetPage={[Function]}
-                                    page={0}
+                                    page={1}
                                     pagesTitle=""
                                     pagesTitlePlural=""
                                     paginationTitle="Pagination"
@@ -43718,6 +43723,7 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
                             page={1}
                             perPage={20}
                             tableId="CHECKBOX"
+                            total={2}
                             updatePagination={[Function]}
                           >
                             <Pagination
@@ -43727,7 +43733,7 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
                               isCompact={false}
                               isDisabled={false}
                               isSticky={false}
-                              itemCount={0}
+                              itemCount={2}
                               itemsEnd={null}
                               itemsStart={null}
                               offset={0}
@@ -43792,22 +43798,22 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
                                   className="pf-c-pagination__total-items"
                                 >
                                   <ToggleTemplate
-                                    firstIndex={0}
-                                    itemCount={0}
+                                    firstIndex={1}
+                                    itemCount={2}
                                     itemsTitle=""
-                                    lastIndex={0}
+                                    lastIndex={2}
                                     ofWord="of"
                                   >
                                     <b>
-                                      0
+                                      1
                                        - 
-                                      0
+                                      2
                                     </b>
                                      
                                     of
                                      
                                     <b>
-                                      0
+                                      2
                                     </b>
                                      
                                   </ToggleTemplate>
@@ -43816,17 +43822,17 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
                                   className=""
                                   defaultToFullPage={false}
                                   dropDirection="down"
-                                  firstIndex={0}
+                                  firstIndex={1}
                                   isDisabled={false}
-                                  itemCount={0}
+                                  itemCount={2}
                                   itemsPerPageTitle="Items per page"
                                   itemsTitle=""
-                                  lastIndex={0}
-                                  lastPage={0}
+                                  lastIndex={2}
+                                  lastPage={1}
                                   ofWord="of"
                                   onPerPageSelect={[Function]}
                                   optionsToggle="Items per page"
-                                  page={0}
+                                  page={1}
                                   perPage={20}
                                   perPageOptions={
                                     Array [
@@ -43914,13 +43920,13 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
                                     position="left"
                                     toggle={
                                       <OptionsToggle
-                                        firstIndex={0}
+                                        firstIndex={1}
                                         isDisabled={false}
                                         isOpen={false}
-                                        itemCount={0}
+                                        itemCount={2}
                                         itemsPerPageTitle="Items per page"
                                         itemsTitle=""
-                                        lastIndex={0}
+                                        lastIndex={2}
                                         ofWord="of"
                                         onToggle={[Function]}
                                         optionsToggle="Items per page"
@@ -43938,18 +43944,18 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
                                     >
                                       <OptionsToggle
                                         aria-haspopup={true}
-                                        firstIndex={0}
+                                        firstIndex={1}
                                         getMenuRef={[Function]}
                                         id="pf-dropdown-toggle-id-32"
                                         isDisabled={false}
                                         isOpen={false}
                                         isPlain={true}
                                         isText={false}
-                                        itemCount={0}
+                                        itemCount={2}
                                         itemsPerPageTitle="Items per page"
                                         itemsTitle=""
                                         key=".0"
-                                        lastIndex={0}
+                                        lastIndex={2}
                                         ofWord="of"
                                         onEnter={[Function]}
                                         onToggle={[Function]}
@@ -43968,15 +43974,15 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
                                                   class="pf-c-options-menu__toggle-text"
                                                 >
                                                   <b>
-                                                    0
+                                                    1
                                                      - 
-                                                    0
+                                                    2
                                                   </b>
                                                    
                                                   of
                                                    
                                                   <b>
-                                                    0
+                                                    2
                                                   </b>
                                                    
                                                   
@@ -44024,22 +44030,22 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
                                             className="pf-c-options-menu__toggle-text"
                                           >
                                             <ToggleTemplate
-                                              firstIndex={0}
-                                              itemCount={0}
+                                              firstIndex={1}
+                                              itemCount={2}
                                               itemsTitle=""
-                                              lastIndex={0}
+                                              lastIndex={2}
                                               ofWord="of"
                                             >
                                               <b>
-                                                0
+                                                1
                                                  - 
-                                                0
+                                                2
                                               </b>
                                                
                                               of
                                                
                                               <b>
-                                                0
+                                                2
                                               </b>
                                                
                                             </ToggleTemplate>
@@ -44048,7 +44054,7 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
                                             aria-label="Items per page"
                                             className="pf-c-options-menu__toggle-button"
                                             id="pagination-options-menu-toggle-11"
-                                            isDisabled={0}
+                                            isDisabled={false}
                                             isOpen={false}
                                             onEnter={[Function]}
                                             onToggle={[Function]}
@@ -44066,15 +44072,15 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
                                                       class="pf-c-options-menu__toggle-text"
                                                     >
                                                       <b>
-                                                        0
+                                                        1
                                                          - 
-                                                        0
+                                                        2
                                                       </b>
                                                        
                                                       of
                                                        
                                                       <b>
-                                                        0
+                                                        2
                                                       </b>
                                                        
                                                       
@@ -44122,7 +44128,7 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
                                               getMenuRef={null}
                                               id="pagination-options-menu-toggle-11"
                                               isActive={false}
-                                              isDisabled={0}
+                                              isDisabled={false}
                                               isOpen={false}
                                               isPlain={false}
                                               isPrimary={false}
@@ -44144,15 +44150,15 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
                                                         class="pf-c-options-menu__toggle-text"
                                                       >
                                                         <b>
-                                                          0
+                                                          1
                                                            - 
-                                                          0
+                                                          2
                                                         </b>
                                                          
                                                         of
                                                          
                                                         <b>
-                                                          0
+                                                          2
                                                         </b>
                                                          
                                                         
@@ -44198,7 +44204,7 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
                                                 data-ouia-component-id="OUIA-Generated-DropdownToggle-12"
                                                 data-ouia-component-type="PF4/DropdownToggle"
                                                 data-ouia-safe={true}
-                                                disabled={0}
+                                                disabled={false}
                                                 id="pagination-options-menu-toggle-11"
                                                 onClick={[Function]}
                                                 onKeyDown={[Function]}
@@ -44246,8 +44252,8 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
                                   firstPage={1}
                                   isCompact={false}
                                   isDisabled={false}
-                                  itemCount={0}
-                                  lastPage={0}
+                                  itemCount={2}
+                                  lastPage={1}
                                   ofWord="of"
                                   onFirstClick={[Function]}
                                   onLastClick={[Function]}
@@ -44255,7 +44261,7 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
                                   onPageInput={[Function]}
                                   onPreviousClick={[Function]}
                                   onSetPage={[Function]}
-                                  page={0}
+                                  page={1}
                                   pagesTitle=""
                                   pagesTitlePlural=""
                                   paginationTitle="Pagination"
@@ -44396,19 +44402,19 @@ exports[`ConnectedBaselinesTable should render loading rows for single-select 1`
                                         aria-label="Current page"
                                         className="pf-c-form-control"
                                         disabled={true}
-                                        max={0}
+                                        max={1}
                                         min={1}
                                         onChange={[Function]}
                                         onKeyDown={[Function]}
                                         type="number"
-                                        value={0}
+                                        value={1}
                                       />
                                       <span
                                         aria-hidden="true"
                                       >
                                         of
                                          
-                                        0
+                                        1
                                       </span>
                                     </div>
                                     <div
@@ -44639,6 +44645,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
     >
       <Connect(BaselinesTable)
         basketIsVisible={false}
+        bulkSelectItems={[MockFunction]}
         columns={
           Array [
             Object {
@@ -44663,7 +44670,6 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
         }
         createButton={true}
         exportButton={true}
-        fetchBaselines={[MockFunction]}
         hasMultiSelect={true}
         kebab={true}
         loading={false}
@@ -44673,6 +44679,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
             "baselinesWrite": true,
           }
         }
+        selectBaseline={[MockFunction]}
         selectedBaselineIds={Array []}
         tableData={
           Array [
@@ -44693,9 +44700,11 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
           ]
         }
         tableId="CHECKBOX"
+        totalBaselines={2}
       >
         <BaselinesTable
           basketIsVisible={false}
+          bulkSelectItems={[MockFunction]}
           columns={
             Array [
               Object {
@@ -44732,6 +44741,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
               "baselinesWrite": true,
             }
           }
+          selectBaseline={[MockFunction]}
           selectedBaselineIds={Array []}
           tableData={
             Array [
@@ -44755,6 +44765,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
           toggleNotificationFulfilled={[Function]}
           toggleNotificationPending={[Function]}
           toggleNotificationRejected={[Function]}
+          totalBaselines={2}
         >
           <BaselinesToolbar
             createButton={true}
@@ -44766,6 +44777,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
             isDeleteDisabled={true}
             kebab={true}
             loading={false}
+            onBulkSelect={[Function]}
             onSearch={[Function]}
             page={1}
             perPage={20}
@@ -44795,6 +44807,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
               ]
             }
             tableId="CHECKBOX"
+            totalBaselines={2}
             updatePagination={[Function]}
           >
             <Connect(DeleteBaselinesModal)
@@ -44932,21 +44945,22 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                 >
                                   <BulkSelect
                                     checked={false}
-                                    count={null}
+                                    count={0}
+                                    id="baselines-bulk-select"
                                     isDisabled={false}
                                     items={
                                       Array [
                                         Object {
-                                          "key": "select-all",
+                                          "key": "select-page",
                                           "onClick": [Function],
-                                          "ouiaId": "select-all",
-                                          "title": "Select all",
+                                          "ouiaId": "baselines-select-page",
+                                          "title": "Select page (2)",
                                         },
                                         Object {
                                           "key": "select-none",
                                           "onClick": [Function],
-                                          "ouiaId": "select-none",
-                                          "title": "Select none",
+                                          "ouiaId": "baselines-select-none",
+                                          "title": "Select none (0)",
                                         },
                                       ]
                                     }
@@ -44959,16 +44973,16 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                           <DropdownItem
                                             component="button"
                                             onClick={[Function]}
-                                            ouiaId="OUIA-Generated-RHI/BulkSelect-3-select-all"
+                                            ouiaId="OUIA-Generated-RHI/BulkSelect-3-select-page"
                                           >
-                                            Select all
+                                            Select page (2)
                                           </DropdownItem>,
                                           <DropdownItem
                                             component="button"
                                             onClick={[Function]}
                                             ouiaId="OUIA-Generated-RHI/BulkSelect-3-select-none"
                                           >
-                                            Select none
+                                            Select none (0)
                                           </DropdownItem>,
                                         ]
                                       }
@@ -44987,7 +45001,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                                 <DropdownToggleCheckbox
                                                   aria-label="Select all"
                                                   className=""
-                                                  id="toggle-checkbox"
+                                                  id="baselines-bulk-select-toggle-checkbox"
                                                   isChecked={false}
                                                   isDisabled={false}
                                                   isValid={true}
@@ -45011,16 +45025,16 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                             <DropdownItem
                                               component="button"
                                               onClick={[Function]}
-                                              ouiaId="OUIA-Generated-RHI/BulkSelect-3-select-all"
+                                              ouiaId="OUIA-Generated-RHI/BulkSelect-3-select-page"
                                             >
-                                              Select all
+                                              Select page (2)
                                             </DropdownItem>,
                                             <DropdownItem
                                               component="button"
                                               onClick={[Function]}
                                               ouiaId="OUIA-Generated-RHI/BulkSelect-3-select-none"
                                             >
-                                              Select none
+                                              Select none (0)
                                             </DropdownItem>,
                                           ]
                                         }
@@ -45042,7 +45056,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                                   <DropdownToggleCheckbox
                                                     aria-label="Select all"
                                                     className=""
-                                                    id="toggle-checkbox"
+                                                    id="baselines-bulk-select-toggle-checkbox"
                                                     isChecked={false}
                                                     isDisabled={false}
                                                     isValid={true}
@@ -45088,7 +45102,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                                   >
                                                     <label
                                                       class="pf-c-dropdown__toggle-check"
-                                                      for="toggle-checkbox"
+                                                      for="baselines-bulk-select-toggle-checkbox"
                                                     >
                                                       <input
                                                         aria-invalid="false"
@@ -45096,7 +45110,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                                         data-ouia-component-id="OUIA-Generated-RHI/BulkSelect-3"
                                                         data-ouia-component-type="PF4/DropdownToggleCheckbox"
                                                         data-ouia-safe="true"
-                                                        id="toggle-checkbox"
+                                                        id="baselines-bulk-select-toggle-checkbox"
                                                         type="checkbox"
                                                       />
                                                       
@@ -45140,7 +45154,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                                   <DropdownToggleCheckbox
                                                     aria-label="Select all"
                                                     className=""
-                                                    id="toggle-checkbox"
+                                                    id="baselines-bulk-select-toggle-checkbox"
                                                     isChecked={false}
                                                     isDisabled={false}
                                                     isValid={true}
@@ -45159,7 +45173,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                               <DropdownToggleCheckbox
                                                 aria-label="Select all"
                                                 className=""
-                                                id="toggle-checkbox"
+                                                id="baselines-bulk-select-toggle-checkbox"
                                                 isChecked={false}
                                                 isDisabled={false}
                                                 isValid={true}
@@ -45168,7 +45182,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                               >
                                                 <label
                                                   className="pf-c-dropdown__toggle-check"
-                                                  htmlFor="toggle-checkbox"
+                                                  htmlFor="baselines-bulk-select-toggle-checkbox"
                                                 >
                                                   <input
                                                     aria-invalid={false}
@@ -45178,7 +45192,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                                     data-ouia-component-type="PF4/DropdownToggleCheckbox"
                                                     data-ouia-safe={true}
                                                     disabled={false}
-                                                    id="toggle-checkbox"
+                                                    id="baselines-bulk-select-toggle-checkbox"
                                                     onChange={[Function]}
                                                     type="checkbox"
                                                   />
@@ -45216,7 +45230,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                                       >
                                                         <label
                                                           class="pf-c-dropdown__toggle-check"
-                                                          for="toggle-checkbox"
+                                                          for="baselines-bulk-select-toggle-checkbox"
                                                         >
                                                           <input
                                                             aria-invalid="false"
@@ -45224,7 +45238,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                                             data-ouia-component-id="OUIA-Generated-RHI/BulkSelect-3"
                                                             data-ouia-component-type="PF4/DropdownToggleCheckbox"
                                                             data-ouia-safe="true"
-                                                            id="toggle-checkbox"
+                                                            id="baselines-bulk-select-toggle-checkbox"
                                                             type="checkbox"
                                                           />
                                                           
@@ -46196,6 +46210,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                               page={1}
                               perPage={20}
                               tableId="CHECKBOX"
+                              total={2}
                               updatePagination={[Function]}
                             >
                               <Pagination
@@ -46205,7 +46220,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                 isCompact={true}
                                 isDisabled={false}
                                 isSticky={false}
-                                itemCount={0}
+                                itemCount={2}
                                 itemsEnd={null}
                                 itemsStart={null}
                                 offset={0}
@@ -46270,22 +46285,22 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                     className="pf-c-pagination__total-items"
                                   >
                                     <ToggleTemplate
-                                      firstIndex={0}
-                                      itemCount={0}
+                                      firstIndex={1}
+                                      itemCount={2}
                                       itemsTitle=""
-                                      lastIndex={0}
+                                      lastIndex={2}
                                       ofWord="of"
                                     >
                                       <b>
-                                        0
+                                        1
                                          - 
-                                        0
+                                        2
                                       </b>
                                        
                                       of
                                        
                                       <b>
-                                        0
+                                        2
                                       </b>
                                        
                                     </ToggleTemplate>
@@ -46294,17 +46309,17 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                     className=""
                                     defaultToFullPage={false}
                                     dropDirection="down"
-                                    firstIndex={0}
+                                    firstIndex={1}
                                     isDisabled={false}
-                                    itemCount={0}
+                                    itemCount={2}
                                     itemsPerPageTitle="Items per page"
                                     itemsTitle=""
-                                    lastIndex={0}
-                                    lastPage={0}
+                                    lastIndex={2}
+                                    lastPage={1}
                                     ofWord="of"
                                     onPerPageSelect={[Function]}
                                     optionsToggle="Items per page"
-                                    page={0}
+                                    page={1}
                                     perPage={20}
                                     perPageOptions={
                                       Array [
@@ -46392,13 +46407,13 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                       position="left"
                                       toggle={
                                         <OptionsToggle
-                                          firstIndex={0}
+                                          firstIndex={1}
                                           isDisabled={false}
                                           isOpen={false}
-                                          itemCount={0}
+                                          itemCount={2}
                                           itemsPerPageTitle="Items per page"
                                           itemsTitle=""
-                                          lastIndex={0}
+                                          lastIndex={2}
                                           ofWord="of"
                                           onToggle={[Function]}
                                           optionsToggle="Items per page"
@@ -46416,18 +46431,18 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                       >
                                         <OptionsToggle
                                           aria-haspopup={true}
-                                          firstIndex={0}
+                                          firstIndex={1}
                                           getMenuRef={[Function]}
                                           id="pf-dropdown-toggle-id-15"
                                           isDisabled={false}
                                           isOpen={false}
                                           isPlain={true}
                                           isText={false}
-                                          itemCount={0}
+                                          itemCount={2}
                                           itemsPerPageTitle="Items per page"
                                           itemsTitle=""
                                           key=".0"
-                                          lastIndex={0}
+                                          lastIndex={2}
                                           ofWord="of"
                                           onEnter={[Function]}
                                           onToggle={[Function]}
@@ -46446,15 +46461,15 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                                     class="pf-c-options-menu__toggle-text"
                                                   >
                                                     <b>
-                                                      0
+                                                      1
                                                        - 
-                                                      0
+                                                      2
                                                     </b>
                                                      
                                                     of
                                                      
                                                     <b>
-                                                      0
+                                                      2
                                                     </b>
                                                      
                                                     
@@ -46502,22 +46517,22 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                               className="pf-c-options-menu__toggle-text"
                                             >
                                               <ToggleTemplate
-                                                firstIndex={0}
-                                                itemCount={0}
+                                                firstIndex={1}
+                                                itemCount={2}
                                                 itemsTitle=""
-                                                lastIndex={0}
+                                                lastIndex={2}
                                                 ofWord="of"
                                               >
                                                 <b>
-                                                  0
+                                                  1
                                                    - 
-                                                  0
+                                                  2
                                                 </b>
                                                  
                                                 of
                                                  
                                                 <b>
-                                                  0
+                                                  2
                                                 </b>
                                                  
                                               </ToggleTemplate>
@@ -46526,7 +46541,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                               aria-label="Items per page"
                                               className="pf-c-options-menu__toggle-button"
                                               id="pagination-options-menu-toggle-4"
-                                              isDisabled={0}
+                                              isDisabled={false}
                                               isOpen={false}
                                               onEnter={[Function]}
                                               onToggle={[Function]}
@@ -46544,15 +46559,15 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                                         class="pf-c-options-menu__toggle-text"
                                                       >
                                                         <b>
-                                                          0
+                                                          1
                                                            - 
-                                                          0
+                                                          2
                                                         </b>
                                                          
                                                         of
                                                          
                                                         <b>
-                                                          0
+                                                          2
                                                         </b>
                                                          
                                                         
@@ -46600,7 +46615,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                                 getMenuRef={null}
                                                 id="pagination-options-menu-toggle-4"
                                                 isActive={false}
-                                                isDisabled={0}
+                                                isDisabled={false}
                                                 isOpen={false}
                                                 isPlain={false}
                                                 isPrimary={false}
@@ -46622,15 +46637,15 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                                           class="pf-c-options-menu__toggle-text"
                                                         >
                                                           <b>
-                                                            0
+                                                            1
                                                              - 
-                                                            0
+                                                            2
                                                           </b>
                                                            
                                                           of
                                                            
                                                           <b>
-                                                            0
+                                                            2
                                                           </b>
                                                            
                                                           
@@ -46676,7 +46691,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                                   data-ouia-component-id="OUIA-Generated-DropdownToggle-5"
                                                   data-ouia-component-type="PF4/DropdownToggle"
                                                   data-ouia-safe={true}
-                                                  disabled={0}
+                                                  disabled={false}
                                                   id="pagination-options-menu-toggle-4"
                                                   onClick={[Function]}
                                                   onKeyDown={[Function]}
@@ -46724,8 +46739,8 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                     firstPage={1}
                                     isCompact={true}
                                     isDisabled={false}
-                                    itemCount={0}
-                                    lastPage={0}
+                                    itemCount={2}
+                                    lastPage={1}
                                     ofWord="of"
                                     onFirstClick={[Function]}
                                     onLastClick={[Function]}
@@ -46733,7 +46748,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                     onPageInput={[Function]}
                                     onPreviousClick={[Function]}
                                     onSetPage={[Function]}
-                                    page={0}
+                                    page={1}
                                     pagesTitle=""
                                     pagesTitlePlural=""
                                     paginationTitle="Pagination"
@@ -51819,6 +51834,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                             page={1}
                             perPage={20}
                             tableId="CHECKBOX"
+                            total={2}
                             updatePagination={[Function]}
                           >
                             <Pagination
@@ -51828,7 +51844,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                               isCompact={false}
                               isDisabled={false}
                               isSticky={false}
-                              itemCount={0}
+                              itemCount={2}
                               itemsEnd={null}
                               itemsStart={null}
                               offset={0}
@@ -51893,22 +51909,22 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                   className="pf-c-pagination__total-items"
                                 >
                                   <ToggleTemplate
-                                    firstIndex={0}
-                                    itemCount={0}
+                                    firstIndex={1}
+                                    itemCount={2}
                                     itemsTitle=""
-                                    lastIndex={0}
+                                    lastIndex={2}
                                     ofWord="of"
                                   >
                                     <b>
-                                      0
+                                      1
                                        - 
-                                      0
+                                      2
                                     </b>
                                      
                                     of
                                      
                                     <b>
-                                      0
+                                      2
                                     </b>
                                      
                                   </ToggleTemplate>
@@ -51917,17 +51933,17 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                   className=""
                                   defaultToFullPage={false}
                                   dropDirection="down"
-                                  firstIndex={0}
+                                  firstIndex={1}
                                   isDisabled={false}
-                                  itemCount={0}
+                                  itemCount={2}
                                   itemsPerPageTitle="Items per page"
                                   itemsTitle=""
-                                  lastIndex={0}
-                                  lastPage={0}
+                                  lastIndex={2}
+                                  lastPage={1}
                                   ofWord="of"
                                   onPerPageSelect={[Function]}
                                   optionsToggle="Items per page"
-                                  page={0}
+                                  page={1}
                                   perPage={20}
                                   perPageOptions={
                                     Array [
@@ -52015,13 +52031,13 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                     position="left"
                                     toggle={
                                       <OptionsToggle
-                                        firstIndex={0}
+                                        firstIndex={1}
                                         isDisabled={false}
                                         isOpen={false}
-                                        itemCount={0}
+                                        itemCount={2}
                                         itemsPerPageTitle="Items per page"
                                         itemsTitle=""
-                                        lastIndex={0}
+                                        lastIndex={2}
                                         ofWord="of"
                                         onToggle={[Function]}
                                         optionsToggle="Items per page"
@@ -52039,18 +52055,18 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                     >
                                       <OptionsToggle
                                         aria-haspopup={true}
-                                        firstIndex={0}
+                                        firstIndex={1}
                                         getMenuRef={[Function]}
                                         id="pf-dropdown-toggle-id-18"
                                         isDisabled={false}
                                         isOpen={false}
                                         isPlain={true}
                                         isText={false}
-                                        itemCount={0}
+                                        itemCount={2}
                                         itemsPerPageTitle="Items per page"
                                         itemsTitle=""
                                         key=".0"
-                                        lastIndex={0}
+                                        lastIndex={2}
                                         ofWord="of"
                                         onEnter={[Function]}
                                         onToggle={[Function]}
@@ -52069,15 +52085,15 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                                   class="pf-c-options-menu__toggle-text"
                                                 >
                                                   <b>
-                                                    0
+                                                    1
                                                      - 
-                                                    0
+                                                    2
                                                   </b>
                                                    
                                                   of
                                                    
                                                   <b>
-                                                    0
+                                                    2
                                                   </b>
                                                    
                                                   
@@ -52125,22 +52141,22 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                             className="pf-c-options-menu__toggle-text"
                                           >
                                             <ToggleTemplate
-                                              firstIndex={0}
-                                              itemCount={0}
+                                              firstIndex={1}
+                                              itemCount={2}
                                               itemsTitle=""
-                                              lastIndex={0}
+                                              lastIndex={2}
                                               ofWord="of"
                                             >
                                               <b>
-                                                0
+                                                1
                                                  - 
-                                                0
+                                                2
                                               </b>
                                                
                                               of
                                                
                                               <b>
-                                                0
+                                                2
                                               </b>
                                                
                                             </ToggleTemplate>
@@ -52149,7 +52165,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                             aria-label="Items per page"
                                             className="pf-c-options-menu__toggle-button"
                                             id="pagination-options-menu-toggle-5"
-                                            isDisabled={0}
+                                            isDisabled={false}
                                             isOpen={false}
                                             onEnter={[Function]}
                                             onToggle={[Function]}
@@ -52167,15 +52183,15 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                                       class="pf-c-options-menu__toggle-text"
                                                     >
                                                       <b>
-                                                        0
+                                                        1
                                                          - 
-                                                        0
+                                                        2
                                                       </b>
                                                        
                                                       of
                                                        
                                                       <b>
-                                                        0
+                                                        2
                                                       </b>
                                                        
                                                       
@@ -52223,7 +52239,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                               getMenuRef={null}
                                               id="pagination-options-menu-toggle-5"
                                               isActive={false}
-                                              isDisabled={0}
+                                              isDisabled={false}
                                               isOpen={false}
                                               isPlain={false}
                                               isPrimary={false}
@@ -52245,15 +52261,15 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                                         class="pf-c-options-menu__toggle-text"
                                                       >
                                                         <b>
-                                                          0
+                                                          1
                                                            - 
-                                                          0
+                                                          2
                                                         </b>
                                                          
                                                         of
                                                          
                                                         <b>
-                                                          0
+                                                          2
                                                         </b>
                                                          
                                                         
@@ -52299,7 +52315,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                                 data-ouia-component-id="OUIA-Generated-DropdownToggle-6"
                                                 data-ouia-component-type="PF4/DropdownToggle"
                                                 data-ouia-safe={true}
-                                                disabled={0}
+                                                disabled={false}
                                                 id="pagination-options-menu-toggle-5"
                                                 onClick={[Function]}
                                                 onKeyDown={[Function]}
@@ -52347,8 +52363,8 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                   firstPage={1}
                                   isCompact={false}
                                   isDisabled={false}
-                                  itemCount={0}
-                                  lastPage={0}
+                                  itemCount={2}
+                                  lastPage={1}
                                   ofWord="of"
                                   onFirstClick={[Function]}
                                   onLastClick={[Function]}
@@ -52356,7 +52372,7 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                   onPageInput={[Function]}
                                   onPreviousClick={[Function]}
                                   onSetPage={[Function]}
-                                  page={0}
+                                  page={1}
                                   pagesTitle=""
                                   pagesTitlePlural=""
                                   paginationTitle="Pagination"
@@ -52497,19 +52513,19 @@ exports[`ConnectedBaselinesTable should render multi-select table 1`] = `
                                         aria-label="Current page"
                                         className="pf-c-form-control"
                                         disabled={true}
-                                        max={0}
+                                        max={1}
                                         min={1}
                                         onChange={[Function]}
                                         onKeyDown={[Function]}
                                         type="number"
-                                        value={0}
+                                        value={1}
                                       />
                                       <span
                                         aria-hidden="true"
                                       >
                                         of
                                          
-                                        0
+                                        1
                                       </span>
                                     </div>
                                     <div
@@ -52740,6 +52756,7 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
     >
       <Connect(BaselinesTable)
         basketIsVisible={false}
+        bulkSelectItems={[MockFunction]}
         columns={
           Array [
             Object {
@@ -52764,7 +52781,6 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
         }
         createButton={true}
         exportButton={true}
-        fetchBaselines={[MockFunction]}
         hasMultiSelect={true}
         kebab={true}
         loading={false}
@@ -52774,12 +52790,15 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
             "baselinesWrite": true,
           }
         }
+        selectBaseline={[MockFunction]}
         selectedBaselineIds={Array []}
         tableData={Array []}
         tableId="CHECKBOX"
+        totalBaselines={2}
       >
         <BaselinesTable
           basketIsVisible={false}
+          bulkSelectItems={[MockFunction]}
           columns={
             Array [
               Object {
@@ -52816,12 +52835,14 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
               "baselinesWrite": true,
             }
           }
+          selectBaseline={[MockFunction]}
           selectedBaselineIds={Array []}
           tableData={Array []}
           tableId="CHECKBOX"
           toggleNotificationFulfilled={[Function]}
           toggleNotificationPending={[Function]}
           toggleNotificationRejected={[Function]}
+          totalBaselines={2}
         >
           <BaselinesToolbar
             createButton={true}
@@ -52833,6 +52854,7 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
             isDeleteDisabled={true}
             kebab={true}
             loading={false}
+            onBulkSelect={[Function]}
             onSearch={[Function]}
             page={1}
             perPage={20}
@@ -52845,6 +52867,7 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
             selectedBaselineIds={Array []}
             tableData={Array []}
             tableId="CHECKBOX"
+            totalBaselines={2}
             updatePagination={[Function]}
           >
             <Connect(DeleteBaselinesModal)
@@ -52982,21 +53005,22 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                 >
                                   <BulkSelect
                                     checked={false}
-                                    count={null}
+                                    count={0}
+                                    id="baselines-bulk-select"
                                     isDisabled={true}
                                     items={
                                       Array [
                                         Object {
-                                          "key": "select-all",
+                                          "key": "select-page",
                                           "onClick": [Function],
-                                          "ouiaId": "select-all",
-                                          "title": "Select all",
+                                          "ouiaId": "baselines-select-page",
+                                          "title": "Select page (0)",
                                         },
                                         Object {
                                           "key": "select-none",
                                           "onClick": [Function],
-                                          "ouiaId": "select-none",
-                                          "title": "Select none",
+                                          "ouiaId": "baselines-select-none",
+                                          "title": "Select none (0)",
                                         },
                                       ]
                                     }
@@ -53009,16 +53033,16 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                           <DropdownItem
                                             component="button"
                                             onClick={[Function]}
-                                            ouiaId="OUIA-Generated-RHI/BulkSelect-4-select-all"
+                                            ouiaId="OUIA-Generated-RHI/BulkSelect-4-select-page"
                                           >
-                                            Select all
+                                            Select page (0)
                                           </DropdownItem>,
                                           <DropdownItem
                                             component="button"
                                             onClick={[Function]}
                                             ouiaId="OUIA-Generated-RHI/BulkSelect-4-select-none"
                                           >
-                                            Select none
+                                            Select none (0)
                                           </DropdownItem>,
                                         ]
                                       }
@@ -53037,7 +53061,7 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                                 <DropdownToggleCheckbox
                                                   aria-label="Select all"
                                                   className=""
-                                                  id="toggle-checkbox"
+                                                  id="baselines-bulk-select-toggle-checkbox"
                                                   isChecked={false}
                                                   isDisabled={false}
                                                   isValid={true}
@@ -53061,16 +53085,16 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                             <DropdownItem
                                               component="button"
                                               onClick={[Function]}
-                                              ouiaId="OUIA-Generated-RHI/BulkSelect-4-select-all"
+                                              ouiaId="OUIA-Generated-RHI/BulkSelect-4-select-page"
                                             >
-                                              Select all
+                                              Select page (0)
                                             </DropdownItem>,
                                             <DropdownItem
                                               component="button"
                                               onClick={[Function]}
                                               ouiaId="OUIA-Generated-RHI/BulkSelect-4-select-none"
                                             >
-                                              Select none
+                                              Select none (0)
                                             </DropdownItem>,
                                           ]
                                         }
@@ -53092,7 +53116,7 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                                   <DropdownToggleCheckbox
                                                     aria-label="Select all"
                                                     className=""
-                                                    id="toggle-checkbox"
+                                                    id="baselines-bulk-select-toggle-checkbox"
                                                     isChecked={false}
                                                     isDisabled={false}
                                                     isValid={true}
@@ -53138,7 +53162,7 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                                   >
                                                     <label
                                                       class="pf-c-dropdown__toggle-check"
-                                                      for="toggle-checkbox"
+                                                      for="baselines-bulk-select-toggle-checkbox"
                                                     >
                                                       <input
                                                         aria-invalid="false"
@@ -53146,7 +53170,7 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                                         data-ouia-component-id="OUIA-Generated-RHI/BulkSelect-4"
                                                         data-ouia-component-type="PF4/DropdownToggleCheckbox"
                                                         data-ouia-safe="true"
-                                                        id="toggle-checkbox"
+                                                        id="baselines-bulk-select-toggle-checkbox"
                                                         type="checkbox"
                                                       />
                                                       
@@ -53191,7 +53215,7 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                                   <DropdownToggleCheckbox
                                                     aria-label="Select all"
                                                     className=""
-                                                    id="toggle-checkbox"
+                                                    id="baselines-bulk-select-toggle-checkbox"
                                                     isChecked={false}
                                                     isDisabled={false}
                                                     isValid={true}
@@ -53210,7 +53234,7 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                               <DropdownToggleCheckbox
                                                 aria-label="Select all"
                                                 className=""
-                                                id="toggle-checkbox"
+                                                id="baselines-bulk-select-toggle-checkbox"
                                                 isChecked={false}
                                                 isDisabled={false}
                                                 isValid={true}
@@ -53219,7 +53243,7 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                               >
                                                 <label
                                                   className="pf-c-dropdown__toggle-check"
-                                                  htmlFor="toggle-checkbox"
+                                                  htmlFor="baselines-bulk-select-toggle-checkbox"
                                                 >
                                                   <input
                                                     aria-invalid={false}
@@ -53229,7 +53253,7 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                                     data-ouia-component-type="PF4/DropdownToggleCheckbox"
                                                     data-ouia-safe={true}
                                                     disabled={false}
-                                                    id="toggle-checkbox"
+                                                    id="baselines-bulk-select-toggle-checkbox"
                                                     onChange={[Function]}
                                                     type="checkbox"
                                                   />
@@ -53267,7 +53291,7 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                                       >
                                                         <label
                                                           class="pf-c-dropdown__toggle-check"
-                                                          for="toggle-checkbox"
+                                                          for="baselines-bulk-select-toggle-checkbox"
                                                         >
                                                           <input
                                                             aria-invalid="false"
@@ -53275,7 +53299,7 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                                             data-ouia-component-id="OUIA-Generated-RHI/BulkSelect-4"
                                                             data-ouia-component-type="PF4/DropdownToggleCheckbox"
                                                             data-ouia-safe="true"
-                                                            id="toggle-checkbox"
+                                                            id="baselines-bulk-select-toggle-checkbox"
                                                             type="checkbox"
                                                           />
                                                           
@@ -54248,6 +54272,7 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                               page={1}
                               perPage={20}
                               tableId="CHECKBOX"
+                              total={2}
                               updatePagination={[Function]}
                             >
                               <Pagination
@@ -54257,7 +54282,7 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                 isCompact={true}
                                 isDisabled={false}
                                 isSticky={false}
-                                itemCount={0}
+                                itemCount={2}
                                 itemsEnd={null}
                                 itemsStart={null}
                                 offset={0}
@@ -54322,22 +54347,22 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                     className="pf-c-pagination__total-items"
                                   >
                                     <ToggleTemplate
-                                      firstIndex={0}
-                                      itemCount={0}
+                                      firstIndex={1}
+                                      itemCount={2}
                                       itemsTitle=""
-                                      lastIndex={0}
+                                      lastIndex={2}
                                       ofWord="of"
                                     >
                                       <b>
-                                        0
+                                        1
                                          - 
-                                        0
+                                        2
                                       </b>
                                        
                                       of
                                        
                                       <b>
-                                        0
+                                        2
                                       </b>
                                        
                                     </ToggleTemplate>
@@ -54346,17 +54371,17 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                     className=""
                                     defaultToFullPage={false}
                                     dropDirection="down"
-                                    firstIndex={0}
+                                    firstIndex={1}
                                     isDisabled={false}
-                                    itemCount={0}
+                                    itemCount={2}
                                     itemsPerPageTitle="Items per page"
                                     itemsTitle=""
-                                    lastIndex={0}
-                                    lastPage={0}
+                                    lastIndex={2}
+                                    lastPage={1}
                                     ofWord="of"
                                     onPerPageSelect={[Function]}
                                     optionsToggle="Items per page"
-                                    page={0}
+                                    page={1}
                                     perPage={20}
                                     perPageOptions={
                                       Array [
@@ -54444,13 +54469,13 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                       position="left"
                                       toggle={
                                         <OptionsToggle
-                                          firstIndex={0}
+                                          firstIndex={1}
                                           isDisabled={false}
                                           isOpen={false}
-                                          itemCount={0}
+                                          itemCount={2}
                                           itemsPerPageTitle="Items per page"
                                           itemsTitle=""
-                                          lastIndex={0}
+                                          lastIndex={2}
                                           ofWord="of"
                                           onToggle={[Function]}
                                           optionsToggle="Items per page"
@@ -54468,18 +54493,18 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                       >
                                         <OptionsToggle
                                           aria-haspopup={true}
-                                          firstIndex={0}
+                                          firstIndex={1}
                                           getMenuRef={[Function]}
                                           id="pf-dropdown-toggle-id-22"
                                           isDisabled={false}
                                           isOpen={false}
                                           isPlain={true}
                                           isText={false}
-                                          itemCount={0}
+                                          itemCount={2}
                                           itemsPerPageTitle="Items per page"
                                           itemsTitle=""
                                           key=".0"
-                                          lastIndex={0}
+                                          lastIndex={2}
                                           ofWord="of"
                                           onEnter={[Function]}
                                           onToggle={[Function]}
@@ -54498,15 +54523,15 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                                     class="pf-c-options-menu__toggle-text"
                                                   >
                                                     <b>
-                                                      0
+                                                      1
                                                        - 
-                                                      0
+                                                      2
                                                     </b>
                                                      
                                                     of
                                                      
                                                     <b>
-                                                      0
+                                                      2
                                                     </b>
                                                      
                                                     
@@ -54554,22 +54579,22 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                               className="pf-c-options-menu__toggle-text"
                                             >
                                               <ToggleTemplate
-                                                firstIndex={0}
-                                                itemCount={0}
+                                                firstIndex={1}
+                                                itemCount={2}
                                                 itemsTitle=""
-                                                lastIndex={0}
+                                                lastIndex={2}
                                                 ofWord="of"
                                               >
                                                 <b>
-                                                  0
+                                                  1
                                                    - 
-                                                  0
+                                                  2
                                                 </b>
                                                  
                                                 of
                                                  
                                                 <b>
-                                                  0
+                                                  2
                                                 </b>
                                                  
                                               </ToggleTemplate>
@@ -54578,7 +54603,7 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                               aria-label="Items per page"
                                               className="pf-c-options-menu__toggle-button"
                                               id="pagination-options-menu-toggle-6"
-                                              isDisabled={0}
+                                              isDisabled={false}
                                               isOpen={false}
                                               onEnter={[Function]}
                                               onToggle={[Function]}
@@ -54596,15 +54621,15 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                                         class="pf-c-options-menu__toggle-text"
                                                       >
                                                         <b>
-                                                          0
+                                                          1
                                                            - 
-                                                          0
+                                                          2
                                                         </b>
                                                          
                                                         of
                                                          
                                                         <b>
-                                                          0
+                                                          2
                                                         </b>
                                                          
                                                         
@@ -54652,7 +54677,7 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                                 getMenuRef={null}
                                                 id="pagination-options-menu-toggle-6"
                                                 isActive={false}
-                                                isDisabled={0}
+                                                isDisabled={false}
                                                 isOpen={false}
                                                 isPlain={false}
                                                 isPrimary={false}
@@ -54674,15 +54699,15 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                                           class="pf-c-options-menu__toggle-text"
                                                         >
                                                           <b>
-                                                            0
+                                                            1
                                                              - 
-                                                            0
+                                                            2
                                                           </b>
                                                            
                                                           of
                                                            
                                                           <b>
-                                                            0
+                                                            2
                                                           </b>
                                                            
                                                           
@@ -54728,7 +54753,7 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                                   data-ouia-component-id="OUIA-Generated-DropdownToggle-7"
                                                   data-ouia-component-type="PF4/DropdownToggle"
                                                   data-ouia-safe={true}
-                                                  disabled={0}
+                                                  disabled={false}
                                                   id="pagination-options-menu-toggle-6"
                                                   onClick={[Function]}
                                                   onKeyDown={[Function]}
@@ -54776,8 +54801,8 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                     firstPage={1}
                                     isCompact={true}
                                     isDisabled={false}
-                                    itemCount={0}
-                                    lastPage={0}
+                                    itemCount={2}
+                                    lastPage={1}
                                     ofWord="of"
                                     onFirstClick={[Function]}
                                     onLastClick={[Function]}
@@ -54785,7 +54810,7 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                     onPageInput={[Function]}
                                     onPreviousClick={[Function]}
                                     onSetPage={[Function]}
-                                    page={0}
+                                    page={1}
                                     pagesTitle=""
                                     pagesTitlePlural=""
                                     paginationTitle="Pagination"
@@ -57294,6 +57319,7 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                             page={1}
                             perPage={20}
                             tableId="CHECKBOX"
+                            total={2}
                             updatePagination={[Function]}
                           >
                             <Pagination
@@ -57303,7 +57329,7 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                               isCompact={false}
                               isDisabled={false}
                               isSticky={false}
-                              itemCount={0}
+                              itemCount={2}
                               itemsEnd={null}
                               itemsStart={null}
                               offset={0}
@@ -57368,22 +57394,22 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                   className="pf-c-pagination__total-items"
                                 >
                                   <ToggleTemplate
-                                    firstIndex={0}
-                                    itemCount={0}
+                                    firstIndex={1}
+                                    itemCount={2}
                                     itemsTitle=""
-                                    lastIndex={0}
+                                    lastIndex={2}
                                     ofWord="of"
                                   >
                                     <b>
-                                      0
+                                      1
                                        - 
-                                      0
+                                      2
                                     </b>
                                      
                                     of
                                      
                                     <b>
-                                      0
+                                      2
                                     </b>
                                      
                                   </ToggleTemplate>
@@ -57392,17 +57418,17 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                   className=""
                                   defaultToFullPage={false}
                                   dropDirection="down"
-                                  firstIndex={0}
+                                  firstIndex={1}
                                   isDisabled={false}
-                                  itemCount={0}
+                                  itemCount={2}
                                   itemsPerPageTitle="Items per page"
                                   itemsTitle=""
-                                  lastIndex={0}
-                                  lastPage={0}
+                                  lastIndex={2}
+                                  lastPage={1}
                                   ofWord="of"
                                   onPerPageSelect={[Function]}
                                   optionsToggle="Items per page"
-                                  page={0}
+                                  page={1}
                                   perPage={20}
                                   perPageOptions={
                                     Array [
@@ -57490,13 +57516,13 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                     position="left"
                                     toggle={
                                       <OptionsToggle
-                                        firstIndex={0}
+                                        firstIndex={1}
                                         isDisabled={false}
                                         isOpen={false}
-                                        itemCount={0}
+                                        itemCount={2}
                                         itemsPerPageTitle="Items per page"
                                         itemsTitle=""
-                                        lastIndex={0}
+                                        lastIndex={2}
                                         ofWord="of"
                                         onToggle={[Function]}
                                         optionsToggle="Items per page"
@@ -57514,18 +57540,18 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                     >
                                       <OptionsToggle
                                         aria-haspopup={true}
-                                        firstIndex={0}
+                                        firstIndex={1}
                                         getMenuRef={[Function]}
                                         id="pf-dropdown-toggle-id-23"
                                         isDisabled={false}
                                         isOpen={false}
                                         isPlain={true}
                                         isText={false}
-                                        itemCount={0}
+                                        itemCount={2}
                                         itemsPerPageTitle="Items per page"
                                         itemsTitle=""
                                         key=".0"
-                                        lastIndex={0}
+                                        lastIndex={2}
                                         ofWord="of"
                                         onEnter={[Function]}
                                         onToggle={[Function]}
@@ -57544,15 +57570,15 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                                   class="pf-c-options-menu__toggle-text"
                                                 >
                                                   <b>
-                                                    0
+                                                    1
                                                      - 
-                                                    0
+                                                    2
                                                   </b>
                                                    
                                                   of
                                                    
                                                   <b>
-                                                    0
+                                                    2
                                                   </b>
                                                    
                                                   
@@ -57600,22 +57626,22 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                             className="pf-c-options-menu__toggle-text"
                                           >
                                             <ToggleTemplate
-                                              firstIndex={0}
-                                              itemCount={0}
+                                              firstIndex={1}
+                                              itemCount={2}
                                               itemsTitle=""
-                                              lastIndex={0}
+                                              lastIndex={2}
                                               ofWord="of"
                                             >
                                               <b>
-                                                0
+                                                1
                                                  - 
-                                                0
+                                                2
                                               </b>
                                                
                                               of
                                                
                                               <b>
-                                                0
+                                                2
                                               </b>
                                                
                                             </ToggleTemplate>
@@ -57624,7 +57650,7 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                             aria-label="Items per page"
                                             className="pf-c-options-menu__toggle-button"
                                             id="pagination-options-menu-toggle-7"
-                                            isDisabled={0}
+                                            isDisabled={false}
                                             isOpen={false}
                                             onEnter={[Function]}
                                             onToggle={[Function]}
@@ -57642,15 +57668,15 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                                       class="pf-c-options-menu__toggle-text"
                                                     >
                                                       <b>
-                                                        0
+                                                        1
                                                          - 
-                                                        0
+                                                        2
                                                       </b>
                                                        
                                                       of
                                                        
                                                       <b>
-                                                        0
+                                                        2
                                                       </b>
                                                        
                                                       
@@ -57698,7 +57724,7 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                               getMenuRef={null}
                                               id="pagination-options-menu-toggle-7"
                                               isActive={false}
-                                              isDisabled={0}
+                                              isDisabled={false}
                                               isOpen={false}
                                               isPlain={false}
                                               isPrimary={false}
@@ -57720,15 +57746,15 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                                         class="pf-c-options-menu__toggle-text"
                                                       >
                                                         <b>
-                                                          0
+                                                          1
                                                            - 
-                                                          0
+                                                          2
                                                         </b>
                                                          
                                                         of
                                                          
                                                         <b>
-                                                          0
+                                                          2
                                                         </b>
                                                          
                                                         
@@ -57774,7 +57800,7 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                                 data-ouia-component-id="OUIA-Generated-DropdownToggle-8"
                                                 data-ouia-component-type="PF4/DropdownToggle"
                                                 data-ouia-safe={true}
-                                                disabled={0}
+                                                disabled={false}
                                                 id="pagination-options-menu-toggle-7"
                                                 onClick={[Function]}
                                                 onKeyDown={[Function]}
@@ -57822,8 +57848,8 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                   firstPage={1}
                                   isCompact={false}
                                   isDisabled={false}
-                                  itemCount={0}
-                                  lastPage={0}
+                                  itemCount={2}
+                                  lastPage={1}
                                   ofWord="of"
                                   onFirstClick={[Function]}
                                   onLastClick={[Function]}
@@ -57831,7 +57857,7 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                   onPageInput={[Function]}
                                   onPreviousClick={[Function]}
                                   onSetPage={[Function]}
-                                  page={0}
+                                  page={1}
                                   pagesTitle=""
                                   pagesTitlePlural=""
                                   paginationTitle="Pagination"
@@ -57972,19 +57998,19 @@ exports[`ConnectedBaselinesTable should render no matching baselines 1`] = `
                                         aria-label="Current page"
                                         className="pf-c-form-control"
                                         disabled={true}
-                                        max={0}
+                                        max={1}
                                         min={1}
                                         onChange={[Function]}
                                         onKeyDown={[Function]}
                                         type="number"
-                                        value={0}
+                                        value={1}
                                       />
                                       <span
                                         aria-hidden="true"
                                       >
                                         of
                                          
-                                        0
+                                        1
                                       </span>
                                     </div>
                                     <div
@@ -58215,6 +58241,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
     >
       <Connect(BaselinesTable)
         basketIsVisible={false}
+        bulkSelectItems={[MockFunction]}
         columns={
           Array [
             Object {
@@ -58239,7 +58266,6 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
         }
         createButton={true}
         exportButton={true}
-        fetchBaselines={[MockFunction]}
         hasMultiSelect={true}
         kebab={true}
         loading={false}
@@ -58249,6 +58275,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
             "baselinesWrite": false,
           }
         }
+        selectBaseline={[MockFunction]}
         selectedBaselineIds={Array []}
         tableData={
           Array [
@@ -58269,9 +58296,11 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
           ]
         }
         tableId="CHECKBOX"
+        totalBaselines={2}
       >
         <BaselinesTable
           basketIsVisible={false}
+          bulkSelectItems={[MockFunction]}
           columns={
             Array [
               Object {
@@ -58308,6 +58337,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
               "baselinesWrite": false,
             }
           }
+          selectBaseline={[MockFunction]}
           selectedBaselineIds={Array []}
           tableData={
             Array [
@@ -58331,6 +58361,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
           toggleNotificationFulfilled={[Function]}
           toggleNotificationPending={[Function]}
           toggleNotificationRejected={[Function]}
+          totalBaselines={2}
         >
           <BaselinesToolbar
             createButton={true}
@@ -58342,6 +58373,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
             isDeleteDisabled={true}
             kebab={true}
             loading={false}
+            onBulkSelect={[Function]}
             onSearch={[Function]}
             page={1}
             perPage={20}
@@ -58371,6 +58403,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
               ]
             }
             tableId="CHECKBOX"
+            totalBaselines={2}
             updatePagination={[Function]}
           >
             <Connect(DeleteBaselinesModal)
@@ -58508,21 +58541,22 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                 >
                                   <BulkSelect
                                     checked={false}
-                                    count={null}
+                                    count={0}
+                                    id="baselines-bulk-select"
                                     isDisabled={true}
                                     items={
                                       Array [
                                         Object {
-                                          "key": "select-all",
+                                          "key": "select-page",
                                           "onClick": [Function],
-                                          "ouiaId": "select-all",
-                                          "title": "Select all",
+                                          "ouiaId": "baselines-select-page",
+                                          "title": "Select page (2)",
                                         },
                                         Object {
                                           "key": "select-none",
                                           "onClick": [Function],
-                                          "ouiaId": "select-none",
-                                          "title": "Select none",
+                                          "ouiaId": "baselines-select-none",
+                                          "title": "Select none (0)",
                                         },
                                       ]
                                     }
@@ -58535,16 +58569,16 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                           <DropdownItem
                                             component="button"
                                             onClick={[Function]}
-                                            ouiaId="OUIA-Generated-RHI/BulkSelect-1-select-all"
+                                            ouiaId="OUIA-Generated-RHI/BulkSelect-1-select-page"
                                           >
-                                            Select all
+                                            Select page (2)
                                           </DropdownItem>,
                                           <DropdownItem
                                             component="button"
                                             onClick={[Function]}
                                             ouiaId="OUIA-Generated-RHI/BulkSelect-1-select-none"
                                           >
-                                            Select none
+                                            Select none (0)
                                           </DropdownItem>,
                                         ]
                                       }
@@ -58563,7 +58597,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                                 <DropdownToggleCheckbox
                                                   aria-label="Select all"
                                                   className=""
-                                                  id="toggle-checkbox"
+                                                  id="baselines-bulk-select-toggle-checkbox"
                                                   isChecked={false}
                                                   isDisabled={false}
                                                   isValid={true}
@@ -58587,16 +58621,16 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                             <DropdownItem
                                               component="button"
                                               onClick={[Function]}
-                                              ouiaId="OUIA-Generated-RHI/BulkSelect-1-select-all"
+                                              ouiaId="OUIA-Generated-RHI/BulkSelect-1-select-page"
                                             >
-                                              Select all
+                                              Select page (2)
                                             </DropdownItem>,
                                             <DropdownItem
                                               component="button"
                                               onClick={[Function]}
                                               ouiaId="OUIA-Generated-RHI/BulkSelect-1-select-none"
                                             >
-                                              Select none
+                                              Select none (0)
                                             </DropdownItem>,
                                           ]
                                         }
@@ -58618,7 +58652,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                                   <DropdownToggleCheckbox
                                                     aria-label="Select all"
                                                     className=""
-                                                    id="toggle-checkbox"
+                                                    id="baselines-bulk-select-toggle-checkbox"
                                                     isChecked={false}
                                                     isDisabled={false}
                                                     isValid={true}
@@ -58664,7 +58698,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                                   >
                                                     <label
                                                       class="pf-c-dropdown__toggle-check"
-                                                      for="toggle-checkbox"
+                                                      for="baselines-bulk-select-toggle-checkbox"
                                                     >
                                                       <input
                                                         aria-invalid="false"
@@ -58672,7 +58706,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                                         data-ouia-component-id="OUIA-Generated-RHI/BulkSelect-1"
                                                         data-ouia-component-type="PF4/DropdownToggleCheckbox"
                                                         data-ouia-safe="true"
-                                                        id="toggle-checkbox"
+                                                        id="baselines-bulk-select-toggle-checkbox"
                                                         type="checkbox"
                                                       />
                                                       
@@ -58717,7 +58751,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                                   <DropdownToggleCheckbox
                                                     aria-label="Select all"
                                                     className=""
-                                                    id="toggle-checkbox"
+                                                    id="baselines-bulk-select-toggle-checkbox"
                                                     isChecked={false}
                                                     isDisabled={false}
                                                     isValid={true}
@@ -58736,7 +58770,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                               <DropdownToggleCheckbox
                                                 aria-label="Select all"
                                                 className=""
-                                                id="toggle-checkbox"
+                                                id="baselines-bulk-select-toggle-checkbox"
                                                 isChecked={false}
                                                 isDisabled={false}
                                                 isValid={true}
@@ -58745,7 +58779,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                               >
                                                 <label
                                                   className="pf-c-dropdown__toggle-check"
-                                                  htmlFor="toggle-checkbox"
+                                                  htmlFor="baselines-bulk-select-toggle-checkbox"
                                                 >
                                                   <input
                                                     aria-invalid={false}
@@ -58755,7 +58789,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                                     data-ouia-component-type="PF4/DropdownToggleCheckbox"
                                                     data-ouia-safe={true}
                                                     disabled={false}
-                                                    id="toggle-checkbox"
+                                                    id="baselines-bulk-select-toggle-checkbox"
                                                     onChange={[Function]}
                                                     type="checkbox"
                                                   />
@@ -58793,7 +58827,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                                       >
                                                         <label
                                                           class="pf-c-dropdown__toggle-check"
-                                                          for="toggle-checkbox"
+                                                          for="baselines-bulk-select-toggle-checkbox"
                                                         >
                                                           <input
                                                             aria-invalid="false"
@@ -58801,7 +58835,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                                             data-ouia-component-id="OUIA-Generated-RHI/BulkSelect-1"
                                                             data-ouia-component-type="PF4/DropdownToggleCheckbox"
                                                             data-ouia-safe="true"
-                                                            id="toggle-checkbox"
+                                                            id="baselines-bulk-select-toggle-checkbox"
                                                             type="checkbox"
                                                           />
                                                           
@@ -59865,6 +59899,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                               page={1}
                               perPage={20}
                               tableId="CHECKBOX"
+                              total={2}
                               updatePagination={[Function]}
                             >
                               <Pagination
@@ -59874,7 +59909,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                 isCompact={true}
                                 isDisabled={false}
                                 isSticky={false}
-                                itemCount={0}
+                                itemCount={2}
                                 itemsEnd={null}
                                 itemsStart={null}
                                 offset={0}
@@ -59939,22 +59974,22 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                     className="pf-c-pagination__total-items"
                                   >
                                     <ToggleTemplate
-                                      firstIndex={0}
-                                      itemCount={0}
+                                      firstIndex={1}
+                                      itemCount={2}
                                       itemsTitle=""
-                                      lastIndex={0}
+                                      lastIndex={2}
                                       ofWord="of"
                                     >
                                       <b>
-                                        0
+                                        1
                                          - 
-                                        0
+                                        2
                                       </b>
                                        
                                       of
                                        
                                       <b>
-                                        0
+                                        2
                                       </b>
                                        
                                     </ToggleTemplate>
@@ -59963,17 +59998,17 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                     className=""
                                     defaultToFullPage={false}
                                     dropDirection="down"
-                                    firstIndex={0}
+                                    firstIndex={1}
                                     isDisabled={false}
-                                    itemCount={0}
+                                    itemCount={2}
                                     itemsPerPageTitle="Items per page"
                                     itemsTitle=""
-                                    lastIndex={0}
-                                    lastPage={0}
+                                    lastIndex={2}
+                                    lastPage={1}
                                     ofWord="of"
                                     onPerPageSelect={[Function]}
                                     optionsToggle="Items per page"
-                                    page={0}
+                                    page={1}
                                     perPage={20}
                                     perPageOptions={
                                       Array [
@@ -60061,13 +60096,13 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                       position="left"
                                       toggle={
                                         <OptionsToggle
-                                          firstIndex={0}
+                                          firstIndex={1}
                                           isDisabled={false}
                                           isOpen={false}
-                                          itemCount={0}
+                                          itemCount={2}
                                           itemsPerPageTitle="Items per page"
                                           itemsTitle=""
-                                          lastIndex={0}
+                                          lastIndex={2}
                                           ofWord="of"
                                           onToggle={[Function]}
                                           optionsToggle="Items per page"
@@ -60085,18 +60120,18 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                       >
                                         <OptionsToggle
                                           aria-haspopup={true}
-                                          firstIndex={0}
+                                          firstIndex={1}
                                           getMenuRef={[Function]}
                                           id="pf-dropdown-toggle-id-3"
                                           isDisabled={false}
                                           isOpen={false}
                                           isPlain={true}
                                           isText={false}
-                                          itemCount={0}
+                                          itemCount={2}
                                           itemsPerPageTitle="Items per page"
                                           itemsTitle=""
                                           key=".0"
-                                          lastIndex={0}
+                                          lastIndex={2}
                                           ofWord="of"
                                           onEnter={[Function]}
                                           onToggle={[Function]}
@@ -60115,15 +60150,15 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                                     class="pf-c-options-menu__toggle-text"
                                                   >
                                                     <b>
-                                                      0
+                                                      1
                                                        - 
-                                                      0
+                                                      2
                                                     </b>
                                                      
                                                     of
                                                      
                                                     <b>
-                                                      0
+                                                      2
                                                     </b>
                                                      
                                                     
@@ -60171,22 +60206,22 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                               className="pf-c-options-menu__toggle-text"
                                             >
                                               <ToggleTemplate
-                                                firstIndex={0}
-                                                itemCount={0}
+                                                firstIndex={1}
+                                                itemCount={2}
                                                 itemsTitle=""
-                                                lastIndex={0}
+                                                lastIndex={2}
                                                 ofWord="of"
                                               >
                                                 <b>
-                                                  0
+                                                  1
                                                    - 
-                                                  0
+                                                  2
                                                 </b>
                                                  
                                                 of
                                                  
                                                 <b>
-                                                  0
+                                                  2
                                                 </b>
                                                  
                                               </ToggleTemplate>
@@ -60195,7 +60230,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                               aria-label="Items per page"
                                               className="pf-c-options-menu__toggle-button"
                                               id="pagination-options-menu-toggle-0"
-                                              isDisabled={0}
+                                              isDisabled={false}
                                               isOpen={false}
                                               onEnter={[Function]}
                                               onToggle={[Function]}
@@ -60213,15 +60248,15 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                                         class="pf-c-options-menu__toggle-text"
                                                       >
                                                         <b>
-                                                          0
+                                                          1
                                                            - 
-                                                          0
+                                                          2
                                                         </b>
                                                          
                                                         of
                                                          
                                                         <b>
-                                                          0
+                                                          2
                                                         </b>
                                                          
                                                         
@@ -60269,7 +60304,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                                 getMenuRef={null}
                                                 id="pagination-options-menu-toggle-0"
                                                 isActive={false}
-                                                isDisabled={0}
+                                                isDisabled={false}
                                                 isOpen={false}
                                                 isPlain={false}
                                                 isPrimary={false}
@@ -60291,15 +60326,15 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                                           class="pf-c-options-menu__toggle-text"
                                                         >
                                                           <b>
-                                                            0
+                                                            1
                                                              - 
-                                                            0
+                                                            2
                                                           </b>
                                                            
                                                           of
                                                            
                                                           <b>
-                                                            0
+                                                            2
                                                           </b>
                                                            
                                                           
@@ -60345,7 +60380,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                                   data-ouia-component-id="OUIA-Generated-DropdownToggle-1"
                                                   data-ouia-component-type="PF4/DropdownToggle"
                                                   data-ouia-safe={true}
-                                                  disabled={0}
+                                                  disabled={false}
                                                   id="pagination-options-menu-toggle-0"
                                                   onClick={[Function]}
                                                   onKeyDown={[Function]}
@@ -60393,8 +60428,8 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                     firstPage={1}
                                     isCompact={true}
                                     isDisabled={false}
-                                    itemCount={0}
-                                    lastPage={0}
+                                    itemCount={2}
+                                    lastPage={1}
                                     ofWord="of"
                                     onFirstClick={[Function]}
                                     onLastClick={[Function]}
@@ -60402,7 +60437,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                     onPageInput={[Function]}
                                     onPreviousClick={[Function]}
                                     onSetPage={[Function]}
-                                    page={0}
+                                    page={1}
                                     pagesTitle=""
                                     pagesTitlePlural=""
                                     paginationTitle="Pagination"
@@ -64193,6 +64228,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                             page={1}
                             perPage={20}
                             tableId="CHECKBOX"
+                            total={2}
                             updatePagination={[Function]}
                           >
                             <Pagination
@@ -64202,7 +64238,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                               isCompact={false}
                               isDisabled={false}
                               isSticky={false}
-                              itemCount={0}
+                              itemCount={2}
                               itemsEnd={null}
                               itemsStart={null}
                               offset={0}
@@ -64267,22 +64303,22 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                   className="pf-c-pagination__total-items"
                                 >
                                   <ToggleTemplate
-                                    firstIndex={0}
-                                    itemCount={0}
+                                    firstIndex={1}
+                                    itemCount={2}
                                     itemsTitle=""
-                                    lastIndex={0}
+                                    lastIndex={2}
                                     ofWord="of"
                                   >
                                     <b>
-                                      0
+                                      1
                                        - 
-                                      0
+                                      2
                                     </b>
                                      
                                     of
                                      
                                     <b>
-                                      0
+                                      2
                                     </b>
                                      
                                   </ToggleTemplate>
@@ -64291,17 +64327,17 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                   className=""
                                   defaultToFullPage={false}
                                   dropDirection="down"
-                                  firstIndex={0}
+                                  firstIndex={1}
                                   isDisabled={false}
-                                  itemCount={0}
+                                  itemCount={2}
                                   itemsPerPageTitle="Items per page"
                                   itemsTitle=""
-                                  lastIndex={0}
-                                  lastPage={0}
+                                  lastIndex={2}
+                                  lastPage={1}
                                   ofWord="of"
                                   onPerPageSelect={[Function]}
                                   optionsToggle="Items per page"
-                                  page={0}
+                                  page={1}
                                   perPage={20}
                                   perPageOptions={
                                     Array [
@@ -64389,13 +64425,13 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                     position="left"
                                     toggle={
                                       <OptionsToggle
-                                        firstIndex={0}
+                                        firstIndex={1}
                                         isDisabled={false}
                                         isOpen={false}
-                                        itemCount={0}
+                                        itemCount={2}
                                         itemsPerPageTitle="Items per page"
                                         itemsTitle=""
-                                        lastIndex={0}
+                                        lastIndex={2}
                                         ofWord="of"
                                         onToggle={[Function]}
                                         optionsToggle="Items per page"
@@ -64413,18 +64449,18 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                     >
                                       <OptionsToggle
                                         aria-haspopup={true}
-                                        firstIndex={0}
+                                        firstIndex={1}
                                         getMenuRef={[Function]}
                                         id="pf-dropdown-toggle-id-4"
                                         isDisabled={false}
                                         isOpen={false}
                                         isPlain={true}
                                         isText={false}
-                                        itemCount={0}
+                                        itemCount={2}
                                         itemsPerPageTitle="Items per page"
                                         itemsTitle=""
                                         key=".0"
-                                        lastIndex={0}
+                                        lastIndex={2}
                                         ofWord="of"
                                         onEnter={[Function]}
                                         onToggle={[Function]}
@@ -64443,15 +64479,15 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                                   class="pf-c-options-menu__toggle-text"
                                                 >
                                                   <b>
-                                                    0
+                                                    1
                                                      - 
-                                                    0
+                                                    2
                                                   </b>
                                                    
                                                   of
                                                    
                                                   <b>
-                                                    0
+                                                    2
                                                   </b>
                                                    
                                                   
@@ -64499,22 +64535,22 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                             className="pf-c-options-menu__toggle-text"
                                           >
                                             <ToggleTemplate
-                                              firstIndex={0}
-                                              itemCount={0}
+                                              firstIndex={1}
+                                              itemCount={2}
                                               itemsTitle=""
-                                              lastIndex={0}
+                                              lastIndex={2}
                                               ofWord="of"
                                             >
                                               <b>
-                                                0
+                                                1
                                                  - 
-                                                0
+                                                2
                                               </b>
                                                
                                               of
                                                
                                               <b>
-                                                0
+                                                2
                                               </b>
                                                
                                             </ToggleTemplate>
@@ -64523,7 +64559,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                             aria-label="Items per page"
                                             className="pf-c-options-menu__toggle-button"
                                             id="pagination-options-menu-toggle-1"
-                                            isDisabled={0}
+                                            isDisabled={false}
                                             isOpen={false}
                                             onEnter={[Function]}
                                             onToggle={[Function]}
@@ -64541,15 +64577,15 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                                       class="pf-c-options-menu__toggle-text"
                                                     >
                                                       <b>
-                                                        0
+                                                        1
                                                          - 
-                                                        0
+                                                        2
                                                       </b>
                                                        
                                                       of
                                                        
                                                       <b>
-                                                        0
+                                                        2
                                                       </b>
                                                        
                                                       
@@ -64597,7 +64633,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                               getMenuRef={null}
                                               id="pagination-options-menu-toggle-1"
                                               isActive={false}
-                                              isDisabled={0}
+                                              isDisabled={false}
                                               isOpen={false}
                                               isPlain={false}
                                               isPrimary={false}
@@ -64619,15 +64655,15 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                                         class="pf-c-options-menu__toggle-text"
                                                       >
                                                         <b>
-                                                          0
+                                                          1
                                                            - 
-                                                          0
+                                                          2
                                                         </b>
                                                          
                                                         of
                                                          
                                                         <b>
-                                                          0
+                                                          2
                                                         </b>
                                                          
                                                         
@@ -64673,7 +64709,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                                 data-ouia-component-id="OUIA-Generated-DropdownToggle-2"
                                                 data-ouia-component-type="PF4/DropdownToggle"
                                                 data-ouia-safe={true}
-                                                disabled={0}
+                                                disabled={false}
                                                 id="pagination-options-menu-toggle-1"
                                                 onClick={[Function]}
                                                 onKeyDown={[Function]}
@@ -64721,8 +64757,8 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                   firstPage={1}
                                   isCompact={false}
                                   isDisabled={false}
-                                  itemCount={0}
-                                  lastPage={0}
+                                  itemCount={2}
+                                  lastPage={1}
                                   ofWord="of"
                                   onFirstClick={[Function]}
                                   onLastClick={[Function]}
@@ -64730,7 +64766,7 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                   onPageInput={[Function]}
                                   onPreviousClick={[Function]}
                                   onSetPage={[Function]}
-                                  page={0}
+                                  page={1}
                                   pagesTitle=""
                                   pagesTitlePlural=""
                                   paginationTitle="Pagination"
@@ -64871,19 +64907,19 @@ exports[`ConnectedBaselinesTable should render no table kebabs with no write per
                                         aria-label="Current page"
                                         className="pf-c-form-control"
                                         disabled={true}
-                                        max={0}
+                                        max={1}
                                         min={1}
                                         onChange={[Function]}
                                         onKeyDown={[Function]}
                                         type="number"
-                                        value={0}
+                                        value={1}
                                       />
                                       <span
                                         aria-hidden="true"
                                       >
                                         of
                                          
-                                        0
+                                        1
                                       </span>
                                     </div>
                                     <div

--- a/src/SmartComponents/BaselinesTable/redux/__tests__/helpers.tests.js
+++ b/src/SmartComponents/BaselinesTable/redux/__tests__/helpers.tests.js
@@ -2,16 +2,19 @@ import baselinesReducerHelpers from '../helpers';
 import fixtures from './baselinesTableReducer.fixtures';
 
 describe('baselines table helpers', () => {
-    it('calls fetchBaselines', () => {
-        const fetchBaselines = jest.fn();
-        baselinesReducerHelpers.fetchBaselines('CHECKBOX', fetchBaselines, {});
+    /*eslint-disable camelcase*/
+    it('returns empty object in returnParams', () => {
+        const params = {
+            limit: undefined,
+            offset: NaN,
+            order_by: undefined,
+            order_how: undefined
+        };
 
-        expect(fetchBaselines).toHaveBeenCalled();
+        expect(baselinesReducerHelpers.returnParams({})).toEqual(params);
     });
 
-    /*eslint-disable camelcase*/
-    it('calls fetchBaselines with params', () => {
-        const fetchBaselines = jest.fn();
+    it('returns correct params in returnParams', () => {
         const fetchParams = {
             orderBy: 'display_name',
             orderHow: 'ASC',
@@ -25,9 +28,7 @@ describe('baselines table helpers', () => {
             offset: NaN
         };
 
-        baselinesReducerHelpers.fetchBaselines('CHECKBOX', fetchBaselines, fetchParams);
-
-        expect(fetchBaselines).toHaveBeenCalledWith('CHECKBOX', params);
+        expect(baselinesReducerHelpers.returnParams(fetchParams)).toEqual(params);
     });
 
     it('converts baseline list to csv', () => {

--- a/src/SmartComponents/BaselinesTable/redux/helpers.js
+++ b/src/SmartComponents/BaselinesTable/redux/helpers.js
@@ -1,6 +1,6 @@
 import moment from 'moment';
 
-function fetchBaselines (tableId, fetchBaselines, fetchParams = {}) {
+function returnParams (fetchParams = {}) {
     let params = {};
 
     /*eslint-disable camelcase*/
@@ -14,7 +14,7 @@ function fetchBaselines (tableId, fetchBaselines, fetchParams = {}) {
     }
     /*eslint-enable camelcase*/
 
-    fetchBaselines(tableId, params);
+    return params;
 }
 
 function buildBaselinesTable(data, selectedBaselineIds) {
@@ -132,7 +132,7 @@ function convertListToJSON(data) {
 /*eslint-enable camelcase*/
 
 export default {
-    fetchBaselines,
+    returnParams,
     buildBaselinesTable,
     setBaselineArray,
     toggleExpandedRow,

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -126,6 +126,7 @@ export const SystemsTable = ({
                             return { ...data };
                         } }
                     bulkSelect={ onSelect && !isAddSystemNotifications && {
+                        id: 'systems-bulk-select',
                         isDisabled: !hasMultiSelect,
                         count: entities?.selectedSystemIds?.length,
                         items: [{

--- a/src/SmartComponents/SystemsTable/__tests__/__snapshots__/SystemsTable.tests.js.snap
+++ b/src/SmartComponents/SystemsTable/__tests__/__snapshots__/SystemsTable.tests.js.snap
@@ -76,6 +76,7 @@ exports[`ConnectedSystemsTable should render correctly 1`] = `
                 Object {
                   "checked": null,
                   "count": undefined,
+                  "id": "systems-bulk-select",
                   "isDisabled": true,
                   "items": Array [
                     Object {
@@ -131,6 +132,7 @@ exports[`ConnectedSystemsTable should render correctly 1`] = `
                   Object {
                     "checked": null,
                     "count": undefined,
+                    "id": "systems-bulk-select",
                     "isDisabled": true,
                     "items": Array [
                       Object {
@@ -203,6 +205,7 @@ exports[`ConnectedSystemsTable should render correctly 1`] = `
                             Object {
                               "checked": null,
                               "count": undefined,
+                              "id": "systems-bulk-select",
                               "isDisabled": true,
                               "items": Array [
                                 Object {
@@ -300,6 +303,7 @@ exports[`ConnectedSystemsTable should render correctly 1`] = `
                         Object {
                           "checked": null,
                           "count": undefined,
+                          "id": "systems-bulk-select",
                           "isDisabled": true,
                           "items": Array [
                             Object {
@@ -400,6 +404,7 @@ exports[`ConnectedSystemsTable should render correctly 1`] = `
                               Object {
                                 "checked": null,
                                 "count": undefined,
+                                "id": "systems-bulk-select",
                                 "isDisabled": true,
                                 "items": Array [
                                   Object {
@@ -497,6 +502,7 @@ exports[`ConnectedSystemsTable should render correctly 1`] = `
                           Object {
                             "checked": null,
                             "count": undefined,
+                            "id": "systems-bulk-select",
                             "isDisabled": true,
                             "items": Array [
                               Object {
@@ -597,6 +603,7 @@ exports[`ConnectedSystemsTable should render correctly 1`] = `
                             Object {
                               "checked": null,
                               "count": undefined,
+                              "id": "systems-bulk-select",
                               "isDisabled": true,
                               "items": Array [
                                 Object {
@@ -706,6 +713,7 @@ exports[`ConnectedSystemsTable should render correctly 1`] = `
                                 Object {
                                   "checked": null,
                                   "count": undefined,
+                                  "id": "systems-bulk-select",
                                   "isDisabled": true,
                                   "items": Array [
                                     Object {

--- a/src/constants.js
+++ b/src/constants.js
@@ -41,3 +41,18 @@ export const EMPTY_RADIO_MESSAGE = [
     'You currently have no baselines displayed.',
     'Create a baseline first in order to copy from it. '
 ];
+
+export const bulkSelectItems = (onBulkSelect, page) => ([
+    {
+        title: `Select page (${ page })`,
+        key: 'select-page',
+        ouiaId: 'baselines-select-page',
+        onClick: () => onBulkSelect('page')
+    },
+    {
+        title: 'Select none (0)',
+        key: 'select-none',
+        ouiaId: 'baselines-select-none',
+        onClick: () => onBulkSelect('none')
+    }
+]);


### PR DESCRIPTION
Bulk selectors have been updated in 2 places for Drift:

- Baseline main page - Missing "Select page (#)" and counts for select none. We have removed 'Select all' from baseline list bulk select because there are no use cases that would utilize a full select of the baselines list and adding the ability to select all would cause some logic that would be a bit too complex for what we hope to achieve.
- Baseline detail page (If you click on a specific baseline to see its facts) - Missing counts for select none & select all

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
