### PR TITLE
[DRFT-1193] Enable filter on no baselines write

### DIFF
--- a/src/SmartComponents/BaselinesTable/BaselinesToolbar/BaselinesToolbar.js
+++ b/src/SmartComponents/BaselinesTable/BaselinesToolbar/BaselinesToolbar.js
@@ -148,7 +148,7 @@ export class BaselinesToolbar extends Component {
                                     data-ouia-component-type='PF4/TextInput'
                                     data-ouia-component-id='filter-by-name-baselines-table'
                                     onChange={ (event, value) => this.setTextFilter(value) }
-                                    isDisabled={ !permissions.baselinesRead || !permissions.baselinesWrite }
+                                    isDisabled={ !permissions.baselinesRead }
                                 />
                             </ToolbarFilter>
                         </ToolbarGroup>


### PR DESCRIPTION
Before, if a user didn't have baselines write permissions, they would not be able to filter the baselines table. This PR adds the ability to filter without baselines write permissions.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
