### PR TITLE
Update frontend.yml

### DIFF
--- a/deploy/frontend.yml
+++ b/deploy/frontend.yml
@@ -36,7 +36,7 @@ objects:
           - id: drift
             module: ./RootApp
             routes:
-              - pathName: /ansible/drift
+              - pathname: /ansible/drift
 parameters:
   - name: ENV_NAME
     required: true


### PR DESCRIPTION
This changes `pathName` to `pathname` in the deploy YAML because I got this error:

```
The Frontend "drift" is invalid: spec.module.modules[0].routes[0].pathname: Required value
```