### PR TITLE
Build scripts, frontend resource, and jest config for migration

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# --------------------------------------------
+# Export vars for helper scripts to use
+# --------------------------------------------
+# name of app-sre "application" folder this component lives in; needs to match for quay
+export COMPONENT="drift"
+# IMAGE should match the quay repo set by app.yaml in app-interface
+export IMAGE="quay.io/cloudservices/drift-frontend"
+export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build's workspace
+export APP_ROOT=$(pwd)
+#16 is the default Node version. Change this to override it.
+export NODE_BUILD_VERSION=16
+COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
+
+set -exv
+# source is preferred to | bash -s in this case to avoid a subshell
+source <(curl -sSL $COMMON_BUILDER/src/frontend-build.sh)
+BUILD_RESULTS=$?
+
+# Stubbed out for now
+mkdir -p $WORKSPACE/artifacts
+cat << EOF > $WORKSPACE/artifacts/junit-dummy.xml
+<testsuite tests="1">
+    <testcase classname="dummy" name="dummytest"/>
+</testsuite>
+EOF
+
+# teardown_docker
+exit $BUILD_RESULTS

--- a/deploy/frontend.yml
+++ b/deploy/frontend.yml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: drift-frontend
+objects:
+  - apiVersion: cloud.redhat.com/v1alpha1
+    kind: Frontend
+    metadata:
+      name: drift
+    spec:
+      envName: ${ENV_NAME}
+      title: Drift Analysis
+      deploymentRepo: https://github.com/RedHatInsights/drift-frontend
+      API:
+        versions:
+          - v1
+      frontend:
+        paths:
+          - /apps/drift
+      image: ${IMAGE}:${IMAGE_TAG}
+      navItems:
+        - title: Drift
+          expandable: true
+          routes:
+            - appId: drift
+              title: Comparison
+              href: /insights/drift/
+              product: Red Hat Insights
+            - appId: drift
+              title: Baselines
+              href: /insights/drift/baselines
+              product: Red Hat Insights
+      module:
+        manifestLocation: /apps/drift/fed-mods.json
+        modules:
+          - id: drift
+            module: ./RootApp
+            routes:
+              - pathName: /ansible/drift
+parameters:
+  - name: ENV_NAME
+    required: true
+  - name: IMAGE_TAG
+    required: true
+  - name: IMAGE
+    value: quay.io/cloudservices/drift-frontend

