### PR TITLE
fix(webpack): update webpack config to account for JS rules

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -5,7 +5,7 @@ const proxyConfiguration = {
     rootFolder: resolve(__dirname, '../'),
     useProxy: process.env.PROXY === 'true',
     appUrl: process.env.BETA ? [ '/beta/insights/drift', '/preview/insights/drift' ] : [ '/insights/drift' ],
-    deployment: process.env.BETA ? 'beta/apps' : 'apps',
+    ...(process.env.BETA === 'true' && { deployment: 'beta/apps' }),
     env: process.env.BETA ? 'stage-beta' : 'stage-stable',
     proxyVerbose: true,
     debug: true

--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -5,7 +5,7 @@ const { config: webpackConfig, plugins } = config({
     rootFolder: resolve(__dirname, '../'),
     https: false,
     debug: true,
-    deployment: process.env.BETA ? 'beta/apps' : 'apps'
+    ...(process.env.BETA === 'true' && { deployment: 'beta/apps' })
 });
 
 plugins.push(


### PR DESCRIPTION
checks for if the variable is true, as opposed to if it exist, because javascript. 