### PR TITLE
fix(Comparison page): Fix the header layout

### DIFF
--- a/src/SmartComponents/DriftPage/DriftPage.js
+++ b/src/SmartComponents/DriftPage/DriftPage.js
@@ -4,7 +4,7 @@ import { withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
 
 import { Main, PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-components';
-import { Card, CardBody, Toolbar, ToolbarGroup, ToolbarItem, PageSection, PaginationVariant } from '@patternfly/react-core';
+import { Card, CardBody, Toolbar, ToolbarGroup, ToolbarItem, PaginationVariant } from '@patternfly/react-core';
 import { ExclamationCircleIcon, LockIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { baselinesTableActions } from '../BaselinesTable/redux';
 import { addSystemModalActions } from '../AddSystemModal/redux';
@@ -100,9 +100,7 @@ export class DriftPage extends Component {
         return (
             <React.Fragment>
                 <PageHeader>
-                    <PageSection>
-                        <PageHeaderTitle title='Comparison'/>
-                    </PageSection>
+                    <PageHeaderTitle title='Comparison'/>
                 </PageHeader>
                 <Main>
                     <PermissionContext.Consumer>


### PR DESCRIPTION
Fixes the header layout for the Comparison page (/insights/draft). Before it took extra space around "Comparison" which looked differently from other pages.

![изображение](https://user-images.githubusercontent.com/31385370/204784207-37a9621e-db45-43f3-9a9c-5986e8b53a88.png)
