### PR TITLE
chore: Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps):"
+    allow:
+      - dependency-name: "@redhat-cloud-services/frontend*"
+      - dependency-name: "@patternfly/*"
+        dependency-type: direct
+    ignore:
+      - dependency-name: "react-router-dom"
+        versions: ["6.x"]


### PR DESCRIPTION
This adds the configuration file for dependabot to enable periodic dependencies upgrade for Drift.