### PR TITLE
[DRFT-371] Success notification to edit baseline name

### DIFF
--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaselineNameModal/EditBaselineNameModal.js
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/EditBaselineNameModal/EditBaselineNameModal.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { dispatchNotification } from '../../../../Utilities/Dispatcher';
 import { Button, Form, FormGroup, Modal, ModalVariant, TextInput, ValidatedOptions } from '@patternfly/react-core';
 
 import { editBaselineActions } from '../redux';
@@ -32,6 +33,12 @@ export class EditBaselineNameModal extends Component {
             /*eslint-enable camelcase*/
 
             toggleEditNameModal();
+            dispatchNotification({
+                variant: 'success',
+                title: `Updated baseline name to ${baselineName}`,
+                dismissable: true,
+                autoDismiss: false
+            });
         } catch (e) {
             // do nothing and let redux handle
         }

--- a/src/Utilities/Dispatcher.js
+++ b/src/Utilities/Dispatcher.js
@@ -1,0 +1,11 @@
+import { getStore } from '../store';
+import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
+
+export function dispatchAction(actionCreator) {
+    const store = getStore();
+    return store.dispatch(actionCreator);
+}
+
+export const dispatchNotification = (notification) => {
+    dispatchAction(addNotification(notification));
+};


### PR DESCRIPTION
When you successfully change the name of a baseline, a success notification will appear on modal close.

Navigate to 'Baselines' -> select a baseline -> Click pencil icon the head to open the modal to change name.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
