### PR TITLE
fix(RHINENG-1446): fix inventory permissions

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -73,7 +73,7 @@ const App = () => {
                 permissionsList.some((permission) => hasPermission(
                     permission, [ 'drift:*:*', 'drift:historical-system-profiles:read', 'drift:*:read' ])
                 ),
-                permissionsList.some((permission) => hasPermission(permission, [ 'inventory:*:*', 'inventory:*:read' ])),
+                permissionsList.some((permission) => hasPermission(permission, [ 'inventory:*:*', 'inventory:hosts:read' ])),
                 permissionsList.some((permission) => hasPermission(permission, [ 'drift:*:*', 'drift:notifications:write', 'drift:*:write' ])),
                 permissionsList.some((permission) => hasPermission(permission, [ 'drift:*:*', 'drift:notifications:read', 'drift:*:read' ]))
             );


### PR DESCRIPTION
Drift was verifying inventory permissions by checking for `inventory:*:read`, but with the addition of `inventory:groups:read`, it changed how permission requests were returned. This PR specifically checks for `inventory:hosts:read`.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
