### PR TITLE
chore(RHINENG-5919): App Zero State checks RHEL only

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -14,12 +14,14 @@ const EditBaselinePage = asyncComponent(() => import ('./SmartComponents/Baselin
 
 const InsightsElement = ({ element: Element, title }) => {
     const INVENTORY_TOTAL_FETCH_URL = '/api/inventory/v1/hosts';
+    const RHEL_ONLY_FILTER = '?filter[system_profile][operating_system][RHEL][version][gte]=0';
     const [ hasSystems, setHasSystems ] = useState(true);
     const chrome = useChrome();
+
     useEffect(() => {
         try {
             axios
-            .get(`${INVENTORY_TOTAL_FETCH_URL}?page=1&per_page=1`)
+            .get(`${INVENTORY_TOTAL_FETCH_URL}${RHEL_ONLY_FILTER}&page=1&per_page=1`)
             .then(({ data }) => {
                 setHasSystems(data.total > 0);
             });
@@ -33,16 +35,19 @@ const InsightsElement = ({ element: Element, title }) => {
     }, [ chrome, title ]);
 
     return (
-        !hasSystems ?
-            <AsynComponent
-                appId="drift_zero_state"
-                appName="dashboard"
-                module="./AppZeroState"
-                scope="dashboard"
-                ErrorComponent={ <ErrorState /> }
-                app="Drift"
-            />
-            : <Element title={ title } />);
+        <AsynComponent
+            appId="drift_zero_state"
+            appName="dashboard"
+            module="./AppZeroState"
+            scope="dashboard"
+            ErrorComponent={ <ErrorState /> }
+            app="Drift"
+            aria-label="Zero state"
+            customFetchResults={ hasSystems }
+        >
+            <Element title={ title } />
+        </AsynComponent>
+    );
 };
 
 InsightsElement.propTypes = {


### PR DESCRIPTION
The `?filter[system_profile][operating_system][RHEL][version][gte]=0` filter has been added to the inventory hosts fetch. This filter ultimately checks for the count of RHEL systems in inventory. So, if a user has only non-RHEL systems (think CentOS only) then the App Zero State will be shown.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
