### PR TITLE
fix(ESSNTL-3721): Fix inventory read permission check

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -73,7 +73,7 @@ const App = () => {
                 permissionsList.some((permission) => hasPermission(
                     permission, [ 'drift:*:*', 'drift:historical-system-profiles:read', 'drift:*:read' ])
                 ),
-                permissionsList.some((permission) => hasPermission(permission, [ 'inventory:*:*', 'inventory:hosts:read' ])),
+                permissionsList.some((permission) => hasPermission(permission, [ 'inventory:*:*', 'inventory:hosts:*', 'inventory:hosts:read'  ])),
                 permissionsList.some((permission) => hasPermission(permission, [ 'drift:*:*', 'drift:notifications:write', 'drift:*:write' ])),
                 permissionsList.some((permission) => hasPermission(permission, [ 'drift:*:*', 'drift:notifications:read', 'drift:*:read' ]))
             );


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/ESSNTL-3721.

## How to test

Set up the `inventory:host:read` permissions with excluding access (or just reach out to me how to find/setup the account and permissions - it's easier 😄). Go to /drift, click "Add systems or baselines", and make sure the modal table loads with the systems that are not member of any group.