### PR TITLE
fix(RHINENG-1032): create baseline navigates to undefined

### DIFF
--- a/src/SmartComponents/BaselinesPage/CreateBaselineModal/CreateBaselineModal.js
+++ b/src/SmartComponents/BaselinesPage/CreateBaselineModal/CreateBaselineModal.js
@@ -1,6 +1,6 @@
-import React, { Component } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { Button, Modal, Radio, TextInput, Form, FormGroup, ValidatedOptions } from '@patternfly/react-core';
 import { sortable, cellWidth } from '@patternfly/react-table';
 import { addNewListener } from '../../../store';
@@ -13,44 +13,232 @@ import { baselinesTableActions } from '../../BaselinesTable/redux';
 import systemsTableActions from '../../SystemsTable/actions';
 import useInsightsNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate';
 
-export class CreateBaselineModal extends Component {
-    constructor(props) {
-        super(props);
+const CreateBaselineModal = ({ middlewareListener, permissions }) => {
+    const dispatch = useDispatch();
+    const navigate = useInsightsNavigate();
+    const [ baselineName, setBaselineName ] = useState('');
+    const [ fromScratchChecked, setFromScratchChecked ] = useState(true);
+    const [ copyBaselineChecked, setCopyBaselineChecked ] = useState(false);
+    const [ copySystemChecked, setCopySystemChecked ] = useState(false);
+    const columns = [
+        { title: 'Name', transforms: [ sortable, cellWidth(60) ]},
+        { title: 'Last updated', transforms: [ sortable, cellWidth(20) ]},
+        { title: 'Associated systems', transforms: [ cellWidth(20) ]}
+    ];
 
-        this.submitBaselineName = this.submitBaselineName.bind(this);
+    const createBaselineModalOpened = useSelector(({ createBaselineModalState }) => createBaselineModalState.createBaselineModalOpened);
+    const baselineData = useSelector(({ createBaselineModalState }) => createBaselineModalState.baselineData);
+    const entities = useSelector(({ entities }) => entities);
+    const selectedBaselineIds = useSelector(({ baselinesTableState }) => baselinesTableState.radioTable.selectedBaselineIds);
+    const createBaselineError = useSelector(({ createBaselineModalState }) => createBaselineModalState.createBaselineError);
+    const loading = useSelector(({ baselinesTableState }) => baselinesTableState.radioTable.loading);
+    const emptyState = useSelector(({ baselinesTableState }) => baselinesTableState.radioTable.emptyState);
+    const baselineTableData = useSelector(({ baselinesTableState }) => baselinesTableState.radioTable.baselineTableData);
+    const totalBaselines = useSelector(({ baselinesTableState }) => baselinesTableState.radioTable.totalBaselines);
+    const globalFilterState = useSelector(({ globalFilterState }) => globalFilterState);
+    const baselineError = useSelector(({ baselinesTableState }) => baselinesTableState.radioTable.baselineError);
 
-        this.state = {
-            baselineName: '',
-            fromScratchChecked: true,
-            copyBaselineChecked: false,
-            copySystemChecked: false,
-            columns: [
-                { title: 'Name', transforms: [ sortable, cellWidth(60) ]},
-                { title: 'Last updated', transforms: [ sortable, cellWidth(20) ]},
-                { title: 'Associated systems', transforms: [ cellWidth(20) ]}
-            ]
+    const deselectHistoricalProfiles = async () => {
+        await dispatch(systemsTableActions.updateColumns('display_name'));
+        dispatch(systemsTableActions.selectSingleHSP());
+    };
+
+    useEffect(() => {
+        if (middlewareListener) {
+            window.entityListener = addNewListener(middlewareListener, {
+                actionType: 'SELECT_ENTITY',
+                callback: () => {
+                    createBaselineModalOpened ? deselectHistoricalProfiles() : null;
+                }
+            });
+
+            window.entityListener = addNewListener(middlewareListener, {
+                actionType: 'SELECT_SINGLE_HSP',
+                callback: () => {
+                    dispatch(systemsTableActions.updateColumns('display_selected_hsp'));
+                }
+            });
+        }
+
+        return () => {
+            window.removeEventListener('SELECT_ENTITY', deselectHistoricalProfiles);
+            window.removeEventListener('SELECT_SINGLE_HSP', systemsTableActions.updateColumns);
         };
+    }, []);
 
-        this.updateBaselineName = value => {
-            this.setState({ baselineName: value });
-        };
+    useEffect(() => {
+        if (baselineData?.id) {
+            navigate(`/baselines/${baselineData.id}`);
+        }
+    }, [ baselineData ]);
 
-        this.handleChecked = (_, event) => {
-            const value = event.currentTarget.value;
-            this.props.clearSelectedBaselines('RADIO');
+    const cancelModal = () => {
+        setBaselineName('');
+        dispatch(baselinesTableActions.clearSelectedBaselines('RADIO'));
+        dispatch(systemsTableActions.selectSingleHSP());
+        dispatch(createBaselineModalActions.toggleCreateBaselineModal());
+    };
 
-            if (value === 'fromScratchChecked') {
-                this.setState({ fromScratchChecked: true, copyBaselineChecked: false, copySystemChecked: false });
-            } else if (value === 'copyBaselineChecked') {
-                this.setState({ fromScratchChecked: false, copyBaselineChecked: true, copySystemChecked: false });
-            } else {
-                this.setState({ fromScratchChecked: false, copyBaselineChecked: false, copySystemChecked: true });
+    const onSelect = (event, isSelected, rowId) => {
+        let id = [ baselineTableData[rowId][0] ];
+        dispatch(baselinesTableActions.selectBaseline(id, isSelected, 'RADIO'));
+    };
+
+    const findSelectedRadio = () => {
+        const radioChecked = { copyBaselineChecked, copySystemChecked, fromScratchChecked };
+        let keys = Object.keys(radioChecked);
+        let selectedKey;
+
+        keys.forEach(function(key) {
+            if (radioChecked[key]) {
+                selectedKey = key.substring(0, key.length - 7).toLowerCase();
             }
-        };
-    }
+        });
 
-    buildSystemColumns = (originalColumns) => {
-        const { permissions } = this.props;
+        return selectedKey;
+    };
+
+    const submitBaselineName = async () => {
+        /*eslint-disable camelcase*/
+        let newBaselineObject = { display_name: baselineName };
+
+        try {
+            if (baselineName !== '') {
+                if (fromScratchChecked) {
+                    newBaselineObject.baseline_facts = [];
+                    await dispatch(createBaselineModalActions.createBaseline(newBaselineObject));
+                } else if (selectedBaselineIds.length === 1 && copyBaselineChecked) {
+                    newBaselineObject = { display_name: baselineName };
+                    await dispatch(createBaselineModalActions.createBaseline(newBaselineObject, selectedBaselineIds[0]));
+                } else if (entities?.selectedSystemIds.length && copySystemChecked) {
+                    newBaselineObject.inventory_uuid = entities?.selectedSystemIds[0];
+                    await dispatch(createBaselineModalActions.createBaseline(newBaselineObject));
+                } else if (entities?.selectedHSP && copySystemChecked) {
+                    newBaselineObject.hsp_uuid = entities.selectedHSP.id;
+                    await dispatch(createBaselineModalActions.createBaseline(newBaselineObject));
+                }
+
+                dispatch(createBaselineModalActions.toggleCreateBaselineModal());
+                dispatch(createBaselineModalActions.selectSingleHSP());
+                dispatch(baselinesTableActions.clearSelectedBaselines('RADIO'));
+            }
+        } catch (e) {
+            // do nothing and let redux handle
+        }
+        /*eslint-enable camelcase*/
+    };
+
+    const handleChecked = (_, event) => {
+        const value = event.currentTarget.value;
+        dispatch(baselinesTableActions.clearSelectedBaselines('RADIO'));
+
+        if (value === 'fromScratchChecked') {
+            setFromScratchChecked(true);
+            setCopyBaselineChecked(false);
+            setCopySystemChecked(false);
+        } else if (value === 'copyBaselineChecked') {
+            setFromScratchChecked(false);
+            setCopyBaselineChecked(true);
+            setCopySystemChecked(false);
+        } else {
+            setFromScratchChecked(false);
+            setCopyBaselineChecked(false);
+            setCopySystemChecked(true);
+        }
+    };
+
+    const renderRadioButtons = () => {
+        return (<React.Fragment>
+            <Radio
+                isChecked={ fromScratchChecked }
+                id='create-baseline'
+                data-testid='from-scratch-radio'
+                ouiaId='create-baseline-from-scratch-radio'
+                name='baseline-create-options'
+                label='Create baseline from scratch'
+                value='fromScratchChecked'
+                onChange={ handleChecked }
+            />
+            <Radio
+                isChecked={ copyBaselineChecked }
+                id='copy-baseline'
+                ouiaId='create-baseline-copy-baseline-radio'
+                data-testid='copy-baseline-radio'
+                name='baseline-create-options'
+                label='Copy an existing baseline'
+                value='copyBaselineChecked'
+                onChange={ handleChecked }
+            />
+            <Radio
+                isChecked={ copySystemChecked }
+                id='copy-system'
+                ouiaId='create-baseline-copy-system-radio'
+                data-testid='copy-system-radio'
+                name='baseline-create-options'
+                label='Copy an existing system or historical profile'
+                value='copySystemChecked'
+                onChange={ handleChecked }
+            />
+        </React.Fragment>
+        );
+    };
+
+    const renderActions = () => {
+        let actions;
+
+        if (baselineName === ''
+            || (copyBaselineChecked && selectedBaselineIds.length === 0)
+            || (copySystemChecked &&
+                (!entities?.selectedSystemIds.length && !entities?.selectedHSP)
+            )
+        ) {
+            actions = [
+                <Button
+                    key="confirm"
+                    variant="primary"
+                    isDisabled
+                    ouiaId={ `create-baseline-button-${findSelectedRadio()}` }
+                    aria-label='create-baseline-disabled'
+                >
+                    Create baseline
+                </Button>,
+                <Button
+                    key="cancel"
+                    variant="link"
+                    onClick={ () => cancelModal() }
+                    ouiaId="create-baseline-modal-cancel-button"
+                    aria-label='cancel-create-baseline'
+                >
+                    Cancel
+                </Button>
+            ];
+        } else {
+            actions = [
+                <Button
+                    key="confirm"
+                    variant="primary"
+                    onClick={ () => submitBaselineName() }
+                    ouiaId={ `create-baseline-button-${findSelectedRadio()}` }
+                    aria-label='create-baseline-confirm'
+                >
+                    Create baseline
+                </Button>,
+                <Button
+                    key="cancel"
+                    variant="link"
+                    onClick={ () => cancelModal() }
+                    ouiaId="create-baseline-modal-cancel-button"
+                    aria-label='cancel-create-baseline'
+                >
+                    Cancel
+                </Button>
+            ];
+        }
+
+        return actions;
+    };
+
+    const buildSystemColumns = (originalColumns) => {
         let columns = originalColumns.map(function(column) {
             if (column.key === 'display_name' || column.key === 'display_selected_hsp') {
                 return {
@@ -73,167 +261,7 @@ export class CreateBaselineModal extends Component {
         return columns;
     };
 
-    async componentDidMount() {
-        if (this.props.middlewareListener) {
-            window.entityListener = addNewListener(this.props.middlewareListener, {
-                actionType: 'SELECT_ENTITY',
-                callback: () => {
-                    this.props.createBaselineModalOpened ? this.deselectHistoricalProfiles() : null;
-                }
-            });
-
-            window.entityListener = addNewListener(this.props.middlewareListener, {
-                actionType: 'SELECT_SINGLE_HSP',
-                callback: () => {
-                    this.props.updateColumns('display_selected_hsp');
-                }
-            });
-        }
-    }
-
-    async componentWillUnmount() {
-        window.removeEventListener('SELECT_ENTITY', this.deselectHistoricalProfiles);
-        window.removeEventListener('SELECT_SINGLE_HSP', this.props.updateColumns);
-    }
-
-    deselectHistoricalProfiles = async () => {
-        const { selectSingleHSP, updateColumns } = this.props;
-
-        await updateColumns('display_name');
-        selectSingleHSP();
-    };
-
-    findSelectedRadio() {
-        const { copyBaselineChecked, copySystemChecked, fromScratchChecked } = this.state;
-        const radioChecked = { copyBaselineChecked, copySystemChecked, fromScratchChecked };
-        let keys = Object.keys(radioChecked);
-        let selectedKey;
-
-        keys.forEach(function(key) {
-            if (radioChecked[key]) {
-                selectedKey = key.substring(0, key.length - 7).toLowerCase();
-            }
-        });
-
-        return selectedKey;
-    }
-
-    async submitBaselineName() {
-        const { baselineName, fromScratchChecked, copyBaselineChecked, copySystemChecked } = this.state;
-        const { createBaseline, toggleCreateBaselineModal, selectedBaselineIds,
-            entities, clearSelectedBaselines, selectSingleHSP, navigate } = this.props;
-
-        /*eslint-disable camelcase*/
-        let newBaselineObject = { display_name: baselineName };
-
-        try {
-            if (baselineName !== '') {
-                if (fromScratchChecked) {
-                    newBaselineObject.baseline_facts = [];
-                    await createBaseline(newBaselineObject);
-                } else if (selectedBaselineIds.length === 1 && copyBaselineChecked) {
-                    newBaselineObject = { display_name: baselineName };
-                    await createBaseline(newBaselineObject, selectedBaselineIds[0]);
-                } else if (entities?.selectedSystemIds.length && copySystemChecked) {
-                    newBaselineObject.inventory_uuid = entities?.selectedSystemIds[0];
-                    await createBaseline(newBaselineObject);
-                } else if (entities?.selectedHSP && copySystemChecked) {
-                    newBaselineObject.hsp_uuid = entities.selectedHSP.id;
-                    await createBaseline(newBaselineObject);
-                }
-
-                navigate('/baselines/' + this.props.baselineData.id);
-                toggleCreateBaselineModal();
-                selectSingleHSP();
-                clearSelectedBaselines('RADIO');
-            }
-        } catch (e) {
-            // do nothing and let redux handle
-        }
-        /*eslint-enable camelcase*/
-    }
-
-    onSelect = (event, isSelected, rowId) => {
-        const { baselineTableData, selectBaseline } = this.props;
-
-        let id = [ baselineTableData[rowId][0] ];
-        selectBaseline(id, isSelected, 'RADIO');
-    }
-
-    cancelModal = () => {
-        const { toggleCreateBaselineModal, clearSelectedBaselines, selectSingleHSP } = this.props;
-
-        this.updateBaselineName('');
-        clearSelectedBaselines('RADIO');
-        selectSingleHSP();
-        toggleCreateBaselineModal();
-    }
-
-    renderRadioButtons() {
-        const { fromScratchChecked, copyBaselineChecked, copySystemChecked } = this.state;
-
-        return (<React.Fragment>
-            <Radio
-                isChecked={ fromScratchChecked }
-                id='create baseline'
-                ouiaId='create-baseline-from-scratch-radio'
-                name='baseline-create-options'
-                label='Create baseline from scratch'
-                value='fromScratchChecked'
-                onChange={ this.handleChecked }
-            />
-            <Radio
-                isChecked={ copyBaselineChecked }
-                id='copy baseline'
-                ouiaId='create-baseline-copy-baseline-radio'
-                name='baseline-create-options'
-                label='Copy an existing baseline'
-                value='copyBaselineChecked'
-                onChange={ this.handleChecked }
-            />
-            <Radio
-                isChecked={ copySystemChecked }
-                id='copy system'
-                ouiaId='create-baseline-copy-system-radio'
-                name='baseline-create-options'
-                label='Copy an existing system or historical profile'
-                value='copySystemChecked'
-                onChange={ this.handleChecked }
-            />
-        </React.Fragment>
-        );
-    }
-
-    renderCopyBaseline() {
-        const { baselineTableData, loading, permissions, selectedBaselineIds, totalBaselines,
-            revertBaselineFetch, baselineError, emptyState } = this.props;
-        const { columns } = this.state;
-
-        return (<React.Fragment>
-            <b>Select baseline to copy from</b>
-            <BaselinesTable
-                tableId='RADIO'
-                onSelect={ this.onSelect }
-                tableData={ baselineTableData }
-                loading={ loading }
-                columns={ columns }
-                totalBaselines={ totalBaselines }
-                permissions={ permissions }
-                hasMultiSelect={ false }
-                selectedBaselineIds={ selectedBaselineIds }
-                leftAlignToolbar={ true }
-                hasSwitch={ false }
-                revertBaselineFetch={ revertBaselineFetch }
-                baselineError={ baselineError }
-                emptyState={ emptyState }
-            />
-        </React.Fragment>
-        );
-    }
-
-    renderCopySystem() {
-        const { entities, permissions } = this.props;
-
+    const renderCopySystem = () => {
         return (<React.Fragment>
             <b>Select system or historical profile to copy from</b>
             <br></br>
@@ -244,33 +272,54 @@ export class CreateBaselineModal extends Component {
                 permissions={ permissions }
                 entities={ entities }
                 selectVariant='radio'
-                systemColumns={ this.buildSystemColumns }
-                deselectHistoricalProfiles={ this.deselectHistoricalProfiles }
+                systemColumns={ buildSystemColumns }
+                deselectHistoricalProfiles={ deselectHistoricalProfiles }
             />
         </React.Fragment>
         );
-    }
+    };
 
-    checkKeyPress = (event) => {
+    const renderCopyBaseline = () => {
+        return (<React.Fragment>
+            <b>Select baseline to copy from</b>
+            <BaselinesTable
+                tableId='RADIO'
+                onSelect={ onSelect }
+                tableData={ baselineTableData }
+                loading={ loading }
+                columns={ columns }
+                totalBaselines={ totalBaselines }
+                permissions={ permissions }
+                hasMultiSelect={ false }
+                selectedBaselineIds={ selectedBaselineIds }
+                leftAlignToolbar={ true }
+                hasSwitch={ false }
+                revertBaselineFetch={ baselinesTableActions.revertBaselineFetch }
+                baselineError={ baselineError }
+                emptyState={ emptyState }
+            />
+        </React.Fragment>
+        );
+    };
+
+    const checkKeyPress = (event) => {
         if (event.key === 'Enter') {
             event.preventDefault();
-            this.state.baselineName ? this.submitBaselineName() : null;
+            baselineName ? submitBaselineName() : null;
         }
-    }
+    };
 
-    renderModalBody = () => {
-        const { baselineName, copyBaselineChecked, copySystemChecked } = this.state;
-        const { createBaselineError } = this.props;
+    const renderModalBody = () => {
         let modalBody;
 
         if (copyBaselineChecked) {
-            modalBody = this.renderCopyBaseline();
+            modalBody = renderCopyBaseline();
         } else if (copySystemChecked) {
-            modalBody = this.renderCopySystem();
+            modalBody = renderCopySystem();
         }
 
         return (<React.Fragment>
-            { this.renderRadioButtons() }
+            { renderRadioButtons() }
             <div className='md-padding-top md-padding-bottom'>
                 <Form>
                     <FormGroup
@@ -280,13 +329,13 @@ export class CreateBaselineModal extends Component {
                         helperTextInvalid={ Object.prototype.hasOwnProperty.call(createBaselineError, 'detail') ? createBaselineError.detail : null }
                         fieldId="name"
                         validated={ Object.prototype.hasOwnProperty.call(createBaselineError, 'status') ? 'error' : null }
-                        onKeyPress={ this.checkKeyPress }
+                        onKeyPress={ checkKeyPress }
                     >
                         <TextInput
                             className="fact-value"
                             value={ baselineName }
                             type="text"
-                            onChange={ this.updateBaselineName }
+                            onChange={ (value) => setBaselineName(value) }
                             validated={ Object.prototype.hasOwnProperty.call(createBaselineError, 'status') ? ValidatedOptions.error : null }
                             aria-label="baseline name"
                         />
@@ -296,146 +345,30 @@ export class CreateBaselineModal extends Component {
             { modalBody }
         </React.Fragment>
         );
-    }
-
-    renderActions() {
-        const { selectedBaselineIds, entities } = this.props;
-        const { baselineName, copyBaselineChecked, copySystemChecked } = this.state;
-        let actions;
-
-        if (baselineName === ''
-            || (copyBaselineChecked && selectedBaselineIds.length === 0)
-            || (copySystemChecked &&
-                (!entities?.selectedSystemIds.length && !entities?.selectedHSP)
-            )
-        ) {
-            actions = [
-                <Button
-                    key="confirm"
-                    variant="primary"
-                    isDisabled
-                    ouiaId={ 'create-baseline-button-' + this.findSelectedRadio() }
-                >
-                    Create baseline
-                </Button>,
-                <Button
-                    key="cancel"
-                    variant="link"
-                    onClick={ this.cancelModal }
-                    ouiaId="create-baseline-modal-cancel-button"
-                >
-                    Cancel
-                </Button>
-            ];
-        } else {
-            actions = [
-                <Button
-                    key="confirm"
-                    variant="primary"
-                    onClick={ this.submitBaselineName }
-                    ouiaId={ 'create-baseline-button-' + this.findSelectedRadio() }
-                >
-                    Create baseline
-                </Button>,
-                <Button
-                    key="cancel"
-                    variant="link"
-                    onClick={ this.cancelModal }
-                    ouiaId="create-baseline-modal-cancel-button"
-                >
-                    Cancel
-                </Button>
-            ];
-        }
-
-        return actions;
-    }
-
-    render() {
-        const { createBaselineModalOpened, globalFilterState } = this.props;
-        const { copySystemChecked } = this.state;
-
-        return (
-            <Modal
-                className="drift create-baseline-modal"
-                width="1200px"
-                title="Create baseline"
-                isOpen={ createBaselineModalOpened }
-                onClose={ this.cancelModal }
-                actions={ this.renderActions() }
-            >
-                { copySystemChecked
-                    ? <GlobalFilterAlert globalFilterState={ globalFilterState }/>
-                    : null
-                }
-                { this.renderModalBody() }
-            </Modal>
-        );
-    }
-}
-
-CreateBaselineModal.propTypes = {
-    createBaselineModalOpened: PropTypes.bool,
-    createBaseline: PropTypes.func,
-    selectBaseline: PropTypes.func,
-    baselineData: PropTypes.object,
-    toggleCreateBaselineModal: PropTypes.func,
-    clearSelectedBaselines: PropTypes.func,
-    entities: PropTypes.object,
-    selectedBaselineIds: PropTypes.array,
-    createBaselineError: PropTypes.object,
-    baselineTableData: PropTypes.array,
-    loading: PropTypes.bool,
-    totalBaselines: PropTypes.number,
-    updatePagination: PropTypes.func,
-    historicalProfiles: PropTypes.array,
-    permissions: PropTypes.object,
-    globalFilterState: PropTypes.object,
-    selectHistoricProfiles: PropTypes.func,
-    setSelectedSystemIds: PropTypes.func,
-    selectSingleHSP: PropTypes.func,
-    updateColumns: PropTypes.func,
-    baselineError: PropTypes.object,
-    revertBaselineFetch: PropTypes.func,
-    emptyState: PropTypes.bool,
-    middlewareListener: PropTypes.object,
-    navigate: PropTypes.func
-};
-
-function mapStateToProps(state) {
-    return {
-        createBaselineModalOpened: state.createBaselineModalState.createBaselineModalOpened,
-        baselineData: state.createBaselineModalState.baselineData,
-        entities: state.entities,
-        selectedBaselineIds: state.baselinesTableState.radioTable.selectedBaselineIds,
-        createBaselineError: state.createBaselineModalState.createBaselineError,
-        loading: state.baselinesTableState.radioTable.loading,
-        emptyState: state.baselinesTableState.radioTable.emptyState,
-        baselineTableData: state.baselinesTableState.radioTable.baselineTableData,
-        totalBaselines: state.baselinesTableState.radioTable.totalBaselines,
-        historicalProfiles: state.compareState.historicalProfiles,
-        globalFilterState: state.globalFilterState,
-        baselineError: state.baselinesTableState.radioTable.baselineError
     };
-}
 
-function mapDispatchToProps(dispatch) {
-    return {
-        toggleCreateBaselineModal: () => dispatch(createBaselineModalActions.toggleCreateBaselineModal()),
-        createBaseline: (newBaselineObject, uuid) => dispatch(createBaselineModalActions.createBaseline(newBaselineObject, uuid)),
-        selectBaseline: (id, isSelected, tableId) => dispatch(baselinesTableActions.selectBaseline(id, isSelected, tableId)),
-        clearSelectedBaselines: (tableId) => dispatch(baselinesTableActions.clearSelectedBaselines(tableId)),
-        selectSingleHSP: (profile) => dispatch(systemsTableActions.selectSingleHSP(profile)),
-        updateColumns: (key) => dispatch(systemsTableActions.updateColumns(key)),
-        revertBaselineFetch: () => dispatch(baselinesTableActions.revertBaselineFetch('RADIO'))
-    };
-}
-
-const CreateBaselineModalWithHooks = props => {
-    const navigate = useInsightsNavigate();
     return (
-        <CreateBaselineModal { ...props } navigate={ navigate } />
+        <Modal
+            className="drift create-baseline-modal"
+            aria-label='create-baseline-modal'
+            width="1200px"
+            title="Create baseline"
+            isOpen={ createBaselineModalOpened }
+            onClose={ cancelModal }
+            actions={ renderActions() }
+        >
+            { copySystemChecked
+                ? <GlobalFilterAlert globalFilterState={ globalFilterState }/>
+                : null
+            }
+            { renderModalBody() }
+        </Modal>
     );
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(CreateBaselineModalWithHooks);
+CreateBaselineModal.propTypes = {
+    middlewareListener: PropTypes.object,
+    permissions: PropTypes.object
+};
+
+export default CreateBaselineModal;

--- a/src/SmartComponents/BaselinesPage/CreateBaselineModal/__tests__/__snapshots__/CreateBaselineModal.tests.js.snap
+++ b/src/SmartComponents/BaselinesPage/CreateBaselineModal/__tests__/__snapshots__/CreateBaselineModal.tests.js.snap
@@ -1,1116 +1,206 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ConnectedCreateBaselineModal should render correctly 1`] = `
-<MemoryRouter
-  keyLength={0}
->
-  <Router
-    location={
-      Object {
-        "hash": "",
-        "key": "default",
-        "pathname": "/",
-        "search": "",
-        "state": null,
-      }
-    }
-    navigationType="POP"
-    navigator={
-      Object {
-        "action": "POP",
-        "createHref": [Function],
-        "createURL": [Function],
-        "encodeLocation": [Function],
-        "go": [Function],
-        "index": 0,
-        "listen": [Function],
-        "location": Object {
-          "hash": "",
-          "key": "default",
-          "pathname": "/",
-          "search": "",
-          "state": null,
-        },
-        "push": [Function],
-        "replace": [Function],
-      }
-    }
-  >
-    <Provider
-      store={
-        Object {
-          "clearActions": [Function],
-          "dispatch": [Function],
-          "getActions": [Function],
-          "getState": [Function],
-          "replaceReducer": [Function],
-          "subscribe": [Function],
-        }
-      }
-    >
-      <Connect(CreateBaselineModalWithHooks)>
-        <CreateBaselineModalWithHooks
-          baselineData={Object {}}
-          baselineTableData={Array []}
-          clearSelectedBaselines={[Function]}
-          createBaseline={[Function]}
-          createBaselineError={Object {}}
-          createBaselineModalOpened={true}
-          emptyState={Object {}}
-          entities={Object {}}
-          historicalProfiles={Array []}
-          loading={false}
-          revertBaselineFetch={[Function]}
-          selectBaseline={[Function]}
-          selectSingleHSP={[Function]}
-          selectedBaselineIds={Array []}
-          toggleCreateBaselineModal={[Function]}
-          updateColumns={[Function]}
-        >
-          <CreateBaselineModal
-            baselineData={Object {}}
-            baselineTableData={Array []}
-            clearSelectedBaselines={[Function]}
-            createBaseline={[Function]}
-            createBaselineError={Object {}}
-            createBaselineModalOpened={true}
-            emptyState={Object {}}
-            entities={Object {}}
-            historicalProfiles={Array []}
-            loading={false}
-            navigate={[MockFunction]}
-            revertBaselineFetch={[Function]}
-            selectBaseline={[Function]}
-            selectSingleHSP={[Function]}
-            selectedBaselineIds={Array []}
-            toggleCreateBaselineModal={[Function]}
-            updateColumns={[Function]}
-          >
-            <Modal
-              actions={
-                Array [
-                  <Button
-                    isDisabled={true}
-                    ouiaId="create-baseline-button-fromscratch"
-                    variant="primary"
-                  >
-                    Create baseline
-                  </Button>,
-                  <Button
-                    onClick={[Function]}
-                    ouiaId="create-baseline-modal-cancel-button"
-                    variant="link"
-                  >
-                    Cancel
-                  </Button>,
-                ]
-              }
-              appendTo={[Function]}
-              aria-describedby=""
-              aria-label=""
-              aria-labelledby=""
-              className="drift create-baseline-modal"
-              hasNoBodyWrapper={false}
-              isOpen={true}
-              onClose={[Function]}
-              ouiaSafe={true}
-              showClose={true}
-              title="Create baseline"
-              titleIconVariant={null}
-              titleLabel=""
-              variant="default"
-              width="1200px"
-            >
-              <Portal
-                containerInfo={
-                  <div>
-                    <div
-                      class="pf-c-backdrop"
-                    >
-                      <div
-                        class="pf-l-bullseye"
-                      >
-                        <div
-                          aria-describedby="pf-modal-part-7"
-                          aria-labelledby="pf-modal-part-6"
-                          aria-modal="true"
-                          class="pf-c-modal-box drift create-baseline-modal"
-                          data-ouia-component-id="OUIA-Generated-Modal-default-6"
-                          data-ouia-component-type="PF4/ModalContent"
-                          data-ouia-safe="true"
-                          id="pf-modal-part-5"
-                          role="dialog"
-                          style="width: 1200px;"
-                        >
-                          <button
-                            aria-disabled="false"
-                            aria-label="Close"
-                            class="pf-c-button pf-m-plain"
-                            data-ouia-component-id="OUIA-Generated-Modal-default-6-ModalBoxCloseButton"
-                            data-ouia-component-type="PF4/Button"
-                            data-ouia-safe="true"
-                            type="button"
-                          >
-                            <svg
-                              aria-hidden="true"
-                              fill="currentColor"
-                              height="1em"
-                              role="img"
-                              style="vertical-align: -0.125em;"
-                              viewBox="0 0 352 512"
-                              width="1em"
-                            >
-                              <path
-                                d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                              />
-                            </svg>
-                          </button>
-                          <header
-                            class="pf-c-modal-box__header"
-                          >
-                            <h1
-                              class="pf-c-modal-box__title"
-                              id="pf-modal-part-6"
-                            >
-                              
-                              <span
-                                class="pf-c-modal-box__title-text"
-                              >
-                                Create baseline
-                              </span>
-                            </h1>
-                          </header>
-                          <div
-                            class="pf-c-modal-box__body"
-                            id="pf-modal-part-7"
-                          >
-                            <div
-                              class="pf-c-radio"
-                            >
-                              <input
-                                aria-invalid="false"
-                                checked=""
-                                class="pf-c-radio__input"
-                                data-ouia-component-id="create-baseline-from-scratch-radio"
-                                data-ouia-component-type="PF4/Radio"
-                                data-ouia-safe="true"
-                                id="create baseline"
-                                name="baseline-create-options"
-                                type="radio"
-                                value="fromScratchChecked"
-                              />
-                              <label
-                                class="pf-c-radio__label"
-                                for="create baseline"
-                              >
-                                Create baseline from scratch
-                              </label>
-                            </div>
-                            <div
-                              class="pf-c-radio"
-                            >
-                              <input
-                                aria-invalid="false"
-                                class="pf-c-radio__input"
-                                data-ouia-component-id="create-baseline-copy-baseline-radio"
-                                data-ouia-component-type="PF4/Radio"
-                                data-ouia-safe="true"
-                                id="copy baseline"
-                                name="baseline-create-options"
-                                type="radio"
-                                value="copyBaselineChecked"
-                              />
-                              <label
-                                class="pf-c-radio__label"
-                                for="copy baseline"
-                              >
-                                Copy an existing baseline
-                              </label>
-                            </div>
-                            <div
-                              class="pf-c-radio"
-                            >
-                              <input
-                                aria-invalid="false"
-                                class="pf-c-radio__input"
-                                data-ouia-component-id="create-baseline-copy-system-radio"
-                                data-ouia-component-type="PF4/Radio"
-                                data-ouia-safe="true"
-                                id="copy system"
-                                name="baseline-create-options"
-                                type="radio"
-                                value="copySystemChecked"
-                              />
-                              <label
-                                class="pf-c-radio__label"
-                                for="copy system"
-                              >
-                                Copy an existing system or historical profile
-                              </label>
-                            </div>
-                            <div
-                              class="md-padding-top md-padding-bottom"
-                            >
-                              <form
-                                class="pf-c-form"
-                                novalidate=""
-                              >
-                                <div
-                                  class="pf-c-form__group"
-                                  type="text"
-                                >
-                                  <div
-                                    class="pf-c-form__group-label"
-                                  >
-                                    <label
-                                      class="pf-c-form__label"
-                                      for="name"
-                                    >
-                                      <span
-                                        class="pf-c-form__label-text"
-                                      >
-                                        Baseline name
-                                      </span>
-                                      <span
-                                        aria-hidden="true"
-                                        class="pf-c-form__label-required"
-                                      >
-                                         
-                                        *
-                                      </span>
-                                    </label>
-                                     
-                                  </div>
-                                  <div
-                                    class="pf-c-form__group-control"
-                                  >
-                                    <input
-                                      aria-invalid="false"
-                                      aria-label="baseline name"
-                                      class="pf-c-form-control fact-value"
-                                      data-ouia-component-id="OUIA-Generated-TextInputBase-5"
-                                      data-ouia-component-type="PF4/TextInput"
-                                      data-ouia-safe="true"
-                                      type="text"
-                                      value=""
-                                    />
-                                    
-                                  </div>
-                                </div>
-                              </form>
-                            </div>
-                          </div>
-                          <footer
-                            class="pf-c-modal-box__footer"
-                          >
-                            <button
-                              aria-disabled="true"
-                              class="pf-c-button pf-m-primary pf-m-disabled"
-                              data-ouia-component-id="create-baseline-button-fromscratch"
-                              data-ouia-component-type="PF4/Button"
-                              data-ouia-safe="true"
-                              disabled=""
-                              type="button"
-                            >
-                              Create baseline
-                            </button>
-                            <button
-                              aria-disabled="false"
-                              class="pf-c-button pf-m-link"
-                              data-ouia-component-id="create-baseline-modal-cancel-button"
-                              data-ouia-component-type="PF4/Button"
-                              data-ouia-safe="true"
-                              type="button"
-                            >
-                              Cancel
-                            </button>
-                          </footer>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                }
-              >
-                <ModalContent
-                  actions={
-                    Array [
-                      <Button
-                        isDisabled={true}
-                        ouiaId="create-baseline-button-fromscratch"
-                        variant="primary"
-                      >
-                        Create baseline
-                      </Button>,
-                      <Button
-                        onClick={[Function]}
-                        ouiaId="create-baseline-modal-cancel-button"
-                        variant="link"
-                      >
-                        Cancel
-                      </Button>,
-                    ]
-                  }
-                  aria-describedby=""
-                  aria-label=""
-                  aria-labelledby=""
-                  boxId="pf-modal-part-5"
-                  className="drift create-baseline-modal"
-                  descriptorId="pf-modal-part-7"
-                  hasNoBodyWrapper={false}
-                  isOpen={true}
-                  labelId="pf-modal-part-6"
-                  onClose={[Function]}
-                  ouiaId="OUIA-Generated-Modal-default-6"
-                  ouiaSafe={true}
-                  showClose={true}
-                  title="Create baseline"
-                  titleIconVariant={null}
-                  titleLabel=""
-                  variant="default"
-                  width="1200px"
-                >
-                  <Backdrop>
-                    <div
-                      className="pf-c-backdrop"
-                    >
-                      <ForwardRef
-                        active={true}
-                        className="pf-l-bullseye"
-                        focusTrapOptions={
-                          Object {
-                            "clickOutsideDeactivates": true,
-                            "tabbableOptions": Object {
-                              "displayCheck": "none",
-                            },
-                          }
-                        }
-                      >
-                        <FocusTrap
-                          active={true}
-                          className="pf-l-bullseye"
-                          focusTrapOptions={
-                            Object {
-                              "clickOutsideDeactivates": true,
-                              "tabbableOptions": Object {
-                                "displayCheck": "none",
-                              },
-                            }
-                          }
-                          innerRef={null}
-                          paused={false}
-                          preventScrollOnDeactivate={false}
-                        >
-                          <div
-                            className="pf-l-bullseye"
-                          >
-                            <ModalBox
-                              aria-describedby="pf-modal-part-7"
-                              aria-label=""
-                              aria-labelledby="pf-modal-part-6"
-                              className="drift create-baseline-modal"
-                              data-ouia-component-id="OUIA-Generated-Modal-default-6"
-                              data-ouia-component-type="PF4/ModalContent"
-                              data-ouia-safe={true}
-                              id="pf-modal-part-5"
-                              style={
-                                Object {
-                                  "width": "1200px",
-                                }
-                              }
-                              variant="default"
-                            >
-                              <div
-                                aria-describedby="pf-modal-part-7"
-                                aria-label={null}
-                                aria-labelledby="pf-modal-part-6"
-                                aria-modal="true"
-                                className="pf-c-modal-box drift create-baseline-modal"
-                                data-ouia-component-id="OUIA-Generated-Modal-default-6"
-                                data-ouia-component-type="PF4/ModalContent"
-                                data-ouia-safe={true}
-                                id="pf-modal-part-5"
-                                role="dialog"
-                                style={
-                                  Object {
-                                    "width": "1200px",
-                                  }
-                                }
-                              >
-                                <ModalBoxCloseButton
-                                  onClose={[Function]}
-                                  ouiaId="OUIA-Generated-Modal-default-6"
-                                >
-                                  <Button
-                                    aria-label="Close"
-                                    className=""
-                                    onClick={[Function]}
-                                    ouiaId="OUIA-Generated-Modal-default-6-ModalBoxCloseButton"
-                                    variant="plain"
-                                  >
-                                    <ButtonBase
-                                      aria-label="Close"
-                                      className=""
-                                      innerRef={null}
-                                      onClick={[Function]}
-                                      ouiaId="OUIA-Generated-Modal-default-6-ModalBoxCloseButton"
-                                      variant="plain"
-                                    >
-                                      <button
-                                        aria-disabled={false}
-                                        aria-label="Close"
-                                        className="pf-c-button pf-m-plain"
-                                        data-ouia-component-id="OUIA-Generated-Modal-default-6-ModalBoxCloseButton"
-                                        data-ouia-component-type="PF4/Button"
-                                        data-ouia-safe={true}
-                                        disabled={false}
-                                        onClick={[Function]}
-                                        role={null}
-                                        type="button"
-                                      >
-                                        <TimesIcon
-                                          color="currentColor"
-                                          noVerticalAlign={false}
-                                          size="sm"
-                                        >
-                                          <svg
-                                            aria-hidden={true}
-                                            aria-labelledby={null}
-                                            fill="currentColor"
-                                            height="1em"
-                                            role="img"
-                                            style={
-                                              Object {
-                                                "verticalAlign": "-0.125em",
-                                              }
-                                            }
-                                            viewBox="0 0 352 512"
-                                            width="1em"
-                                          >
-                                            <path
-                                              d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                                            />
-                                          </svg>
-                                        </TimesIcon>
-                                      </button>
-                                    </ButtonBase>
-                                  </Button>
-                                </ModalBoxCloseButton>
-                                <ModalBoxHeader
-                                  help={null}
-                                >
-                                  <header
-                                    className="pf-c-modal-box__header"
-                                  >
-                                    <ModalBoxTitle
-                                      id="pf-modal-part-6"
-                                      title="Create baseline"
-                                      titleIconVariant={null}
-                                      titleLabel=""
-                                    >
-                                      <h1
-                                        className="pf-c-modal-box__title"
-                                        id="pf-modal-part-6"
-                                      >
-                                        <span
-                                          className="pf-c-modal-box__title-text"
-                                        >
-                                          Create baseline
-                                        </span>
-                                      </h1>
-                                    </ModalBoxTitle>
-                                  </header>
-                                </ModalBoxHeader>
-                                <ModalBoxBody
-                                  id="pf-modal-part-7"
-                                >
-                                  <div
-                                    className="pf-c-modal-box__body"
-                                    id="pf-modal-part-7"
-                                  >
-                                    <Radio
-                                      className=""
-                                      id="create baseline"
-                                      isChecked={true}
-                                      isDisabled={false}
-                                      isValid={true}
-                                      label="Create baseline from scratch"
-                                      name="baseline-create-options"
-                                      onChange={[Function]}
-                                      ouiaId="create-baseline-from-scratch-radio"
-                                      value="fromScratchChecked"
-                                    >
-                                      <div
-                                        className="pf-c-radio"
-                                      >
-                                        <input
-                                          aria-invalid={false}
-                                          checked={true}
-                                          className="pf-c-radio__input"
-                                          data-ouia-component-id="create-baseline-from-scratch-radio"
-                                          data-ouia-component-type="PF4/Radio"
-                                          data-ouia-safe={true}
-                                          disabled={false}
-                                          id="create baseline"
-                                          name="baseline-create-options"
-                                          onChange={[Function]}
-                                          type="radio"
-                                          value="fromScratchChecked"
-                                        />
-                                        <label
-                                          className="pf-c-radio__label"
-                                          htmlFor="create baseline"
-                                        >
-                                          Create baseline from scratch
-                                        </label>
-                                      </div>
-                                    </Radio>
-                                    <Radio
-                                      className=""
-                                      id="copy baseline"
-                                      isChecked={false}
-                                      isDisabled={false}
-                                      isValid={true}
-                                      label="Copy an existing baseline"
-                                      name="baseline-create-options"
-                                      onChange={[Function]}
-                                      ouiaId="create-baseline-copy-baseline-radio"
-                                      value="copyBaselineChecked"
-                                    >
-                                      <div
-                                        className="pf-c-radio"
-                                      >
-                                        <input
-                                          aria-invalid={false}
-                                          checked={false}
-                                          className="pf-c-radio__input"
-                                          data-ouia-component-id="create-baseline-copy-baseline-radio"
-                                          data-ouia-component-type="PF4/Radio"
-                                          data-ouia-safe={true}
-                                          disabled={false}
-                                          id="copy baseline"
-                                          name="baseline-create-options"
-                                          onChange={[Function]}
-                                          type="radio"
-                                          value="copyBaselineChecked"
-                                        />
-                                        <label
-                                          className="pf-c-radio__label"
-                                          htmlFor="copy baseline"
-                                        >
-                                          Copy an existing baseline
-                                        </label>
-                                      </div>
-                                    </Radio>
-                                    <Radio
-                                      className=""
-                                      id="copy system"
-                                      isChecked={false}
-                                      isDisabled={false}
-                                      isValid={true}
-                                      label="Copy an existing system or historical profile"
-                                      name="baseline-create-options"
-                                      onChange={[Function]}
-                                      ouiaId="create-baseline-copy-system-radio"
-                                      value="copySystemChecked"
-                                    >
-                                      <div
-                                        className="pf-c-radio"
-                                      >
-                                        <input
-                                          aria-invalid={false}
-                                          checked={false}
-                                          className="pf-c-radio__input"
-                                          data-ouia-component-id="create-baseline-copy-system-radio"
-                                          data-ouia-component-type="PF4/Radio"
-                                          data-ouia-safe={true}
-                                          disabled={false}
-                                          id="copy system"
-                                          name="baseline-create-options"
-                                          onChange={[Function]}
-                                          type="radio"
-                                          value="copySystemChecked"
-                                        />
-                                        <label
-                                          className="pf-c-radio__label"
-                                          htmlFor="copy system"
-                                        >
-                                          Copy an existing system or historical profile
-                                        </label>
-                                      </div>
-                                    </Radio>
-                                    <div
-                                      className="md-padding-top md-padding-bottom"
-                                    >
-                                      <Form>
-                                        <FormBase
-                                          innerRef={null}
-                                        >
-                                          <form
-                                            className="pf-c-form"
-                                            noValidate={true}
-                                          >
-                                            <FormGroup
-                                              fieldId="name"
-                                              helperTextInvalid={null}
-                                              isRequired={true}
-                                              label="Baseline name"
-                                              onKeyPress={[Function]}
-                                              type="text"
-                                              validated={null}
-                                            >
-                                              <GenerateId
-                                                prefix="pf-random-id-"
-                                              >
-                                                <div
-                                                  className="pf-c-form__group"
-                                                  onKeyPress={[Function]}
-                                                  type="text"
-                                                >
-                                                  <div
-                                                    className="pf-c-form__group-label"
-                                                  >
-                                                    <label
-                                                      className="pf-c-form__label"
-                                                      htmlFor="name"
-                                                    >
-                                                      <span
-                                                        className="pf-c-form__label-text"
-                                                      >
-                                                        Baseline name
-                                                      </span>
-                                                      <span
-                                                        aria-hidden="true"
-                                                        className="pf-c-form__label-required"
-                                                      >
-                                                         
-                                                        *
-                                                      </span>
-                                                    </label>
-                                                     
-                                                  </div>
-                                                  <div
-                                                    className="pf-c-form__group-control"
-                                                  >
-                                                    <TextInput
-                                                      aria-label="baseline name"
-                                                      className="fact-value"
-                                                      onChange={[Function]}
-                                                      type="text"
-                                                      validated={null}
-                                                      value=""
-                                                    >
-                                                      <TextInputBase
-                                                        aria-label="baseline name"
-                                                        className="fact-value"
-                                                        innerRef={null}
-                                                        isDisabled={false}
-                                                        isIconSprite={false}
-                                                        isLeftTruncated={false}
-                                                        isReadOnly={false}
-                                                        isRequired={false}
-                                                        onChange={[Function]}
-                                                        ouiaSafe={true}
-                                                        type="text"
-                                                        validated={null}
-                                                        value=""
-                                                      >
-                                                        <input
-                                                          aria-invalid={false}
-                                                          aria-label="baseline name"
-                                                          className="pf-c-form-control fact-value"
-                                                          data-ouia-component-id="OUIA-Generated-TextInputBase-5"
-                                                          data-ouia-component-type="PF4/TextInput"
-                                                          data-ouia-safe={true}
-                                                          disabled={false}
-                                                          onBlur={[Function]}
-                                                          onChange={[Function]}
-                                                          onFocus={[Function]}
-                                                          required={false}
-                                                          type="text"
-                                                          value=""
-                                                        />
-                                                      </TextInputBase>
-                                                    </TextInput>
-                                                  </div>
-                                                </div>
-                                              </GenerateId>
-                                            </FormGroup>
-                                          </form>
-                                        </FormBase>
-                                      </Form>
-                                    </div>
-                                  </div>
-                                </ModalBoxBody>
-                                <ModalBoxFooter>
-                                  <footer
-                                    className="pf-c-modal-box__footer"
-                                  >
-                                    <Button
-                                      isDisabled={true}
-                                      key="confirm"
-                                      ouiaId="create-baseline-button-fromscratch"
-                                      variant="primary"
-                                    >
-                                      <ButtonBase
-                                        innerRef={null}
-                                        isDisabled={true}
-                                        ouiaId="create-baseline-button-fromscratch"
-                                        variant="primary"
-                                      >
-                                        <button
-                                          aria-disabled={true}
-                                          aria-label={null}
-                                          className="pf-c-button pf-m-primary pf-m-disabled"
-                                          data-ouia-component-id="create-baseline-button-fromscratch"
-                                          data-ouia-component-type="PF4/Button"
-                                          data-ouia-safe={true}
-                                          disabled={true}
-                                          role={null}
-                                          tabIndex={null}
-                                          type="button"
-                                        >
-                                          Create baseline
-                                        </button>
-                                      </ButtonBase>
-                                    </Button>
-                                    <Button
-                                      key="cancel"
-                                      onClick={[Function]}
-                                      ouiaId="create-baseline-modal-cancel-button"
-                                      variant="link"
-                                    >
-                                      <ButtonBase
-                                        innerRef={null}
-                                        onClick={[Function]}
-                                        ouiaId="create-baseline-modal-cancel-button"
-                                        variant="link"
-                                      >
-                                        <button
-                                          aria-disabled={false}
-                                          aria-label={null}
-                                          className="pf-c-button pf-m-link"
-                                          data-ouia-component-id="create-baseline-modal-cancel-button"
-                                          data-ouia-component-type="PF4/Button"
-                                          data-ouia-safe={true}
-                                          disabled={false}
-                                          onClick={[Function]}
-                                          role={null}
-                                          type="button"
-                                        >
-                                          Cancel
-                                        </button>
-                                      </ButtonBase>
-                                    </Button>
-                                  </footer>
-                                </ModalBoxFooter>
-                              </div>
-                            </ModalBox>
-                          </div>
-                        </FocusTrap>
-                      </ForwardRef>
-                    </div>
-                  </Backdrop>
-                </ModalContent>
-              </Portal>
-            </Modal>
-          </CreateBaselineModal>
-        </CreateBaselineModalWithHooks>
-      </Connect(CreateBaselineModalWithHooks)>
-    </Provider>
-  </Router>
-</MemoryRouter>
-`;
-
 exports[`CreateBaselineModal should render correctly 1`] = `
-<Modal
-  actions={
-    Array [
-      <Button
-        isDisabled={true}
-        ouiaId="create-baseline-button-fromscratch"
-        variant="primary"
-      >
-        Create baseline
-      </Button>,
-      <Button
-        onClick={[Function]}
-        ouiaId="create-baseline-modal-cancel-button"
-        variant="link"
-      >
-        Cancel
-      </Button>,
-    ]
-  }
-  appendTo={[Function]}
-  aria-describedby=""
-  aria-label=""
-  aria-labelledby=""
-  className="drift create-baseline-modal"
-  hasNoBodyWrapper={false}
-  isOpen={false}
-  onClose={[Function]}
-  ouiaSafe={true}
-  showClose={true}
-  title="Create baseline"
-  titleIconVariant={null}
-  titleLabel=""
-  variant="default"
-  width="1200px"
+<div
+  aria-describedby="pf-modal-part-2"
+  aria-label="create-baseline-modal"
+  aria-labelledby="pf-modal-part-0 pf-modal-part-1"
+  aria-modal="true"
+  class="pf-c-modal-box drift create-baseline-modal"
+  data-ouia-component-id="OUIA-Generated-Modal-default-1"
+  data-ouia-component-type="PF4/ModalContent"
+  data-ouia-safe="true"
+  id="pf-modal-part-0"
+  role="dialog"
+  style="width: 1200px;"
 >
-  <Radio
-    className=""
-    id="create baseline"
-    isChecked={true}
-    isDisabled={false}
-    isValid={true}
-    label="Create baseline from scratch"
-    name="baseline-create-options"
-    onChange={[Function]}
-    ouiaId="create-baseline-from-scratch-radio"
-    value="fromScratchChecked"
-  />
-  <Radio
-    className=""
-    id="copy baseline"
-    isChecked={false}
-    isDisabled={false}
-    isValid={true}
-    label="Copy an existing baseline"
-    name="baseline-create-options"
-    onChange={[Function]}
-    ouiaId="create-baseline-copy-baseline-radio"
-    value="copyBaselineChecked"
-  />
-  <Radio
-    className=""
-    id="copy system"
-    isChecked={false}
-    isDisabled={false}
-    isValid={true}
-    label="Copy an existing system or historical profile"
-    name="baseline-create-options"
-    onChange={[Function]}
-    ouiaId="create-baseline-copy-system-radio"
-    value="copySystemChecked"
-  />
-  <div
-    className="md-padding-top md-padding-bottom"
+  <button
+    aria-disabled="false"
+    aria-label="Close"
+    class="pf-c-button pf-m-plain"
+    data-ouia-component-id="OUIA-Generated-Modal-default-1-ModalBoxCloseButton"
+    data-ouia-component-type="PF4/Button"
+    data-ouia-safe="true"
+    type="button"
   >
-    <Form>
-      <FormGroup
-        fieldId="name"
-        helperTextInvalid={null}
-        isRequired={true}
-        label="Baseline name"
-        onKeyPress={[Function]}
-        type="text"
-        validated={null}
-      >
-        <TextInput
-          aria-label="baseline name"
-          className="fact-value"
-          onChange={[Function]}
-          type="text"
-          validated={null}
-          value=""
-        />
-      </FormGroup>
-    </Form>
-  </div>
-</Modal>
-`;
-
-exports[`CreateBaselineModal should render error correctly 1`] = `
-<Modal
-  actions={
-    Array [
-      <Button
-        isDisabled={true}
-        ouiaId="create-baseline-button-fromscratch"
-        variant="primary"
-      >
-        Create baseline
-      </Button>,
-      <Button
-        onClick={[Function]}
-        ouiaId="create-baseline-modal-cancel-button"
-        variant="link"
-      >
-        Cancel
-      </Button>,
-    ]
-  }
-  appendTo={[Function]}
-  aria-describedby=""
-  aria-label=""
-  aria-labelledby=""
-  className="drift create-baseline-modal"
-  hasNoBodyWrapper={false}
-  isOpen={false}
-  onClose={[Function]}
-  ouiaSafe={true}
-  showClose={true}
-  title="Create baseline"
-  titleIconVariant={null}
-  titleLabel=""
-  variant="default"
-  width="1200px"
->
-  <Radio
-    className=""
-    id="create baseline"
-    isChecked={true}
-    isDisabled={false}
-    isValid={true}
-    label="Create baseline from scratch"
-    name="baseline-create-options"
-    onChange={[Function]}
-    ouiaId="create-baseline-from-scratch-radio"
-    value="fromScratchChecked"
-  />
-  <Radio
-    className=""
-    id="copy baseline"
-    isChecked={false}
-    isDisabled={false}
-    isValid={true}
-    label="Copy an existing baseline"
-    name="baseline-create-options"
-    onChange={[Function]}
-    ouiaId="create-baseline-copy-baseline-radio"
-    value="copyBaselineChecked"
-  />
-  <Radio
-    className=""
-    id="copy system"
-    isChecked={false}
-    isDisabled={false}
-    isValid={true}
-    label="Copy an existing system or historical profile"
-    name="baseline-create-options"
-    onChange={[Function]}
-    ouiaId="create-baseline-copy-system-radio"
-    value="copySystemChecked"
-  />
-  <div
-    className="md-padding-top md-padding-bottom"
-  >
-    <Form>
-      <FormGroup
-        fieldId="name"
-        helperTextInvalid="This is an error"
-        isRequired={true}
-        label="Baseline name"
-        onKeyPress={[Function]}
-        type="text"
-        validated="error"
-      >
-        <TextInput
-          aria-label="baseline name"
-          className="fact-value"
-          onChange={[Function]}
-          type="text"
-          validated="error"
-          value=""
-        />
-      </FormGroup>
-    </Form>
-  </div>
-</Modal>
-`;
-
-exports[`CreateBaselineModal should render mount correctly 1`] = `
-<CreateBaselineModal
-  baselineData={Object {}}
-  clearSelectedBaselines={[MockFunction]}
-  createBaselineError={Object {}}
-  createBaselineModalOpened={false}
-  entities={Object {}}
-  handleChecked={[MockFunction]}
-  permissions={
-    Object {
-      "hspRead": true,
-    }
-  }
-  selectedBaselineIds={Array []}
->
-  <Modal
-    actions={
-      Array [
-        <Button
-          isDisabled={true}
-          ouiaId="create-baseline-button-fromscratch"
-          variant="primary"
-        >
-          Create baseline
-        </Button>,
-        <Button
-          onClick={[Function]}
-          ouiaId="create-baseline-modal-cancel-button"
-          variant="link"
-        >
-          Cancel
-        </Button>,
-      ]
-    }
-    appendTo={[Function]}
-    aria-describedby=""
-    aria-label=""
-    aria-labelledby=""
-    className="drift create-baseline-modal"
-    hasNoBodyWrapper={false}
-    isOpen={false}
-    onClose={[Function]}
-    ouiaSafe={true}
-    showClose={true}
-    title="Create baseline"
-    titleIconVariant={null}
-    titleLabel=""
-    variant="default"
-    width="1200px"
-  >
-    <Portal
-      containerInfo={<div />}
+    <svg
+      aria-hidden="true"
+      fill="currentColor"
+      height="1em"
+      role="img"
+      style="vertical-align: -0.125em;"
+      viewBox="0 0 352 512"
+      width="1em"
     >
-      <ModalContent
-        actions={
-          Array [
-            <Button
-              isDisabled={true}
-              ouiaId="create-baseline-button-fromscratch"
-              variant="primary"
-            >
-              Create baseline
-            </Button>,
-            <Button
-              onClick={[Function]}
-              ouiaId="create-baseline-modal-cancel-button"
-              variant="link"
-            >
-              Cancel
-            </Button>,
-          ]
-        }
-        aria-describedby=""
-        aria-label=""
-        aria-labelledby=""
-        boxId="pf-modal-part-0"
-        className="drift create-baseline-modal"
-        descriptorId="pf-modal-part-2"
-        hasNoBodyWrapper={false}
-        isOpen={false}
-        labelId="pf-modal-part-1"
-        onClose={[Function]}
-        ouiaId="OUIA-Generated-Modal-default-1"
-        ouiaSafe={true}
-        showClose={true}
-        title="Create baseline"
-        titleIconVariant={null}
-        titleLabel=""
-        variant="default"
-        width="1200px"
+      <path
+        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
       />
-    </Portal>
-  </Modal>
-</CreateBaselineModal>
+    </svg>
+  </button>
+  <header
+    class="pf-c-modal-box__header"
+  >
+    <h1
+      class="pf-c-modal-box__title"
+      id="pf-modal-part-1"
+    >
+      
+      <span
+        class="pf-c-modal-box__title-text"
+      >
+        Create baseline
+      </span>
+    </h1>
+  </header>
+  <div
+    class="pf-c-modal-box__body"
+    id="pf-modal-part-2"
+  >
+    <div
+      class="pf-c-radio"
+    >
+      <input
+        aria-invalid="false"
+        checked=""
+        class="pf-c-radio__input"
+        data-ouia-component-id="create-baseline-from-scratch-radio"
+        data-ouia-component-type="PF4/Radio"
+        data-ouia-safe="true"
+        data-testid="from-scratch-radio"
+        id="create-baseline"
+        name="baseline-create-options"
+        type="radio"
+        value="fromScratchChecked"
+      />
+      <label
+        class="pf-c-radio__label"
+        for="create-baseline"
+      >
+        Create baseline from scratch
+      </label>
+    </div>
+    <div
+      class="pf-c-radio"
+    >
+      <input
+        aria-invalid="false"
+        class="pf-c-radio__input"
+        data-ouia-component-id="create-baseline-copy-baseline-radio"
+        data-ouia-component-type="PF4/Radio"
+        data-ouia-safe="true"
+        data-testid="copy-baseline-radio"
+        id="copy-baseline"
+        name="baseline-create-options"
+        type="radio"
+        value="copyBaselineChecked"
+      />
+      <label
+        class="pf-c-radio__label"
+        for="copy-baseline"
+      >
+        Copy an existing baseline
+      </label>
+    </div>
+    <div
+      class="pf-c-radio"
+    >
+      <input
+        aria-invalid="false"
+        class="pf-c-radio__input"
+        data-ouia-component-id="create-baseline-copy-system-radio"
+        data-ouia-component-type="PF4/Radio"
+        data-ouia-safe="true"
+        data-testid="copy-system-radio"
+        id="copy-system"
+        name="baseline-create-options"
+        type="radio"
+        value="copySystemChecked"
+      />
+      <label
+        class="pf-c-radio__label"
+        for="copy-system"
+      >
+        Copy an existing system or historical profile
+      </label>
+    </div>
+    <div
+      class="md-padding-top md-padding-bottom"
+    >
+      <form
+        class="pf-c-form"
+        novalidate=""
+      >
+        <div
+          class="pf-c-form__group"
+          type="text"
+        >
+          <div
+            class="pf-c-form__group-label"
+          >
+            <label
+              class="pf-c-form__label"
+              for="name"
+            >
+              <span
+                class="pf-c-form__label-text"
+              >
+                Baseline name
+              </span>
+              <span
+                aria-hidden="true"
+                class="pf-c-form__label-required"
+              >
+                 
+                *
+              </span>
+            </label>
+             
+          </div>
+          <div
+            class="pf-c-form__group-control"
+          >
+            <input
+              aria-invalid="false"
+              aria-label="baseline name"
+              class="pf-c-form-control fact-value"
+              data-ouia-component-id="OUIA-Generated-TextInputBase-1"
+              data-ouia-component-type="PF4/TextInput"
+              data-ouia-safe="true"
+              type="text"
+              value=""
+            />
+            
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+  <footer
+    class="pf-c-modal-box__footer"
+  >
+    <button
+      aria-disabled="true"
+      aria-label="create-baseline-disabled"
+      class="pf-c-button pf-m-primary pf-m-disabled"
+      data-ouia-component-id="create-baseline-button-fromscratch"
+      data-ouia-component-type="PF4/Button"
+      data-ouia-safe="true"
+      disabled=""
+      type="button"
+    >
+      Create baseline
+    </button>
+    <button
+      aria-disabled="false"
+      aria-label="cancel-create-baseline"
+      class="pf-c-button pf-m-link"
+      data-ouia-component-id="create-baseline-modal-cancel-button"
+      data-ouia-component-type="PF4/Button"
+      data-ouia-safe="true"
+      type="button"
+    >
+      Cancel
+    </button>
+  </footer>
+</div>
 `;

--- a/src/SmartComponents/BaselinesPage/__tests__/__snapshots__/BaselinesPage.tests.js.snap
+++ b/src/SmartComponents/BaselinesPage/__tests__/__snapshots__/BaselinesPage.tests.js.snap
@@ -96,7 +96,7 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
             selectedBaselineIds={Array []}
             setSelectedSystemIds={[Function]}
           >
-            <Connect(CreateBaselineModalWithHooks)
+            <CreateBaselineModal
               permissions={
                 Object {
                   "baselinesRead": true,
@@ -107,59 +107,51 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
               selectHistoricProfiles={[Function]}
               setSelectedSystemIds={[Function]}
             >
-              <CreateBaselineModalWithHooks
-                baselineError={Object {}}
-                clearSelectedBaselines={[Function]}
-                createBaseline={[Function]}
-                createBaselineError={Object {}}
-                createBaselineModalOpened={false}
-                emptyState={false}
-                loading={false}
-                permissions={
-                  Object {
-                    "baselinesRead": true,
-                    "baselinesWrite": true,
-                    "compareRead": true,
-                  }
+              <Modal
+                actions={
+                  Array [
+                    <Button
+                      aria-label="create-baseline-disabled"
+                      isDisabled={true}
+                      ouiaId="create-baseline-button-fromscratch"
+                      variant="primary"
+                    >
+                      Create baseline
+                    </Button>,
+                    <Button
+                      aria-label="cancel-create-baseline"
+                      onClick={[Function]}
+                      ouiaId="create-baseline-modal-cancel-button"
+                      variant="link"
+                    >
+                      Cancel
+                    </Button>,
+                  ]
                 }
-                revertBaselineFetch={[Function]}
-                selectBaseline={[Function]}
-                selectHistoricProfiles={[Function]}
-                selectSingleHSP={[Function]}
-                selectedBaselineIds={Array []}
-                setSelectedSystemIds={[Function]}
-                toggleCreateBaselineModal={[Function]}
-                updateColumns={[Function]}
+                appendTo={[Function]}
+                aria-describedby=""
+                aria-label="create-baseline-modal"
+                aria-labelledby=""
+                className="drift create-baseline-modal"
+                hasNoBodyWrapper={false}
+                isOpen={false}
+                onClose={[Function]}
+                ouiaSafe={true}
+                showClose={true}
+                title="Create baseline"
+                titleIconVariant={null}
+                titleLabel=""
+                variant="default"
+                width="1200px"
               >
-                <CreateBaselineModal
-                  baselineError={Object {}}
-                  clearSelectedBaselines={[Function]}
-                  createBaseline={[Function]}
-                  createBaselineError={Object {}}
-                  createBaselineModalOpened={false}
-                  emptyState={false}
-                  loading={false}
-                  navigate={[MockFunction]}
-                  permissions={
-                    Object {
-                      "baselinesRead": true,
-                      "baselinesWrite": true,
-                      "compareRead": true,
-                    }
-                  }
-                  revertBaselineFetch={[Function]}
-                  selectBaseline={[Function]}
-                  selectHistoricProfiles={[Function]}
-                  selectSingleHSP={[Function]}
-                  selectedBaselineIds={Array []}
-                  setSelectedSystemIds={[Function]}
-                  toggleCreateBaselineModal={[Function]}
-                  updateColumns={[Function]}
+                <Portal
+                  containerInfo={<div />}
                 >
-                  <Modal
+                  <ModalContent
                     actions={
                       Array [
                         <Button
+                          aria-label="create-baseline-disabled"
                           isDisabled={true}
                           ouiaId="create-baseline-button-fromscratch"
                           variant="primary"
@@ -167,6 +159,7 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                           Create baseline
                         </Button>,
                         <Button
+                          aria-label="cancel-create-baseline"
                           onClick={[Function]}
                           ouiaId="create-baseline-modal-cancel-button"
                           variant="link"
@@ -175,14 +168,17 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                         </Button>,
                       ]
                     }
-                    appendTo={[Function]}
                     aria-describedby=""
-                    aria-label=""
+                    aria-label="create-baseline-modal"
                     aria-labelledby=""
+                    boxId="pf-modal-part-0"
                     className="drift create-baseline-modal"
+                    descriptorId="pf-modal-part-2"
                     hasNoBodyWrapper={false}
                     isOpen={false}
+                    labelId="pf-modal-part-1"
                     onClose={[Function]}
+                    ouiaId="OUIA-Generated-Modal-default-1"
                     ouiaSafe={true}
                     showClose={true}
                     title="Create baseline"
@@ -190,53 +186,10 @@ exports[`ConnectedBaselinesPage should render correctly 1`] = `
                     titleLabel=""
                     variant="default"
                     width="1200px"
-                  >
-                    <Portal
-                      containerInfo={<div />}
-                    >
-                      <ModalContent
-                        actions={
-                          Array [
-                            <Button
-                              isDisabled={true}
-                              ouiaId="create-baseline-button-fromscratch"
-                              variant="primary"
-                            >
-                              Create baseline
-                            </Button>,
-                            <Button
-                              onClick={[Function]}
-                              ouiaId="create-baseline-modal-cancel-button"
-                              variant="link"
-                            >
-                              Cancel
-                            </Button>,
-                          ]
-                        }
-                        aria-describedby=""
-                        aria-label=""
-                        aria-labelledby=""
-                        boxId="pf-modal-part-0"
-                        className="drift create-baseline-modal"
-                        descriptorId="pf-modal-part-2"
-                        hasNoBodyWrapper={false}
-                        isOpen={false}
-                        labelId="pf-modal-part-1"
-                        onClose={[Function]}
-                        ouiaId="OUIA-Generated-Modal-default-1"
-                        ouiaSafe={true}
-                        showClose={true}
-                        title="Create baseline"
-                        titleIconVariant={null}
-                        titleLabel=""
-                        variant="default"
-                        width="1200px"
-                      />
-                    </Portal>
-                  </Modal>
-                </CreateBaselineModal>
-              </CreateBaselineModalWithHooks>
-            </Connect(CreateBaselineModalWithHooks)>
+                  />
+                </Portal>
+              </Modal>
+            </CreateBaselineModal>
             <PageHeader>
               <section
                 className="pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
@@ -5939,7 +5892,7 @@ exports[`ConnectedBaselinesPage should render empty state 1`] = `
             selectedBaselineIds={Array []}
             setSelectedSystemIds={[Function]}
           >
-            <Connect(CreateBaselineModalWithHooks)
+            <CreateBaselineModal
               permissions={
                 Object {
                   "baselinesRead": true,
@@ -5950,59 +5903,51 @@ exports[`ConnectedBaselinesPage should render empty state 1`] = `
               selectHistoricProfiles={[Function]}
               setSelectedSystemIds={[Function]}
             >
-              <CreateBaselineModalWithHooks
-                baselineError={Object {}}
-                clearSelectedBaselines={[Function]}
-                createBaseline={[Function]}
-                createBaselineError={Object {}}
-                createBaselineModalOpened={false}
-                emptyState={false}
-                loading={false}
-                permissions={
-                  Object {
-                    "baselinesRead": true,
-                    "baselinesWrite": true,
-                    "compareRead": true,
-                  }
+              <Modal
+                actions={
+                  Array [
+                    <Button
+                      aria-label="create-baseline-disabled"
+                      isDisabled={true}
+                      ouiaId="create-baseline-button-fromscratch"
+                      variant="primary"
+                    >
+                      Create baseline
+                    </Button>,
+                    <Button
+                      aria-label="cancel-create-baseline"
+                      onClick={[Function]}
+                      ouiaId="create-baseline-modal-cancel-button"
+                      variant="link"
+                    >
+                      Cancel
+                    </Button>,
+                  ]
                 }
-                revertBaselineFetch={[Function]}
-                selectBaseline={[Function]}
-                selectHistoricProfiles={[Function]}
-                selectSingleHSP={[Function]}
-                selectedBaselineIds={Array []}
-                setSelectedSystemIds={[Function]}
-                toggleCreateBaselineModal={[Function]}
-                updateColumns={[Function]}
+                appendTo={[Function]}
+                aria-describedby=""
+                aria-label="create-baseline-modal"
+                aria-labelledby=""
+                className="drift create-baseline-modal"
+                hasNoBodyWrapper={false}
+                isOpen={false}
+                onClose={[Function]}
+                ouiaSafe={true}
+                showClose={true}
+                title="Create baseline"
+                titleIconVariant={null}
+                titleLabel=""
+                variant="default"
+                width="1200px"
               >
-                <CreateBaselineModal
-                  baselineError={Object {}}
-                  clearSelectedBaselines={[Function]}
-                  createBaseline={[Function]}
-                  createBaselineError={Object {}}
-                  createBaselineModalOpened={false}
-                  emptyState={false}
-                  loading={false}
-                  navigate={[MockFunction]}
-                  permissions={
-                    Object {
-                      "baselinesRead": true,
-                      "baselinesWrite": true,
-                      "compareRead": true,
-                    }
-                  }
-                  revertBaselineFetch={[Function]}
-                  selectBaseline={[Function]}
-                  selectHistoricProfiles={[Function]}
-                  selectSingleHSP={[Function]}
-                  selectedBaselineIds={Array []}
-                  setSelectedSystemIds={[Function]}
-                  toggleCreateBaselineModal={[Function]}
-                  updateColumns={[Function]}
+                <Portal
+                  containerInfo={<div />}
                 >
-                  <Modal
+                  <ModalContent
                     actions={
                       Array [
                         <Button
+                          aria-label="create-baseline-disabled"
                           isDisabled={true}
                           ouiaId="create-baseline-button-fromscratch"
                           variant="primary"
@@ -6010,6 +5955,7 @@ exports[`ConnectedBaselinesPage should render empty state 1`] = `
                           Create baseline
                         </Button>,
                         <Button
+                          aria-label="cancel-create-baseline"
                           onClick={[Function]}
                           ouiaId="create-baseline-modal-cancel-button"
                           variant="link"
@@ -6018,14 +5964,17 @@ exports[`ConnectedBaselinesPage should render empty state 1`] = `
                         </Button>,
                       ]
                     }
-                    appendTo={[Function]}
                     aria-describedby=""
-                    aria-label=""
+                    aria-label="create-baseline-modal"
                     aria-labelledby=""
+                    boxId="pf-modal-part-3"
                     className="drift create-baseline-modal"
+                    descriptorId="pf-modal-part-5"
                     hasNoBodyWrapper={false}
                     isOpen={false}
+                    labelId="pf-modal-part-4"
                     onClose={[Function]}
+                    ouiaId="OUIA-Generated-Modal-default-3"
                     ouiaSafe={true}
                     showClose={true}
                     title="Create baseline"
@@ -6033,53 +5982,10 @@ exports[`ConnectedBaselinesPage should render empty state 1`] = `
                     titleLabel=""
                     variant="default"
                     width="1200px"
-                  >
-                    <Portal
-                      containerInfo={<div />}
-                    >
-                      <ModalContent
-                        actions={
-                          Array [
-                            <Button
-                              isDisabled={true}
-                              ouiaId="create-baseline-button-fromscratch"
-                              variant="primary"
-                            >
-                              Create baseline
-                            </Button>,
-                            <Button
-                              onClick={[Function]}
-                              ouiaId="create-baseline-modal-cancel-button"
-                              variant="link"
-                            >
-                              Cancel
-                            </Button>,
-                          ]
-                        }
-                        aria-describedby=""
-                        aria-label=""
-                        aria-labelledby=""
-                        boxId="pf-modal-part-3"
-                        className="drift create-baseline-modal"
-                        descriptorId="pf-modal-part-5"
-                        hasNoBodyWrapper={false}
-                        isOpen={false}
-                        labelId="pf-modal-part-4"
-                        onClose={[Function]}
-                        ouiaId="OUIA-Generated-Modal-default-3"
-                        ouiaSafe={true}
-                        showClose={true}
-                        title="Create baseline"
-                        titleIconVariant={null}
-                        titleLabel=""
-                        variant="default"
-                        width="1200px"
-                      />
-                    </Portal>
-                  </Modal>
-                </CreateBaselineModal>
-              </CreateBaselineModalWithHooks>
-            </Connect(CreateBaselineModalWithHooks)>
+                  />
+                </Portal>
+              </Modal>
+            </CreateBaselineModal>
             <PageHeader>
               <section
                 className="pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"

--- a/src/SmartComponents/modules/reducers.js
+++ b/src/SmartComponents/modules/reducers.js
@@ -389,8 +389,14 @@ export function compareReducer(state = initialState, action) {
     }
 }
 
+export const globalFilterInitialState = {
+    tagsFilter: [],
+    workloadsFilter: {},
+    sidsFilter: []
+};
+
 export const globalFilterReducer = applyReducerHash({
-    [types.SET_GLOBAL_FILTER_TAGS]: (state = {}, action) => ({
+    [types.SET_GLOBAL_FILTER_TAGS]: (state = globalFilterInitialState, action) => ({
         ...state,
         tagsFilter: action.payload
     }),


### PR DESCRIPTION
Repro:

Navigate to Baselines
Click Create Baseline
Create baseline from scratch
Enter baseline name and click Create Baseline
The result in stage will be Error 400: malformed UUIDs (see screenshots).  However, the baseline does get created.

This is a react 18 bug and you won't be able to easily reproduce it in dev. It was an issue with a navigate trying to run before an api request had time to finish. It's part of the new feature with bulk requests.

You'll have to review the code, push to stage and check there to make sure it works.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