--- a/package.json
+++ b/package.json
@@ -1,118 +1,119 @@
 {
-  "name": "drift-frontend",
-  "version": "1.1.0",
-  "private": false,
-  "dependencies": {
-    "@babel/runtime": "^7.17.2",
-    "@patternfly/patternfly": "^4.196.7",
-    "@patternfly/react-core": "^4.221.3",
-    "@patternfly/react-icons": "^4.72.3",
-    "@patternfly/react-table": "^4.90.3",
-    "@redhat-cloud-services/frontend-components": "^3.9.8",
-    "@redhat-cloud-services/frontend-components-notifications": "^3.2.7",
-    "@redhat-cloud-services/frontend-components-utilities": "^3.2.16",
-    "axios": "^0.25.0",
-    "classnames": "^2.3.1",
-    "jiff": "^0.7.3",
-    "moment": "^2.29.4",
-    "prop-types": "^15.8.1",
-    "query-string": "^7.1.1",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "react-redux": "^7.2.6",
-    "react-router-dom": "^5.3.0",
-    "redux": "^4.1.2",
-    "redux-logger": "^3.0.6",
-    "redux-promise-middleware": "^6.1.2",
-    "ua-parser-js": "^1.0.2"
-  },
-  "sassIncludes": {
-    "patternfly": "node_modules/patternfly/dist/sass",
-    "bootstrap": "node_modules/patternfly/node_modules/bootstrap-sass/assets/stylesheets",
-    "fontAwesome": "node_modules/patternfly/node_modules/font-awesome-sass/assets/stylesheets"
-  },
-  "jest": {
-    "collectCoverage": true,
-    "collectCoverageFrom": [
-      "<rootDir>/src/**/*.js",
-      "!<rootDir>/src/**/index.js"
-    ],
-    "testPathIgnorePatterns": [
-      "<rootDir>/.+fixtures.+"
-    ],
-    "setupFilesAfterEnv": [
-      "<rootDir>/config/setupTests.js"
-    ],
-    "roots": [
-      "<rootDir>/src/"
-    ],
-    "moduleNameMapper": {
-      "\\.(css|scss)$": "identity-obj-proxy"
+    "name": "drift-frontend",
+    "version": "1.1.0",
+    "private": false,
+    "dependencies": {
+        "@babel/runtime": "^7.17.2",
+        "@patternfly/patternfly": "^4.196.7",
+        "@patternfly/react-core": "^4.221.3",
+        "@patternfly/react-icons": "^4.72.3",
+        "@patternfly/react-table": "^4.90.3",
+        "@redhat-cloud-services/frontend-components": "^3.9.8",
+        "@redhat-cloud-services/frontend-components-notifications": "^3.2.7",
+        "@redhat-cloud-services/frontend-components-utilities": "^3.2.16",
+        "axios": "^0.25.0",
+        "classnames": "^2.3.1",
+        "jiff": "^0.7.3",
+        "moment": "^2.29.4",
+        "prop-types": "^15.8.1",
+        "query-string": "^7.1.1",
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2",
+        "react-redux": "^7.2.6",
+        "react-router-dom": "^5.3.0",
+        "redux": "^4.1.2",
+        "redux-logger": "^3.0.6",
+        "redux-promise-middleware": "^6.1.2",
+        "ua-parser-js": "^1.0.2"
+    },
+    "sassIncludes": {
+        "patternfly": "node_modules/patternfly/dist/sass",
+        "bootstrap": "node_modules/patternfly/node_modules/bootstrap-sass/assets/stylesheets",
+        "fontAwesome": "node_modules/patternfly/node_modules/font-awesome-sass/assets/stylesheets"
+    },
+    "jest": {
+        "collectCoverage": true,
+        "collectCoverageFrom": [
+            "<rootDir>/src/**/*.js",
+            "!<rootDir>/src/**/index.js"
+        ],
+        "testPathIgnorePatterns": [
+            "<rootDir>/.+fixtures.+"
+        ],
+        "setupFilesAfterEnv": [
+            "<rootDir>/config/setupTests.js"
+        ],
+        "roots": [
+            "<rootDir>/src/"
+        ],
+        "moduleNameMapper": {
+            "\\.(css|scss)$": "identity-obj-proxy"
+        },
+        "test": "TZ=UTC jest --verbose --no-cache"
+    },
+    "devDependencies": {
+        "@babel/core": "^7.17.2",
+        "@babel/eslint-parser": "7.13.8",
+        "@babel/plugin-proposal-class-properties": "^7.16.7",
+        "@babel/plugin-proposal-decorators": "^7.17.2",
+        "@babel/plugin-proposal-object-rest-spread": "^7.16.7",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+        "@babel/plugin-transform-runtime": "^7.17.0",
+        "@babel/preset-env": "^7.16.11",
+        "@babel/preset-flow": "^7.16.7",
+        "@babel/preset-react": "^7.16.7",
+        "@redhat-cloud-services/frontend-components-config": "^4.6.14",
+        "@testing-library/dom": "^8.11.3",
+        "@testing-library/jest-dom": "^5.16.2",
+        "@testing-library/react": "^12.1.3",
+        "@testing-library/user-event": "^13.5.0",
+        "@wojtekmaj/enzyme-adapter-react-17": "0.6.6",
+        "babel-core": "^7.0.0-bridge.0",
+        "babel-jest": "^27.5.1",
+        "babel-loader": "^8.2.3",
+        "babel-plugin-lodash": "^3.3.4",
+        "enzyme": "^3.11.0",
+        "enzyme-to-json": "^3.6.2",
+        "eslint": "^8.8.0",
+        "eslint-config-prettier": "^8.3.0",
+        "eslint-plugin-react": "^7.28.0",
+        "identity-obj-proxy": "^3.0.0",
+        "jest": "^27.5.1",
+        "moxios": "^0.4.0",
+        "npm-run-all": "^4.1.5",
+        "redux-mock-store": "^1.5.4",
+        "regenerator-runtime": "^0.13.9",
+        "stylelint": "^14.4.0",
+        "stylelint-config-recommended-scss": "^5.0.2",
+        "stylelint-scss": "^4.1.0",
+        "webpack": "^5.68.0",
+        "webpack-bundle-analyzer": "^4.5.0",
+        "webpack-cli": "^4.9.2"
+    },
+    "scripts": {
+        "build": "webpack --config config/prod.webpack.config.js",
+        "test": "jest --verbose --env=jsdom",
+        "test-watch": "jest --verbose --watch",
+        "lint": "npm-run-all lint:*",
+        "lint:js": "eslint config src",
+        "lint:js:fix": "eslint config src --fix",
+        "lint:sass": "stylelint 'src/**/*.scss' --config .stylelintrc.json",
+        "prod": "NODE_ENV=production webpack serve --config config/dev.webpack.config.js",
+        "server:ctr": "node src/server/generateServerKey.js",
+        "start": "npm run start:proxy",
+        "start:beta": "npm run start:proxy:beta",
+        "start:proxy": "NODE_ENV=development webpack serve --config config/dev.webpack.config.js",
+        "start:proxy:beta": "NODE_ENV=development BETA=true webpack serve --config config/dev.webpack.config.js",
+        "stage": "NODE_ENV=development webpack serve --config config/dev.stage.webpack.config.js",
+        "ephemeral": "CONFIG_PATH=$PWD/profiles/local-frontend-and-ephemeral-cluster.js NODE_ENV=development webpack serve --config config/dev.ephemeral.webpack.config.js",
+        "local": "CONFIG_PATH=$PWD/profiles/local-frontend-and-local.js NODE_ENV=development webpack serve --config config/dev.local.webpack.config.js",
+        "travis:build": "NODE_ENV=production webpack --config config/prod.webpack.config.js",
+        "travis:verify": "npm-run-all travis:build lint test",
+        "verify": "npm-run-all build lint test",
+        "nightly": "npm run travis:verify",
+        "update-snapshot": "jest -u"
+    },
+    "insights": {
+        "appname": "drift"
     }
-  },
-  "devDependencies": {
-    "@babel/core": "^7.17.2",
-    "@babel/eslint-parser": "7.13.8",
-    "@babel/plugin-proposal-class-properties": "^7.16.7",
-    "@babel/plugin-proposal-decorators": "^7.17.2",
-    "@babel/plugin-proposal-object-rest-spread": "^7.16.7",
-    "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-    "@babel/plugin-transform-runtime": "^7.17.0",
-    "@babel/preset-env": "^7.16.11",
-    "@babel/preset-flow": "^7.16.7",
-    "@babel/preset-react": "^7.16.7",
-    "@redhat-cloud-services/frontend-components-config": "^4.6.14",
-    "@testing-library/dom": "^8.11.3",
-    "@testing-library/jest-dom": "^5.16.2",
-    "@testing-library/react": "^12.1.3",
-    "@testing-library/user-event": "^13.5.0",
-    "@wojtekmaj/enzyme-adapter-react-17": "0.6.6",
-    "babel-core": "^7.0.0-bridge.0",
-    "babel-jest": "^27.5.1",
-    "babel-loader": "^8.2.3",
-    "babel-plugin-lodash": "^3.3.4",
-    "enzyme": "^3.11.0",
-    "enzyme-to-json": "^3.6.2",
-    "eslint": "^8.8.0",
-    "eslint-config-prettier": "^8.3.0",
-    "eslint-plugin-react": "^7.28.0",
-    "identity-obj-proxy": "^3.0.0",
-    "jest": "^27.5.1",
-    "moxios": "^0.4.0",
-    "npm-run-all": "^4.1.5",
-    "redux-mock-store": "^1.5.4",
-    "regenerator-runtime": "^0.13.9",
-    "stylelint": "^14.4.0",
-    "stylelint-config-recommended-scss": "^5.0.2",
-    "stylelint-scss": "^4.1.0",
-    "webpack": "^5.68.0",
-    "webpack-bundle-analyzer": "^4.5.0",
-    "webpack-cli": "^4.9.2"
-  },
-  "scripts": {
-    "build": "webpack --config config/prod.webpack.config.js",
-    "test": "jest --verbose --env=jsdom",
-    "test-watch": "jest --verbose --watch",
-    "lint": "npm-run-all lint:*",
-    "lint:js": "eslint config src",
-    "lint:js:fix": "eslint config src --fix",
-    "lint:sass": "stylelint 'src/**/*.scss' --config .stylelintrc.json",
-    "prod": "NODE_ENV=production webpack serve --config config/dev.webpack.config.js",
-    "server:ctr": "node src/server/generateServerKey.js",
-    "start": "npm run start:proxy",
-    "start:beta": "npm run start:proxy:beta",
-    "start:proxy": "NODE_ENV=development webpack serve --config config/dev.webpack.config.js",
-    "start:proxy:beta": "NODE_ENV=development BETA=true webpack serve --config config/dev.webpack.config.js",
-    "stage": "NODE_ENV=development webpack serve --config config/dev.stage.webpack.config.js",
-    "ephemeral": "CONFIG_PATH=$PWD/profiles/local-frontend-and-ephemeral-cluster.js NODE_ENV=development webpack serve --config config/dev.ephemeral.webpack.config.js",
-    "local": "CONFIG_PATH=$PWD/profiles/local-frontend-and-local.js NODE_ENV=development webpack serve --config config/dev.local.webpack.config.js",
-    "travis:build": "NODE_ENV=production webpack --config config/prod.webpack.config.js",
-    "travis:verify": "npm-run-all travis:build lint test",
-    "verify": "npm-run-all build lint test",
-    "nightly": "npm run travis:verify",
-    "update-snapshot": "jest -u"
-  },
-  "insights": {
-    "appname": "drift"
-  }
 }

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# --------------------------------------------
+# Export vars for helper scripts to use
+# --------------------------------------------
+# name of app-sre "application" folder this component lives in; needs to match for quay
+export COMPONENT="drift"
+# IMAGE should match the quay repo set by app.yaml in app-interface
+export IMAGE="quay.io/cloudservices/drift-frontend"
+export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build's workspace
+export APP_ROOT=$(pwd)
+#16 is the default Node version. Change this to override it.
+export NODE_BUILD_VERSION=16
+COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
+
+# --------------------------------------------
+# Options that must be configured by app owner
+# --------------------------------------------
+
+IQE_PLUGINS="drift"
+IQE_MARKER_EXPRESSION="smoke"
+IQE_FILTER_EXPRESSION=""
+    
+
+set -exv
+# source is preferred to | bash -s in this case to avoid a subshell
+source <(curl -sSL $COMMON_BUILDER/src/frontend-build.sh)
+BUILD_RESULTS=$?
+
+# Stubbed out for now
+mkdir -p $WORKSPACE/artifacts
+cat << EOF > $WORKSPACE/artifacts/junit-dummy.xml
+<testsuite tests="1">
+    <testcase classname="dummy" name="dummytest"/>
+</testsuite>
+EOF
+
+# teardown_docker
+exit $BUILD_RESULTS


### PR DESCRIPTION
This patch contains the files / changes required for the consoledot containerization migration. Manifest:

- package.json disable jest cache in test
- deploy/frontend.yml is your new Frontend resource for k8s
- The two shell scripts are the build and PR check scripts for CI/CD