### PR TITLE
[DRFT-845] Change title in edit baseline name modal

### DIFF
--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaselineNameModal/EditBaselineNameModal.js
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaselineNameModal/EditBaselineNameModal.js
@@ -59,7 +59,7 @@ export class EditBaselineNameModal extends Component {
         return (<div className='fact-value'>
             <Form>
                 <FormGroup
-                    label='Baseline title'
+                    label='Baseline name'
                     isRequired
                     fieldId='baseline name'
                     helperTextInvalid={ Object.prototype.hasOwnProperty.call(error, 'detail') ? error.detail : null }

--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaselineNameModal/__tests__/__snapshots__/EditBaselineNameModal.tests.js.snap
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaselineNameModal/__tests__/__snapshots__/EditBaselineNameModal.tests.js.snap
@@ -52,7 +52,7 @@ exports[`EditBaselineNameModal should render correctly 1`] = `
         fieldId="baseline name"
         helperTextInvalid={null}
         isRequired={true}
-        label="Baseline title"
+        label="Baseline name"
         onKeyPress={[Function]}
         validated={null}
       >
@@ -112,7 +112,7 @@ exports[`EditBaselineNameModal should render error correctly 1`] = `
         fieldId="baseline name"
         helperTextInvalid="This is an error"
         isRequired={true}
-        label="Baseline title"
+        label="Baseline name"
         onKeyPress={[Function]}
         validated="error"
       >
@@ -311,7 +311,7 @@ exports[`EditBaselineNameModal should render mount correctly 1`] = `
                             <span
                               class="pf-c-form__label-text"
                             >
-                              Baseline title
+                              Baseline name
                             </span>
                             <span
                               aria-hidden="true"
@@ -558,7 +558,7 @@ exports[`EditBaselineNameModal should render mount correctly 1`] = `
                                 fieldId="baseline name"
                                 helperTextInvalid={null}
                                 isRequired={true}
-                                label="Baseline title"
+                                label="Baseline name"
                                 onKeyPress={[Function]}
                                 validated={null}
                               >
@@ -576,7 +576,7 @@ exports[`EditBaselineNameModal should render mount correctly 1`] = `
                                       <span
                                         className="pf-c-form__label-text"
                                       >
-                                        Baseline title
+                                        Baseline name
                                       </span>
                                       <span
                                         aria-hidden="true"


### PR DESCRIPTION
In edit baseline name modal, the input title should read "Baseline name" instead of "Baseline title".

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
