### PR TITLE
chore(fec): removed duplicated webpack code

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -5,7 +5,6 @@ const proxyConfiguration = {
     rootFolder: resolve(__dirname, '../'),
     useProxy: process.env.PROXY === 'true',
     appUrl: process.env.BETA ? [ '/beta/insights/drift', '/preview/insights/drift' ] : [ '/insights/drift' ],
-    deployment: process.env.BETA ? 'beta/apps' : 'apps',
     env: process.env.BETA ? 'stage-beta' : 'stage-stable',
     proxyVerbose: true,
     debug: true


### PR DESCRIPTION
Drift has the latest FEC code, this just removes code in inventory that it is already importing from FEC.