### PR TITLE
fix(RHIENG-1025): fix comparison column width

### DIFF
--- a/src/SmartComponents/DriftPage/DriftTable/ComparisonHeader/ComparisonHeader.js
+++ b/src/SmartComponents/DriftPage/DriftTable/ComparisonHeader/ComparisonHeader.js
@@ -23,14 +23,15 @@ class ComparisonHeader extends Component {
     }
 
     setColumnWidth = () => {
-        if (this.columnWidth) {
+        if (this.columnWidth?.current) {
             this.props.setColumnHeaderWidth(this.columnWidth.current.offsetWidth);
             this.setState({ refState: this.columnWidth });
         }
     };
 
     componentDidMount() {
-        window.addEventListener('resize', debounce(this.setColumnWidth, 500));
+        this.setColumnWidth();
+        window.addEventListener('resize', debounce(this.setColumnWidth, 250));
     }
 
     formatDate = (dateString) => {

--- a/src/SmartComponents/DriftPage/DriftTable/ComparisonHeader/__tests__/ComparisonHeader.tests.js
+++ b/src/SmartComponents/DriftPage/DriftTable/ComparisonHeader/__tests__/ComparisonHeader.tests.js
@@ -31,7 +31,8 @@ describe('ComparisonHeader react-testing-library', () => {
             toggleFactSort: jest.fn(),
             toggleStateSort: jest.fn(),
             updateReferenceId: jest.fn(),
-            setHistory: jest.fn()
+            setHistory: jest.fn(),
+            setColumnHeaderWidth: jest.fn()
         };
     });
 

--- a/src/SmartComponents/DriftPage/DriftTable/__tests__/__snapshots__/DriftTable.tests.js.snap
+++ b/src/SmartComponents/DriftPage/DriftTable/__tests__/__snapshots__/DriftTable.tests.js.snap
@@ -3008,7 +3008,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                   className="second-scroll"
                   style={
                     Object {
-                      "width": "",
+                      "width": 0,
                     }
                   }
                 />
@@ -3253,7 +3253,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                                       <div
                                         aria-live="off"
                                         className="pf-c-tooltip"
-                                        id="pf-tooltip-1"
+                                        id="pf-tooltip-16"
                                         role="tooltip"
                                         style={
                                           Object {
@@ -3392,7 +3392,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                                       <div
                                         aria-live="off"
                                         className="pf-c-tooltip"
-                                        id="pf-tooltip-2"
+                                        id="pf-tooltip-17"
                                         role="tooltip"
                                         style={
                                           Object {
@@ -3575,7 +3575,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                                       <div
                                         aria-live="off"
                                         className="pf-c-tooltip"
-                                        id="pf-tooltip-3"
+                                        id="pf-tooltip-18"
                                         role="tooltip"
                                         style={
                                           Object {
@@ -3714,7 +3714,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                                       <div
                                         aria-live="off"
                                         className="pf-c-tooltip"
-                                        id="pf-tooltip-4"
+                                        id="pf-tooltip-19"
                                         role="tooltip"
                                         style={
                                           Object {
@@ -3897,7 +3897,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                                       <div
                                         aria-live="off"
                                         className="pf-c-tooltip"
-                                        id="pf-tooltip-5"
+                                        id="pf-tooltip-20"
                                         role="tooltip"
                                         style={
                                           Object {
@@ -4036,7 +4036,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                                       <div
                                         aria-live="off"
                                         className="pf-c-tooltip"
-                                        id="pf-tooltip-6"
+                                        id="pf-tooltip-21"
                                         role="tooltip"
                                         style={
                                           Object {
@@ -4489,7 +4489,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                                       <div
                                         aria-live="off"
                                         className="pf-c-tooltip"
-                                        id="pf-tooltip-7"
+                                        id="pf-tooltip-22"
                                         role="tooltip"
                                         style={
                                           Object {
@@ -4629,7 +4629,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                                       <div
                                         aria-live="off"
                                         className="pf-c-tooltip"
-                                        id="pf-tooltip-8"
+                                        id="pf-tooltip-23"
                                         role="tooltip"
                                         style={
                                           Object {
@@ -5084,7 +5084,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                                       <div
                                         aria-live="off"
                                         className="pf-c-tooltip"
-                                        id="pf-tooltip-9"
+                                        id="pf-tooltip-24"
                                         role="tooltip"
                                         style={
                                           Object {
@@ -5224,7 +5224,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                                       <div
                                         aria-live="off"
                                         className="pf-c-tooltip"
-                                        id="pf-tooltip-10"
+                                        id="pf-tooltip-25"
                                         role="tooltip"
                                         style={
                                           Object {
@@ -5679,7 +5679,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                                       <div
                                         aria-live="off"
                                         className="pf-c-tooltip"
-                                        id="pf-tooltip-11"
+                                        id="pf-tooltip-26"
                                         role="tooltip"
                                         style={
                                           Object {
@@ -5818,7 +5818,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                                       <div
                                         aria-live="off"
                                         className="pf-c-tooltip"
-                                        id="pf-tooltip-12"
+                                        id="pf-tooltip-27"
                                         role="tooltip"
                                         style={
                                           Object {
@@ -6346,7 +6346,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                                 <div
                                   aria-live="off"
                                   className="pf-c-tooltip"
-                                  id="pf-tooltip-13"
+                                  id="pf-tooltip-28"
                                   role="tooltip"
                                   style={
                                     Object {
@@ -6619,7 +6619,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                                 <div
                                   aria-live="off"
                                   className="pf-c-tooltip"
-                                  id="pf-tooltip-14"
+                                  id="pf-tooltip-29"
                                   role="tooltip"
                                   style={
                                     Object {
@@ -6890,7 +6890,7 @@ exports[`ConnectedDriftTable should render systems, baselines and historicalProf
                                 <div
                                   aria-live="off"
                                   className="pf-c-tooltip"
-                                  id="pf-tooltip-15"
+                                  id="pf-tooltip-30"
                                   role="tooltip"
                                   style={
                                     Object {

--- a/src/SmartComponents/DriftPage/DriftToolbar/DriftToolbar.js
+++ b/src/SmartComponents/DriftPage/DriftToolbar/DriftToolbar.js
@@ -62,7 +62,6 @@ export class DriftToolbar extends Component {
 
     prepareExport = (exportFunc) => {
         const { store } = this.props;
-        console.log(store, 'store');
 
         preparingExportNotification(store);
 


### PR DESCRIPTION
You will not see this bug on dev. In stage or prod, try comparing any 2 systems/baselines and run the comparison. Note that the column widths are not aligned on first load. If you resize the window it will update.

Check and make sure this still works in dev. We'll have to just merge and test in stage and see if it works, but I think it will.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
