### PR TITLE
fix(RHINENG-5473): Do not show CentOS systems in modals

### DIFF
--- a/config/setupTests.js
+++ b/config/setupTests.js
@@ -35,7 +35,7 @@ jest.mock('react-router-dom', () => ({
 }));
 
 jest.mock('@redhat-cloud-services/frontend-components/Inventory', () => ({
-    InventoryTable: jest.fn(() => <div className='testInventroyComponentChild'><div>This is child</div></div>)
+    InventoryTable: jest.fn(() => <div className='testInventoryComponentChild'><div>This is child</div></div>)
 }));
 
 jest.mock('@redhat-cloud-services/frontend-components/AsyncComponent', () => (

--- a/src/SmartComponents/AddSystemModal/__tests__/__snapshots__/AddSystemModal.tests.js.snap
+++ b/src/SmartComponents/AddSystemModal/__tests__/__snapshots__/AddSystemModal.tests.js.snap
@@ -639,7 +639,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                 class="inventory-toolbar-no-padding"
                               >
                                 <div
-                                  class="testInventroyComponentChild"
+                                  class="testInventoryComponentChild"
                                 >
                                   <div>
                                     This is child
@@ -2460,7 +2460,15 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                                     customFilters={
                                                       Object {
                                                         "filter": Object {
-                                                          "system_profile": Object {},
+                                                          "system_profile": Object {
+                                                            "operating_system": Object {
+                                                              "RHEL": Object {
+                                                                "version": Object {
+                                                                  "gte": "0",
+                                                                },
+                                                              },
+                                                            },
+                                                          },
                                                         },
                                                         "tags": Array [],
                                                       }
@@ -2480,7 +2488,7 @@ exports[`ConnectedAddSystemModal should render baselines correctly 1`] = `
                                                     }
                                                   >
                                                     <div
-                                                      className="testInventroyComponentChild"
+                                                      className="testInventoryComponentChild"
                                                     >
                                                       <div>
                                                         This is child
@@ -7688,7 +7696,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                 class="inventory-toolbar-no-padding"
                               >
                                 <div
-                                  class="testInventroyComponentChild"
+                                  class="testInventoryComponentChild"
                                 >
                                   <div>
                                     This is child
@@ -9510,7 +9518,15 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                                     customFilters={
                                                       Object {
                                                         "filter": Object {
-                                                          "system_profile": Object {},
+                                                          "system_profile": Object {
+                                                            "operating_system": Object {
+                                                              "RHEL": Object {
+                                                                "version": Object {
+                                                                  "gte": "0",
+                                                                },
+                                                              },
+                                                            },
+                                                          },
                                                         },
                                                         "tags": Array [],
                                                       }
@@ -9530,7 +9546,7 @@ exports[`ConnectedAddSystemModal should render correctly 1`] = `
                                                     }
                                                   >
                                                     <div
-                                                      className="testInventroyComponentChild"
+                                                      className="testInventoryComponentChild"
                                                     >
                                                       <div>
                                                         This is child

--- a/src/SmartComponents/BaselinesPage/EditBaselinePage/SystemNotification/__tests__/__snapshots__/SystemNotification.tests.js.snap
+++ b/src/SmartComponents/BaselinesPage/EditBaselinePage/SystemNotification/__tests__/__snapshots__/SystemNotification.tests.js.snap
@@ -532,7 +532,7 @@ exports[`ConnectedSystemNotification should render correctly 1`] = `
                     }
                   >
                     <div
-                      className="testInventroyComponentChild"
+                      className="testInventoryComponentChild"
                     >
                       <div>
                         This is child

--- a/src/SmartComponents/SystemsTable/SystemsTable.js
+++ b/src/SmartComponents/SystemsTable/SystemsTable.js
@@ -89,7 +89,15 @@ export const SystemsTable = ({
                                     && { ansible: 'not_nil' },
                                         ...workloadsFilter?.['Microsoft SQL']?.isSelected
                                     && { mssql: 'not_nil' },
-                                        ...sidsFilter?.length > 0 && { sap_sids: sidsFilter }
+                                        ...sidsFilter?.length > 0 && { sap_sids: sidsFilter },
+                                        // drift does not support and does not display CentOS systems
+                                        operating_system: {
+                                            RHEL: {
+                                                version: {
+                                                    gte: '0'
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             }}

--- a/src/SmartComponents/SystemsTable/__tests__/SystemsTable.tests.js
+++ b/src/SmartComponents/SystemsTable/__tests__/SystemsTable.tests.js
@@ -8,6 +8,7 @@ import toJson from 'enzyme-to-json';
 import ConnectedSystemsTable from '../SystemsTable';
 import { createMiddlewareListener } from '../../../store';
 import fixtures from './fixtures';
+import { InventoryTable } from '@redhat-cloud-services/frontend-components/Inventory';
 
 const middlewareListener = createMiddlewareListener();
 middlewareListener.getMiddleware();
@@ -104,5 +105,34 @@ describe('ConnectedSystemsTable', () => {
         );
 
         expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('should display only RHEL hosts', () => {
+        const store = mockStore(initialState);
+
+        mount(<MemoryRouter>
+            <Provider store={ store }>
+                <ConnectedSystemsTable { ...props } />
+            </Provider>
+        </MemoryRouter>);
+
+        expect(InventoryTable).toBeCalledWith(expect.objectContaining({ customFilters: {
+            filter: {
+                // eslint-disable-next-line camelcase
+                system_profile: expect.objectContaining({ operating_system: { RHEL: { version: { gte: '0' }}}})
+            }
+        }}), expect.anything());
+    });
+
+    it('should not show CentOS versions in the OS filter', () => {
+        const store = mockStore(initialState);
+
+        mount(<MemoryRouter>
+            <Provider store={ store }>
+                <ConnectedSystemsTable { ...props } />
+            </Provider>
+        </MemoryRouter>);
+
+        expect(InventoryTable).toBeCalledWith(expect.not.objectContaining({ showCentosVersions: true }), expect.anything());
     });
 });

--- a/src/SmartComponents/SystemsTable/__tests__/__snapshots__/NotificationsSystemsTable.tests.js.snap
+++ b/src/SmartComponents/SystemsTable/__tests__/__snapshots__/NotificationsSystemsTable.tests.js.snap
@@ -208,7 +208,7 @@ exports[`ConnectedNotificationsSystemsTable should render correctly 1`] = `
                 }
               >
                 <div
-                  className="testInventroyComponentChild"
+                  className="testInventoryComponentChild"
                 >
                   <div>
                     This is child
@@ -415,7 +415,7 @@ exports[`ConnectedNotificationsSystemsTable should render correctly with no inve
                 }
               >
                 <div
-                  className="testInventroyComponentChild"
+                  className="testInventoryComponentChild"
                 >
                   <div>
                     This is child

--- a/src/SmartComponents/SystemsTable/__tests__/__snapshots__/SystemsTable.tests.js.snap
+++ b/src/SmartComponents/SystemsTable/__tests__/__snapshots__/SystemsTable.tests.js.snap
@@ -98,7 +98,15 @@ exports[`ConnectedSystemsTable should render correctly 1`] = `
               customFilters={
                 Object {
                   "filter": Object {
-                    "system_profile": Object {},
+                    "system_profile": Object {
+                      "operating_system": Object {
+                        "RHEL": Object {
+                          "version": Object {
+                            "gte": "0",
+                          },
+                        },
+                      },
+                    },
                   },
                   "tags": undefined,
                 }
@@ -118,7 +126,7 @@ exports[`ConnectedSystemsTable should render correctly 1`] = `
               }
             >
               <div
-                className="testInventroyComponentChild"
+                className="testInventoryComponentChild"
               >
                 <div>
                   This is child


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-5473.

This makes sure no modals show CentOS systems nor allowing users to filter out the CentOS systems. Drift only supports RHEL systems at the moment.

## How to test

1. Use an account with at least one CentOS system registered in Inventory
2. Go to /insights/drift and verify that you are not able to add any CentOS system to comparison
3. Create or navigate to any baselines, switch to Associated systems
4. Make sure you are the same way not able to associate any CentOS system with this baseline.
