### PR TITLE
fix: Don't show empty state by default

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -14,7 +14,7 @@ const EditBaselinePage = asyncComponent(() => import ('./SmartComponents/Baselin
 
 const InsightsElement = ({ element: Element, title }) => {
     const INVENTORY_TOTAL_FETCH_URL = '/api/inventory/v1/hosts';
-    const [ hasSystems, setHasSystems ] = useState(false);
+    const [ hasSystems, setHasSystems ] = useState(true);
     const chrome = useChrome();
     useEffect(() => {
         try {


### PR DESCRIPTION
To be consistent between other apps, Empty State should not be shown by default or when the request fails.


## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
