### PR TITLE
Fix webpack config for router v6 upgrade

### DIFF
--- a/config/dev.ephemeral.webpack.config.js
+++ b/config/dev.ephemeral.webpack.config.js
@@ -15,7 +15,16 @@ plugins.push(
         root: resolve(__dirname, '../'),
         exposes: {
             './RootApp': resolve(__dirname, '../src/DevEntry')
-        }
+        },
+        exclude: [ 'react-router-dom' ],
+        shared: [
+            {
+                'react-router-dom': {
+                    singleton: true,
+                    requiredVersion: '*'
+                }
+            }
+        ]
     })
 );
 

--- a/config/dev.local.webpack.config.js
+++ b/config/dev.local.webpack.config.js
@@ -15,7 +15,16 @@ plugins.push(
         root: resolve(__dirname, '../'),
         exposes: {
             './RootApp': resolve(__dirname, '../src/DevEntry')
-        }
+        },
+        exclude: [ 'react-router-dom' ],
+        shared: [
+            {
+                'react-router-dom': {
+                    singleton: true,
+                    requiredVersion: '*'
+                }
+            }
+        ]
     })
 );
 

--- a/config/dev.stage.webpack.config.js
+++ b/config/dev.stage.webpack.config.js
@@ -15,7 +15,16 @@ plugins.push(
         root: resolve(__dirname, '../'),
         exposes: {
             './RootApp': resolve(__dirname, '../src/DevEntry')
-        }
+        },
+        exclude: [ 'react-router-dom' ],
+        shared: [
+            {
+                'react-router-dom': {
+                    singleton: true,
+                    requiredVersion: '*'
+                }
+            }
+        ]
     })
 );
 

--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -11,7 +11,16 @@ const { config: webpackConfig, plugins } = config({
 
 plugins.push(
     require('@redhat-cloud-services/frontend-components-config/federated-modules')({
-        root: resolve(__dirname, '../')
+        root: resolve(__dirname, '../'),
+        exclude: [ 'react-router-dom' ],
+        shared: [
+            {
+                'react-router-dom': {
+                    singleton: true,
+                    requiredVersion: '*'
+                }
+            }
+        ]
     })
 );
 


### PR DESCRIPTION
Drift is down on Stage, everything works locally so I suspect it's caused by the missing react-router-dom in federated modules

![image](https://github.com/RedHatInsights/drift-frontend/assets/20592948/518f3ccb-9d94-4601-aaf8-11abbdd63644)


## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
